### PR TITLE
auth: domain transactions

### DIFF
--- a/docs/appendices/backend-writers-guide.rst
+++ b/docs/appendices/backend-writers-guide.rst
@@ -67,10 +67,10 @@ following methods are relevant:
         {
         public:
         virtual unsigned int getCapabilities()=0;
-        virtual void lookup(const QType &qtype, const string &qdomain, domainid_t zoneId, DNSPacket *pkt_p=nullptr)=0;
-        virtual bool list(const string &target, domainid_t domain_id)=0;
+        virtual void lookup(const QType &qtype, const DNSName &qdomain, domainid_t zoneId, DNSPacket *pkt_p=nullptr)=0;
+        virtual bool list(const ZoneName &target, domainid_t domain_id)=0;
         virtual bool get(DNSResourceRecord &r)=0;
-        virtual bool getSOA(const string &name, domainid_t zoneId, SOAData &soadata);
+        virtual bool getSOA(const ZoneName &name, domainid_t zoneId, SOAData &soadata);
         };
 
 Note that the first four methods must be implemented. ``getSOA()`` has
@@ -164,12 +164,12 @@ furthermore, only about its A record:
     public:
       unsigned int getCapabilities() override { return 0; }
 
-      bool list(const string &target, domainid_t id)
+      bool list(const ZoneName &target, domainid_t id, bool include_disabled)
       {
         return false; // we don't support pdnsutil zone list or AXFR
       }
 
-      void lookup(const QType &type, const string &qdomain, domainid_t zoneId, DNSPacket *p)
+      void lookup(const QType &type, const DNSName &qdomain, domainid_t zoneId, DNSPacket *p)
       {
         if(type.getCode()!=QType::A || qdomain!="random.powerdns.com")  // we only know about random.powerdns.com A
           d_answer="";                                                  // no answer
@@ -355,7 +355,7 @@ Methods
 * `CAP_DNSSEC`     Backend implements :ref:`backend-dnssec`.
 * `CAP_LIST`       Backend implements `list`, for AXFR or `pdnsutil zone list`
 
-.. cpp:function:: void DNSBackend::lookup(const QType &qtype, const string &qdomain, domainid_t zoneId, DNSPacket *pkt=nullptr)
+.. cpp:function:: void DNSBackend::lookup(const QType &qtype, const DNSName &qdomain, domainid_t zoneId, DNSPacket *pkt=nullptr)
 
   This function is used to initiate a straight lookup for a record of name
   'qdomain' and type 'qtype'. A QType can be converted into an integer by
@@ -422,7 +422,7 @@ Methods
 
   Should throw an PDNSException in case a database error occurred.
 
-.. cpp:function:: bool DNSBackend::getSOA(const string &name, domainid_t zoneId, SOAData &soadata)
+.. cpp:function:: bool DNSBackend::getSOA(const ZoneName &name, domainid_t zoneId, SOAData &soadata)
 
   If the backend considers itself authoritative over domain ``name``, of
   id ``zoneId`` if known (otherwise, ``UnknownDomainID``), this method should
@@ -562,14 +562,15 @@ The following excerpt from the DNSBackend shows the relevant functions:
           class DNSBackend {
           public:
                /* ... */
-               virtual bool getDomainInfo(const string &domain, DomainInfo &di, bool getSerial = true);
+               virtual bool getDomainInfo(const ZoneName &domain, DomainInfo &di, bool getSerial = true);
                virtual bool isPrimary(const ComboAddress& ipAddress);
-               virtual bool startTransaction(const string &qname, domainid_t id);
+               virtual bool startTransaction(const ZoneName &qname, domainid_t id);
                virtual bool commitTransaction();
                virtual bool abortTransaction();
                virtual bool feedRecord(const DNSResourceRecord &rr, const DNSName &ordername, bool ordernameIsNSEC3 = false);
                virtual void getUnfreshSecondaryInfos(vector<DomainInfo>* domains);
                virtual void setFresh(domainid_t id);
+               virtual void deleteContents(domainid_t id);
                /* ... */
          }
 
@@ -628,13 +629,13 @@ this zone.
   When called, the backend should examine its list of secondary domains and
   add any unfresh ones to the domains vector.
 
-.. cpp:function:: bool DomainInfo::getDomainInfo(const string &name, DomainInfo & di, boot getSerial)
+.. cpp:function:: bool DomainInfo::getDomainInfo(const ZoneName &name, DomainInfo & di, boot getSerial)
 
   This is like ``getUnfreshSecondaryInfos``, but for a specific domain. If the
   backend considers itself authoritative for the named zone, ``di`` should
   be filled out, and 'true' be returned. Otherwise, return false.
 
-.. cpp:function:: bool DomainInfo::startTransaction(const string &qname, domainid_t id)
+.. cpp:function:: bool DomainInfo::startTransaction(const ZoneName &qname, domainid_t id)
 
   When called, the backend should start a transaction that can be
   committed or rolled back atomically later on. In SQL terms, this
@@ -695,7 +696,7 @@ implement the following method:
 
                 class DNSBackend
                 {
-                   virtual bool autoPrimaryBackend(const string &ip, const DNSName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db)
+                   virtual bool autoPrimaryBackend(const string &ip, const ZoneName &domain, const vector<DNSResourceRecord>&nsset, string *nameserver, string *account, DNSBackend **db)
                 };
 
 This function gets called with the IP address of the potential
@@ -830,23 +831,23 @@ In order for a backend to support domain metadata, the following operations have
     class DNSBackend {
     public:
       /* ... */
-      virtual bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string> >& meta);
-      virtual bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta);
-      virtual bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta);
+      virtual bool getAllDomainMetadata(const ZoneName& name, std::map<std::string, std::vector<std::string> >& meta);
+      virtual bool getDomainMetadata(const ZoneName& name, const std::string& kind, std::vector<std::string>& meta);
+      virtual bool setDomainMetadata(const ZoneName& name, const std::string& kind, const std::vector<std::string>& meta);
       /* ... */
     }
 
-.. cpp:function:: virtual bool getAllDomainMetadata(const DNSName& name, std::map<std::string, std::vector<std::string> >& meta)
+.. cpp:function:: virtual bool getAllDomainMetadata(const ZoneName& name, std::map<std::string, std::vector<std::string> >& meta)
 
   Fills 'meta' with the value(s) of all kinds for zone 'name'. Returns true if the domain metadata operation are supported, regardless
   of whether there is any data for this zone.
 
-.. cpp:function:: virtual bool getDomainMetadata(const DNSName& name, const std::string& kind, std::vector<std::string>& meta)
+.. cpp:function:: virtual bool getDomainMetadata(const ZoneName& name, const std::string& kind, std::vector<std::string>& meta)
 
   Fills 'meta' with the value(s) of the specified kind for zone 'name'. Returns true if the domain metadata operation are supported, regardless
   of whether there is any data of this kind for this zone.
 
-.. cpp:function:: virtual bool setDomainMetadata(const DNSName& name, const std::string& kind, const std::vector<std::string>& meta)
+.. cpp:function:: virtual bool setDomainMetadata(const ZoneName& name, const std::string& kind, const std::vector<std::string>& meta)
 
   Store the values from 'meta' for the specified kind for zone 'name', discarding existing values if any. An empty meta is equivalent to a deletion request.
   Returns true if the values have been correctly stored, and false otherwise.
@@ -899,13 +900,13 @@ In order for a backend to support DNSSEC, quite a few number of additional opera
       virtual bool feedEnts3(domainid_t domain_id, const DNSName &domain, map<DNSName,bool> &nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow);
 
       /* keys management */
-      virtual bool getDomainKeys(const DNSName& name, std::vector<KeyData>& keys);
-      virtual bool removeDomainKey(const DNSName& name, unsigned int id);
-      virtual bool addDomainKey(const DNSName& name, const KeyData& key, int64_t& id);
-      virtual bool activateDomainKey(const DNSName& name, unsigned int id);
-      virtual bool deactivateDomainKey(const DNSName& name, unsigned int id);
-      virtual bool publishDomainKey(const DNSName& name, unsigned int id);
-      virtual bool unpublishDomainKey(const DNSName& name, unsigned int id);
+      virtual bool getDomainKeys(const ZoneName& name, std::vector<KeyData>& keys);
+      virtual bool removeDomainKey(const ZoneName& name, unsigned int id);
+      virtual bool addDomainKey(const ZoneName& name, const KeyData& key, int64_t& id);
+      virtual bool activateDomainKey(const ZoneName& name, unsigned int id);
+      virtual bool deactivateDomainKey(const ZoneName& name, unsigned int id);
+      virtual bool publishDomainKey(const ZoneName& name, unsigned int id);
+      virtual bool unpublishDomainKey(const ZoneName& name, unsigned int id);
 
       /* ... */
     }

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1564,7 +1564,7 @@ BB2DomainInfo Bind2Backend::createDomainEntry(const ZoneName& domain)
   return bbd;
 }
 
-bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& /* nameserver */, const string& account)
+bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& /* nameserver */, const string& account, DomainInfo& info)
 {
   std::string domainname = domain.toStringNoDot();
 
@@ -1625,7 +1625,7 @@ bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName
   bbd.updateCtime();
   safePutBBDomainInfo(bbd);
 
-  return true;
+  return getDomainInfo(domain, info, false);
 }
 
 bool Bind2Backend::searchRecords(const string& pattern, size_t maxResults, vector<DNSResourceRecord>& result)

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1625,7 +1625,15 @@ bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName
   bbd.updateCtime();
   safePutBBDomainInfo(bbd);
 
-  return getDomainInfo(domain, info, false);
+  // inline getDomainInfo(domain, info, false) without having to look for BB2DomainInfo again
+  info.id = bbd.d_id;
+  info.zone = domain;
+  info.primaries = bbd.d_primaries;
+  info.last_check = bbd.d_lastcheck;
+  info.backend = this;
+  info.kind = bbd.d_kind;
+  info.serial = 0;
+  return true;
 }
 
 bool Bind2Backend::searchRecords(const string& pattern, size_t maxResults, vector<DNSResourceRecord>& result)

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -224,7 +224,7 @@ void Bind2Backend::setFresh(domainid_t domain_id)
   setLastCheck(domain_id, time(nullptr));
 }
 
-bool Bind2Backend::startDomainCreationTransactionInternal(BB2DomainInfo& bbd)
+bool Bind2Backend::startDomainReplacementTransactionInternal(BB2DomainInfo& bbd)
 {
   d_transaction_qname = bbd.d_name;
   d_transaction_id = bbd.d_id;
@@ -253,7 +253,7 @@ bool Bind2Backend::startDomainCreationTransactionInternal(BB2DomainInfo& bbd)
   return true;
 }
 
-bool Bind2Backend::startDomainCreationTransaction(const ZoneName& /* qname */, domainid_t domainId)
+bool Bind2Backend::startDomainReplacementTransaction(const ZoneName& /* qname */, domainid_t domainId)
 {
   d_transaction_tmpname.clear();
   d_transaction_id = UnknownDomainID;
@@ -271,7 +271,7 @@ bool Bind2Backend::startDomainCreationTransaction(const ZoneName& /* qname */, d
   if (bbd.d_pending) {
     return false;
   }
-  return startDomainCreationTransactionInternal(bbd);
+  return startDomainReplacementTransactionInternal(bbd);
 }
 
 bool Bind2Backend::startDomainModificationTransaction(const ZoneName& /* qname */)
@@ -1717,7 +1717,7 @@ bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName
   if (startTransaction) {
     // Remember this domain is pending until the transaction gets committed.
     bbd.d_pending = true;
-    startDomainCreationTransactionInternal(bbd);
+    startDomainReplacementTransactionInternal(bbd);
   }
   safePutBBDomainInfo(bbd);
 

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -210,38 +210,46 @@ void Bind2Backend::setFresh(domainid_t domain_id)
   Bind2Backend::setLastCheck(domain_id, time(nullptr));
 }
 
-bool Bind2Backend::startDomainCreationTransaction(const ZoneName& qname, domainid_t domainId)
+bool Bind2Backend::startDomainCreationTransactionInternal(BB2DomainInfo& bbd)
 {
+  d_transaction_qname = bbd.d_name;
+  d_transaction_id = bbd.d_id;
+  d_transaction_tmpname = bbd.main_filename() + "XXXXXX";
+  int fd = mkstemp(&d_transaction_tmpname.at(0));
+  if (fd == -1) {
+    throw DBException("Unable to create a unique temporary zonefile '" + d_transaction_tmpname + "': " + stringerror());
+  }
+
+  d_of = std::make_unique<ofstream>(d_transaction_tmpname);
+  if (!*d_of) {
+    unlink(d_transaction_tmpname.c_str());
+    close(fd);
+    fd = -1;
+    d_of.reset();
+    throw DBException("Unable to open temporary zonefile '" + d_transaction_tmpname + "': " + stringerror());
+  }
+  close(fd);
+  fd = -1;
+
+  *d_of << "; Written by PowerDNS, don't edit!" << endl;
+  *d_of << "; Zone '" << bbd.d_name << "' retrieved from primary " << endl
+        << "; at " << nowTime() << endl; // insert primary info here again
+
+  return true;
+}
+
+bool Bind2Backend::startDomainCreationTransaction(const ZoneName& /* qname */, domainid_t domainId)
+{
+  d_transaction_tmpname.clear();
+  d_transaction_id = UnknownDomainID;
+
   if (domainId == 0) {
     throw DBException("domain_id 0 is invalid for this backend.");
   }
 
-  d_transaction_id = domainId;
-  d_transaction_qname = qname;
   BB2DomainInfo bbd;
   if (safeGetBBDomainInfo(domainId, &bbd)) {
-    d_transaction_tmpname = bbd.main_filename() + "XXXXXX";
-    int fd = mkstemp(&d_transaction_tmpname.at(0));
-    if (fd == -1) {
-      throw DBException("Unable to create a unique temporary zonefile '" + d_transaction_tmpname + "': " + stringerror());
-    }
-
-    d_of = std::make_unique<ofstream>(d_transaction_tmpname);
-    if (!*d_of) {
-      unlink(d_transaction_tmpname.c_str());
-      close(fd);
-      fd = -1;
-      d_of.reset();
-      throw DBException("Unable to open temporary zonefile '" + d_transaction_tmpname + "': " + stringerror());
-    }
-    close(fd);
-    fd = -1;
-
-    *d_of << "; Written by PowerDNS, don't edit!" << endl;
-    *d_of << "; Zone '" << bbd.d_name << "' retrieved from primary " << endl
-          << "; at " << nowTime() << endl; // insert primary info here again
-
-    return true;
+    return startDomainCreationTransactionInternal(bbd);
   }
   return false;
 }
@@ -250,6 +258,7 @@ bool Bind2Backend::startDomainModificationTransaction(const ZoneName& /* qname *
 {
   d_transaction_tmpname.clear();
   d_transaction_id = UnknownDomainID;
+
   // No support for domain contents modification, except as a "delete and
   // recreate in its entirety" operation.
   return false;

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1576,7 +1576,7 @@ BB2DomainInfo Bind2Backend::createDomainEntry(const ZoneName& domain)
   return bbd;
 }
 
-bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& /* nameserver */, const string& account, DomainInfo& info)
+bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& /* nameserver */, const string& account, DomainInfo& info, bool /* startTransaction */)
 {
   std::string domainname = domain.toStringNoDot();
 

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -720,7 +720,7 @@ string Bind2Backend::DLReloadNowHandler(const vector<string>& parts, Utility::pi
     ZoneName zone(*i);
     if (safeGetBBDomainInfo(zone, &bbd)) {
       if (bbd.d_pending) {
-        ret << *i << ": not commited yet\n";
+        ret << *i << ": not committed yet\n";
         continue;
       }
       Bind2Backend bb2;
@@ -750,7 +750,7 @@ string Bind2Backend::DLDomStatusHandler(const vector<string>& parts, Utility::pi
       BB2DomainInfo bbd;
       if (safeGetBBDomainInfo(ZoneName(*i), &bbd)) {
         if (bbd.d_pending) {
-          ret << "not commited yet\n";
+          ret << "not committed yet\n";
         }
         else {
           ret << (bbd.d_loaded ? "" : "[rejected]") << "\t" << bbd.d_status << "\n";
@@ -766,7 +766,7 @@ string Bind2Backend::DLDomStatusHandler(const vector<string>& parts, Utility::pi
     for (const auto& bbd : *state) {
       ret << bbd.d_name << ": ";
       if (bbd.d_pending) {
-        ret << "not commited yet\n";
+        ret << "not committed yet\n";
       }
       else {
         ret << (bbd.d_loaded ? "" : "[rejected]") << "\t" << bbd.d_status << "\n";
@@ -823,7 +823,7 @@ string Bind2Backend::DLDomExtendedStatusHandler(const vector<string>& parts, Uti
       BB2DomainInfo bbd;
       if (safeGetBBDomainInfo(ZoneName(*i), &bbd)) {
         if (bbd.d_pending) {
-          ret << *i << ": not commited yet\n";
+          ret << *i << ": not committed yet\n";
           continue;
         }
         printDomainExtendedStatus(ret, bbd);
@@ -868,7 +868,7 @@ string Bind2Backend::DLAddDomainHandler(const vector<string>& parts, Utility::pi
   BB2DomainInfo bbd;
   if (safeGetBBDomainInfo(domainname, &bbd)) {
     if (bbd.d_pending) {
-      return "Not commited yet";
+      return "Not committed yet";
     }
     return "Already loaded";
   }
@@ -1129,8 +1129,8 @@ void Bind2Backend::loadConfig(string* status) // NOLINT(readability-function-cog
 
       if (safeGetBBDomainInfo(domain.name, &bbd)) {
         if (bbd.d_pending) {
-          SLOG(g_log << Logger::Warning << d_logprefix << " Warning! Skipping zone '" << domain.name << "' because it is not commited yet" << endl,
-               d_slog->info(Logr::Warning, "Skipping zone because it is not commited yet", "zone", Logging::Loggable(domain.name)));
+          SLOG(g_log << Logger::Warning << d_logprefix << " Warning! Skipping zone '" << domain.name << "' because it is not committed yet" << endl,
+               d_slog->info(Logr::Warning, "Skipping zone because it is not committed yet", "zone", Logging::Loggable(domain.name)));
           rejected++;
           continue;
         }
@@ -1715,7 +1715,7 @@ bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName
   bbd.updateCtime();
 
   if (startTransaction) {
-    // Remember this domain is pending until the transaction gets commited.
+    // Remember this domain is pending until the transaction gets committed.
     bbd.d_pending = true;
     startDomainCreationTransactionInternal(bbd);
   }

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -210,14 +210,8 @@ void Bind2Backend::setFresh(domainid_t domain_id)
   Bind2Backend::setLastCheck(domain_id, time(nullptr));
 }
 
-bool Bind2Backend::startTransaction(const ZoneName& qname, domainid_t domainId)
+bool Bind2Backend::startDomainCreationTransaction(const ZoneName& qname, domainid_t domainId)
 {
-  if (domainId == UnknownDomainID) {
-    d_transaction_tmpname.clear();
-    d_transaction_id = UnknownDomainID;
-    // No support for domain contents deletion
-    return false;
-  }
   if (domainId == 0) {
     throw DBException("domain_id 0 is invalid for this backend.");
   }
@@ -249,6 +243,15 @@ bool Bind2Backend::startTransaction(const ZoneName& qname, domainid_t domainId)
 
     return true;
   }
+  return false;
+}
+
+bool Bind2Backend::startDomainModificationTransaction(const ZoneName& /* qname */)
+{
+  d_transaction_tmpname.clear();
+  d_transaction_id = UnknownDomainID;
+  // No support for domain contents modification, except as a "delete and
+  // recreate in its entirety" operation.
   return false;
 }
 

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -184,8 +184,15 @@ void Bind2Backend::safePutBBDomainInfo(const BB2DomainInfo& bbd)
 void Bind2Backend::setNotified(domainid_t id, uint32_t serial)
 {
   BB2DomainInfo bbd;
-  if (!safeGetBBDomainInfo(id, &bbd))
+  if (!safeGetBBDomainInfo(id, &bbd)) {
     return;
+  }
+  // Ignore pending domains unless we are the backend running the transaction
+  // in which they are being created. This can't be done in safeGetBBDomainInfo
+  // because it needs to be a static method.
+  if (bbd.d_pending && bbd.d_id != d_transaction_id) {
+    return;
+  }
   bbd.d_lastnotified = serial;
   safePutBBDomainInfo(bbd);
 }
@@ -194,20 +201,27 @@ void Bind2Backend::setNotified(domainid_t id, uint32_t serial)
 void Bind2Backend::setLastCheck(domainid_t domain_id, time_t lastcheck)
 {
   BB2DomainInfo bbd;
-  if (safeGetBBDomainInfo(domain_id, &bbd)) {
-    bbd.d_lastcheck = lastcheck;
-    safePutBBDomainInfo(bbd);
+  if (!safeGetBBDomainInfo(domain_id, &bbd)) {
+    return;
   }
+  // Ignore pending domains unless we are the backend running the transaction
+  // in which they are being created. This can't be done in safeGetBBDomainInfo
+  // because it needs to be a static method.
+  if (bbd.d_pending && bbd.d_id != d_transaction_id) {
+    return;
+  }
+  bbd.d_lastcheck = lastcheck;
+  safePutBBDomainInfo(bbd);
 }
 
 void Bind2Backend::setStale(domainid_t domain_id)
 {
-  Bind2Backend::setLastCheck(domain_id, 0);
+  setLastCheck(domain_id, 0);
 }
 
 void Bind2Backend::setFresh(domainid_t domain_id)
 {
-  Bind2Backend::setLastCheck(domain_id, time(nullptr));
+  setLastCheck(domain_id, time(nullptr));
 }
 
 bool Bind2Backend::startDomainCreationTransactionInternal(BB2DomainInfo& bbd)
@@ -215,6 +229,7 @@ bool Bind2Backend::startDomainCreationTransactionInternal(BB2DomainInfo& bbd)
   d_transaction_qname = bbd.d_name;
   d_transaction_id = bbd.d_id;
   d_transaction_tmpname = bbd.main_filename() + "XXXXXX";
+  // NOLINTNEXTLINE(readability-identifier-length)
   int fd = mkstemp(&d_transaction_tmpname.at(0));
   if (fd == -1) {
     throw DBException("Unable to create a unique temporary zonefile '" + d_transaction_tmpname + "': " + stringerror());
@@ -224,12 +239,12 @@ bool Bind2Backend::startDomainCreationTransactionInternal(BB2DomainInfo& bbd)
   if (!*d_of) {
     unlink(d_transaction_tmpname.c_str());
     close(fd);
-    fd = -1;
+    fd = -1; // NOLINT(clang-analyzer-deadcode.DeadStores)
     d_of.reset();
     throw DBException("Unable to open temporary zonefile '" + d_transaction_tmpname + "': " + stringerror());
   }
   close(fd);
-  fd = -1;
+  fd = -1; // NOLINT(clang-analyzer-deadcode.DeadStores)
 
   *d_of << "; Written by PowerDNS, don't edit!" << endl;
   *d_of << "; Zone '" << bbd.d_name << "' retrieved from primary " << endl
@@ -248,10 +263,15 @@ bool Bind2Backend::startDomainCreationTransaction(const ZoneName& /* qname */, d
   }
 
   BB2DomainInfo bbd;
-  if (safeGetBBDomainInfo(domainId, &bbd)) {
-    return startDomainCreationTransactionInternal(bbd);
+  if (!safeGetBBDomainInfo(domainId, &bbd)) {
+    return false;
   }
-  return false;
+  // Ignore pending domains since we don't have an active transaction at this
+  // point, so we can't be the backend currently creating them.
+  if (bbd.d_pending) {
+    return false;
+  }
+  return startDomainCreationTransactionInternal(bbd);
 }
 
 bool Bind2Backend::startDomainModificationTransaction(const ZoneName& /* qname */)
@@ -278,6 +298,12 @@ bool Bind2Backend::commitTransaction()
     if (rename(d_transaction_tmpname.c_str(), bbd.main_filename().c_str()) < 0) {
       throw DBException("Unable to commit (rename to: '" + bbd.main_filename() + "') AXFRed zone: " + stringerror());
     }
+    // If that domain was part of a transaction, we can finally mark it as
+    // available to everyone.
+    if (bbd.d_pending) {
+      bbd.d_pending = false;
+      safePutBBDomainInfo(bbd);
+    }
     queueReloadAndStore(bbd.d_id);
   }
 
@@ -291,6 +317,12 @@ bool Bind2Backend::abortTransaction()
   // d_transaction_id is only set to a valid domain id if we are actually
   // setting up a replacement zone file with the updated data.
   if (d_transaction_id != UnknownDomainID) {
+    BB2DomainInfo bbd;
+    if (safeGetBBDomainInfo(d_transaction_id, &bbd)) {
+      if (bbd.d_pending) {
+        safeRemoveBBDomainInfo(bbd.d_name);
+      }
+    }
     unlink(d_transaction_tmpname.c_str());
     d_of.reset();
     d_transaction_id = UnknownDomainID;
@@ -427,18 +459,24 @@ void Bind2Backend::getUpdatedPrimaries(vector<DomainInfo>& changedDomains, std::
   {
     auto state = s_state.read_lock();
 
-    for (const auto& i : *state) {
-      if (i.d_kind != DomainInfo::Primary && this->alsoNotify.empty() && i.d_also_notify.empty())
+    for (const auto& bbd : *state) {
+      // Ignore pending domains unless we are the backend running the
+      // transaction in which they are being created.
+      if (bbd.d_pending && bbd.d_id != d_transaction_id) {
         continue;
+      }
+      if (bbd.d_kind != DomainInfo::Primary && this->alsoNotify.empty() && bbd.d_also_notify.empty()) {
+        continue;
+      }
 
-      DomainInfo di;
-      di.id = i.d_id;
-      di.zone = i.d_name;
-      di.last_check = i.d_lastcheck;
-      di.notified_serial = i.d_lastnotified;
-      di.backend = this;
-      di.kind = DomainInfo::Primary;
-      consider.push_back(std::move(di));
+      DomainInfo info;
+      info.id = bbd.d_id;
+      info.zone = bbd.d_name;
+      info.last_check = bbd.d_lastcheck;
+      info.notified_serial = bbd.d_lastnotified;
+      info.backend = this;
+      info.kind = DomainInfo::Primary;
+      consider.push_back(std::move(info));
     }
   }
 
@@ -453,6 +491,8 @@ void Bind2Backend::getUpdatedPrimaries(vector<DomainInfo>& changedDomains, std::
     }
     if (di.notified_serial != soadata.serial) {
       BB2DomainInfo bbd;
+      // Note that we don't need to filter pending domains here as the loop
+      // initializing [consider] above has already done that filtering.
       if (safeGetBBDomainInfo(di.id, &bbd)) {
         bbd.d_lastnotified = soadata.serial;
         safePutBBDomainInfo(bbd);
@@ -543,6 +583,12 @@ bool Bind2Backend::getDomainInfo(const ZoneName& domain, DomainInfo& info, bool 
   BB2DomainInfo bbd;
   if (!safeGetBBDomainInfo(domain, &bbd))
     return false;
+  // Ignore pending domains unless we are the backend running the transaction
+  // in which they are being created. This can't be done in safeGetBBDomainInfo
+  // because it needs to be a static method.
+  if (bbd.d_pending && bbd.d_id != d_transaction_id) {
+    return false;
+  }
 
   info.id = bbd.d_id;
   info.zone = domain;
@@ -673,6 +719,10 @@ string Bind2Backend::DLReloadNowHandler(const vector<string>& parts, Utility::pi
     BB2DomainInfo bbd;
     ZoneName zone(*i);
     if (safeGetBBDomainInfo(zone, &bbd)) {
+      if (bbd.d_pending) {
+        ret << *i << ": not commited yet\n";
+        continue;
+      }
       Bind2Backend bb2;
       bb2.queueReloadAndStore(bbd.d_id);
       if (!safeGetBBDomainInfo(zone, &bbd)) // Read the *new* domain status
@@ -683,7 +733,7 @@ string Bind2Backend::DLReloadNowHandler(const vector<string>& parts, Utility::pi
       DNSSECKeeper::clearMetaCache(zone);
     }
     else
-      ret << *i << " no such domain\n";
+      ret << *i << ": no such domain\n";
   }
   if (ret.str().empty())
     ret << "no domains reloaded";
@@ -696,19 +746,31 @@ string Bind2Backend::DLDomStatusHandler(const vector<string>& parts, Utility::pi
 
   if (parts.size() > 1) {
     for (auto i = parts.begin() + 1; i < parts.end(); ++i) {
+      ret << *i << ": ";
       BB2DomainInfo bbd;
       if (safeGetBBDomainInfo(ZoneName(*i), &bbd)) {
-        ret << *i << ": " << (bbd.d_loaded ? "" : "[rejected]") << "\t" << bbd.d_status << "\n";
+        if (bbd.d_pending) {
+          ret << "not commited yet\n";
+        }
+        else {
+          ret << (bbd.d_loaded ? "" : "[rejected]") << "\t" << bbd.d_status << "\n";
+        }
       }
       else {
-        ret << *i << " no such domain\n";
+        ret << "no such domain\n";
       }
     }
   }
   else {
     auto state = s_state.read_lock();
-    for (const auto& i : *state) {
-      ret << i.d_name << ": " << (i.d_loaded ? "" : "[rejected]") << "\t" << i.d_status << "\n";
+    for (const auto& bbd : *state) {
+      ret << bbd.d_name << ": ";
+      if (bbd.d_pending) {
+        ret << "not commited yet\n";
+      }
+      else {
+        ret << (bbd.d_loaded ? "" : "[rejected]") << "\t" << bbd.d_status << "\n";
+      }
     }
   }
 
@@ -760,10 +822,14 @@ string Bind2Backend::DLDomExtendedStatusHandler(const vector<string>& parts, Uti
     for (auto i = parts.begin() + 1; i < parts.end(); ++i) {
       BB2DomainInfo bbd;
       if (safeGetBBDomainInfo(ZoneName(*i), &bbd)) {
+        if (bbd.d_pending) {
+          ret << *i << ": not commited yet\n";
+          continue;
+        }
         printDomainExtendedStatus(ret, bbd);
       }
       else {
-        ret << *i << " no such domain" << std::endl;
+        ret << *i << ": no such domain" << std::endl;
       }
     }
   }
@@ -800,8 +866,12 @@ string Bind2Backend::DLAddDomainHandler(const vector<string>& parts, Utility::pi
   ZoneName domainname(parts[1]);
   const string& filename = parts[2];
   BB2DomainInfo bbd;
-  if (safeGetBBDomainInfo(domainname, &bbd))
+  if (safeGetBBDomainInfo(domainname, &bbd)) {
+    if (bbd.d_pending) {
+      return "Not commited yet";
+    }
     return "Already loaded";
+  }
 
   if (!boost::starts_with(filename, "/") && ::arg()["chroot"].empty())
     return "Unable to load zone " + domainname.toLogString() + " from " + filename + " as the filename is not absolute.";
@@ -1057,7 +1127,15 @@ void Bind2Backend::loadConfig(string* status) // NOLINT(readability-function-cog
       BB2DomainInfo bbd;
       bool isNew = false;
 
-      if (!safeGetBBDomainInfo(domain.name, &bbd)) {
+      if (safeGetBBDomainInfo(domain.name, &bbd)) {
+        if (bbd.d_pending) {
+          SLOG(g_log << Logger::Warning << d_logprefix << " Warning! Skipping zone '" << domain.name << "' because it is not commited yet" << endl,
+               d_slog->info(Logr::Warning, "Skipping zone because it is not commited yet", "zone", Logging::Loggable(domain.name)));
+          rejected++;
+          continue;
+        }
+      }
+      else {
         isNew = true;
         bbd.d_id = domain_id++;
         bbd.setCheckInterval(getArgAsNum("check-interval"));
@@ -1182,8 +1260,9 @@ void Bind2Backend::queueReloadAndStore(domainid_t id)
 {
   BB2DomainInfo bbold;
   try {
-    if (!safeGetBBDomainInfo(id, &bbold))
+    if (!safeGetBBDomainInfo(id, &bbold) || bbold.d_pending) {
       return;
+    }
     bbold.d_checknow = false;
     BB2DomainInfo bbnew(bbold);
     /* make sure that nothing will be able to alter the existing records,
@@ -1255,6 +1334,12 @@ bool Bind2Backend::getBeforeAndAfterNamesAbsolute(domainid_t id, const DNSName& 
   BB2DomainInfo bbd;
   if (!safeGetBBDomainInfo(id, &bbd))
     return false;
+  // Ignore pending domains unless we are the backend running the transaction
+  // in which they are being created. This can't be done in safeGetBBDomainInfo
+  // because it needs to be a static method.
+  if (bbd.d_pending && bbd.d_id != d_transaction_id) {
+    return false;
+  }
 
   shared_ptr<const recordstorage_t> records = bbd.d_records.get();
   if (!bbd.d_nsec3zone) {
@@ -1304,7 +1389,14 @@ void Bind2Backend::lookup(const QType& qtype, const DNSName& qname, domainid_t z
   }
 
   if (zoneId != UnknownDomainID) {
-    if ((found = (safeGetBBDomainInfo(zoneId, &bbd) && qname.isPartOf(bbd.d_name)))) {
+    found = safeGetBBDomainInfo(zoneId, &bbd) && qname.isPartOf(bbd.d_name);
+    // Ignore pending domains unless we are the backend running the transaction
+    // in which they are being created. This can't be done in safeGetBBDomainInfo
+    // because it needs to be a static method.
+    if (found && bbd.d_pending && bbd.d_id != d_transaction_id) {
+      found = false;
+    }
+    if (found) {
       domain = std::move(bbd.d_name);
     }
   }
@@ -1312,6 +1404,12 @@ void Bind2Backend::lookup(const QType& qtype, const DNSName& qname, domainid_t z
     domain = ZoneName(qname);
     do {
       found = safeGetBBDomainInfo(domain, &bbd);
+      // Ignore pending domains unless we are the backend running the transaction
+      // in which they are being created. This can't be done in safeGetBBDomainInfo
+      // because it needs to be a static method.
+      if (found && bbd.d_pending && bbd.d_id != d_transaction_id) {
+        found = false;
+      }
     } while (!found && qtype != QType::SOA && domain.chopOff());
   }
 
@@ -1455,6 +1553,12 @@ bool Bind2Backend::list(const ZoneName& /* target */, domainid_t domainId, bool 
   if (!safeGetBBDomainInfo(domainId, &bbd)) {
     return false;
   }
+  // Ignore pending domains unless we are the backend running the transaction
+  // in which they are being created. This can't be done in safeGetBBDomainInfo
+  // because it needs to be a static method.
+  if (bbd.d_pending && bbd.d_id != d_transaction_id) {
+    return false;
+  }
 
   d_handle.reset();
   DLOG(SLOG(g_log << "Bind2Backend constructing handle for list of " << domainId << endl,
@@ -1576,8 +1680,10 @@ BB2DomainInfo Bind2Backend::createDomainEntry(const ZoneName& domain)
   return bbd;
 }
 
-bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& /* nameserver */, const string& account, DomainInfo& info, bool /* startTransaction */)
+bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& /* nameserver */, const string& account, DomainInfo& info, bool startTransaction)
 {
+  info.backend = this; // to be able to abortTransaction if the operation fails
+
   std::string domainname = domain.toStringNoDot();
 
   // Reject domain name if it embeds quotes; this may happen if 8bit-dns is
@@ -1601,6 +1707,19 @@ bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName
     // Make sure the zone file name does not contain path separators.
     filename.append(boost::replace_all_copy(domainname, "/", "\\047"));
   }
+
+  BB2DomainInfo bbd = createDomainEntry(domain);
+  bbd.d_kind = DomainInfo::Secondary;
+  bbd.d_primaries.emplace_back(ComboAddress(ipAddress, 53));
+  bbd.d_fileinfo.emplace_back(std::make_pair(filename, 0));
+  bbd.updateCtime();
+
+  if (startTransaction) {
+    // Remember this domain is pending until the transaction gets commited.
+    bbd.d_pending = true;
+    startDomainCreationTransactionInternal(bbd);
+  }
+  safePutBBDomainInfo(bbd);
 
   SLOG(g_log << Logger::Warning << d_logprefix
              << " Writing bind config zone statement for autosecondary zone '" << domain
@@ -1630,14 +1749,6 @@ bool Bind2Backend::createSecondaryDomain(const string& ipAddress, const ZoneName
     c_of.close();
   }
 
-  BB2DomainInfo bbd = createDomainEntry(domain);
-  bbd.d_kind = DomainInfo::Secondary;
-  bbd.d_primaries.emplace_back(ComboAddress(ipAddress, 53));
-  bbd.d_fileinfo.emplace_back(std::make_pair(filename, 0));
-  bbd.updateCtime();
-  safePutBBDomainInfo(bbd);
-
-  // inline getDomainInfo(domain, info, false) without having to look for BB2DomainInfo again
   info.id = bbd.d_id;
   info.zone = domain;
   info.primaries = bbd.d_primaries;
@@ -1663,6 +1774,12 @@ bool Bind2Backend::searchRecords(const string& pattern, size_t maxResults, vecto
     for (const auto& i : *state) {
       BB2DomainInfo h;
       if (!safeGetBBDomainInfo(i.d_id, &h)) {
+        continue;
+      }
+      // Ignore pending domains unless we are the backend running the transaction
+      // in which they are being created. This can't be done in safeGetBBDomainInfo
+      // because it needs to be a static method.
+      if (h.d_pending && h.d_id != d_transaction_id) {
         continue;
       }
 

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -237,7 +237,7 @@ public:
   bool autoPrimariesList(std::vector<AutoPrimary>& primaries) override;
   bool autoPrimaryBackend(const string& ipAddress, const ZoneName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** backend) override;
   static std::mutex s_autosecondary_config_lock;
-  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account) override;
+  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info) override;
 
 private:
   void setupDNSSEC();

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -315,6 +315,7 @@ private:
   bool d_upgradeContent;
 
   BB2DomainInfo createDomainEntry(const ZoneName& domain); //!< does not insert in s_state
+  bool startDomainCreationTransactionInternal(BB2DomainInfo& bbd);
 
   void queueReloadAndStore(domainid_t id);
   static bool findBeforeAndAfterUnhashed(std::shared_ptr<const recordstorage_t>& records, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after);

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -238,7 +238,7 @@ public:
   bool autoPrimariesList(std::vector<AutoPrimary>& primaries) override;
   bool autoPrimaryBackend(const string& ipAddress, const ZoneName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** backend) override;
   static std::mutex s_autosecondary_config_lock;
-  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info) override;
+  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool startTransaction) override;
 
 private:
   void setupDNSSEC();

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -162,6 +162,7 @@ public:
   bool d_wasRejectedLastReload{false}; //!< if the domain was rejected during Bind2Backend::queueReloadAndStore
   bool d_nsec3zone{false};
   NSEC3PARAMRecordContent d_nsec3param;
+  bool d_pending{false};
 
   // Sugar for the main filename. Only use if d_fileinfo is NOT empty!
   const std::string& main_filename() const { return d_fileinfo.front().first; }
@@ -250,7 +251,7 @@ private:
   static bool safeRemoveBBDomainInfo(const ZoneName& name);
   shared_ptr<SSQLite3> d_dnssecdb;
   bool getNSEC3PARAM(const ZoneName& name, NSEC3PARAMRecordContent* ns3p);
-  static void setLastCheck(domainid_t domain_id, time_t lastcheck);
+  void setLastCheck(domainid_t domain_id, time_t lastcheck);
   bool getNSEC3PARAMuncached(const ZoneName& name, NSEC3PARAMRecordContent* ns3p);
   class handle
   {

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -200,7 +200,8 @@ public:
   void setStale(domainid_t domain_id) override;
   void setFresh(domainid_t domain_id) override;
   void setNotified(domainid_t id, uint32_t serial) override;
-  bool startTransaction(const ZoneName& qname, domainid_t domainId) override;
+  bool startDomainCreationTransaction(const ZoneName& qname, domainid_t domainId) override;
+  bool startDomainModificationTransaction(const ZoneName& qname) override;
   bool feedRecord(const DNSResourceRecord& rr, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
   bool commitTransaction() override;
   bool abortTransaction() override;

--- a/modules/bindbackend/bindbackend2.hh
+++ b/modules/bindbackend/bindbackend2.hh
@@ -201,7 +201,7 @@ public:
   void setStale(domainid_t domain_id) override;
   void setFresh(domainid_t domain_id) override;
   void setNotified(domainid_t id, uint32_t serial) override;
-  bool startDomainCreationTransaction(const ZoneName& qname, domainid_t domainId) override;
+  bool startDomainReplacementTransaction(const ZoneName& qname, domainid_t domainId) override;
   bool startDomainModificationTransaction(const ZoneName& qname) override;
   bool feedRecord(const DNSResourceRecord& rr, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
   bool commitTransaction() override;
@@ -316,7 +316,7 @@ private:
   bool d_upgradeContent;
 
   BB2DomainInfo createDomainEntry(const ZoneName& domain); //!< does not insert in s_state
-  bool startDomainCreationTransactionInternal(BB2DomainInfo& bbd);
+  bool startDomainReplacementTransactionInternal(BB2DomainInfo& bbd);
 
   void queueReloadAndStore(domainid_t id);
   static bool findBeforeAndAfterUnhashed(std::shared_ptr<const recordstorage_t>& records, const DNSName& qname, DNSName& unhashed, DNSName& before, DNSName& after);

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -38,7 +38,7 @@ void Bind2Backend::setupDNSSEC()
 
 unsigned int Bind2Backend::getCapabilities()
 {
-  unsigned int caps = CAP_LIST | CAP_SEARCH;
+  unsigned int caps = CAP_LIST | CAP_SEARCH | CAP_DOMAIN_TRANSACTION;
   if (d_hybrid) {
     caps |= CAP_DNSSEC;
   }
@@ -203,7 +203,7 @@ void Bind2Backend::freeStatements()
 
 unsigned int Bind2Backend::getCapabilities()
 {
-  unsigned int caps = CAP_LIST | CAP_SEARCH;
+  unsigned int caps = CAP_LIST | CAP_SEARCH | CAP_DOMAIN_TRANSACTION;
   if (d_dnssecdb || d_hybrid) {
     caps |= CAP_DNSSEC;
   }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2469,10 +2469,8 @@ bool LMDBBackend::setPrimaries(const ZoneName& domain, const vector<ComboAddress
   });
 }
 
-bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account)
+bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info)
 {
-  DomainInfo info;
-
   if (findDomain(domain, info)) {
     throw DBException("Domain '" + domain.toLogString() + "' exists already");
   }
@@ -2490,7 +2488,7 @@ bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
     writeTransientDomainInfo(info);
   }
 
-  return true;
+  return getDomainInfo(domain, info);
 }
 
 void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow)

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1405,7 +1405,7 @@ void LMDBBackend::updateDomainInfo(const DomainInfo& info)
   writeTransientDomainInfo(info);
 }
 
-bool LMDBBackend::startDomainCreationTransaction(const ZoneName& domain, domainid_t domain_id)
+bool LMDBBackend::startDomainReplacementTransaction(const ZoneName& domain, domainid_t domain_id)
 {
   if (d_rwtxn) {
     throw DBException("Attempt to start a transaction while one was open already");
@@ -1992,7 +1992,7 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
   for (auto id : idvec) {
 
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-    startDomainCreationTransaction(domain, id);
+    startDomainReplacementTransaction(domain, id);
 
     { // Remove metadata
       auto txn = d_tmeta->getRWTransaction();
@@ -2036,7 +2036,7 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
     startDomainModificationTransaction(transactionDomain);
   }
   else {
-    startDomainCreationTransaction(transactionDomain, transactionDomainId);
+    startDomainReplacementTransaction(transactionDomain, transactionDomainId);
   }
 
   return true;

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1284,8 +1284,8 @@ static uint32_t peekAtTtl(const string_view& buffer)
 /* A note on the design.
 
    If you ask a question without a zone id (this can be the case for lookup(),
-   and of course also for startTransaction if you don't want to delete the
-   domain contents), we lookup the best zone id for you, and answer from that.
+   and of course also for startDomainModificationTransaction), we lookup the
+   best zone id for you, and answer from that.
 
    The index we use is "zoneid,canonical relative name". This index is also used
    for AXFR.
@@ -1404,43 +1404,38 @@ void LMDBBackend::updateDomainInfo(const DomainInfo& info)
   writeTransientDomainInfo(info);
 }
 
-/* Here's the complicated story. Other backends have just one transaction, which is either
-   on or not.
-
-   You can't call feedRecord without a transaction started with startTransaction.
-
-   However, other functions can be called after startTransaction() or without startTransaction()
-     (like updateDNSSECOrderNameAndAuth)
-
-
-
-*/
-
-bool LMDBBackend::startTransaction(const ZoneName& domain, domainid_t domain_id)
+bool LMDBBackend::startDomainCreationTransaction(const ZoneName& domain, domainid_t domain_id)
 {
-  // cout <<"startTransaction("<<domain<<", "<<domain_id<<")"<<endl;
-  domainid_t real_id = domain_id;
-  if (real_id == UnknownDomainID) {
-    DomainInfo info;
-    if (!findDomain(domain, info)) {
-      return false;
-    }
-    real_id = info.id;
-  }
   if (d_rwtxn) {
     throw DBException("Attempt to start a transaction while one was open already");
   }
-  d_rwtxn = getRecordsRWTransaction(real_id);
+  d_rwtxn = getRecordsRWTransaction(domain_id);
   d_txnorder = false;
-
   d_transactiondomain = domain;
-  d_transactiondomainid = real_id;
-  if (domain_id != UnknownDomainID) {
-    compoundOrdername order;
-    string match = order(domain_id);
-    LMDBBackend::deleteDomainRecords(*d_rwtxn, match);
-  }
+  d_transactiondomainid = domain_id;
 
+  // In the current state of transactions, the domain must be created in the
+  // domains table first, so that its domain id can be passed to this function.
+  compoundOrdername order;
+  string match = order(domain_id);
+  LMDBBackend::deleteDomainRecords(*d_rwtxn, match);
+
+  return true;
+}
+
+bool LMDBBackend::startDomainModificationTransaction(const ZoneName& domain)
+{
+  if (d_rwtxn) {
+    throw DBException("Attempt to start a transaction while one was open already");
+  }
+  DomainInfo info;
+  if (!findDomain(domain, info)) {
+    return false;
+  }
+  d_rwtxn = getRecordsRWTransaction(info.id);
+  d_txnorder = false;
+  d_transactiondomain = domain;
+  d_transactiondomainid = info.id;
   return true;
 }
 
@@ -1975,9 +1970,12 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
     throw DBException(std::string(__PRETTY_FUNCTION__) + " called without a transaction");
   }
 
+  // Save the current transaction details, and abort it.
+  // TODO: this needs to be revisited to allow this to be part of a larger
+  // transaction without having to abort it. Or should this call be rejected
+  // if a transaction is active?
   int transactionDomainId = d_transactiondomainid;
   ZoneName transactionDomain = d_transactiondomain;
-
   abortTransaction();
 
   LmdbIdVec idvec;
@@ -2001,7 +1999,7 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
 
   for (auto id : idvec) {
 
-    startTransaction(domain, id);
+    startDomainCreationTransaction(domain, id);
 
     { // Remove metadata
       auto txn = d_tmeta->getRWTransaction();
@@ -2041,6 +2039,7 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
     txn.commit();
   }
 
+  // Use startTransaction() here as transactionDomainId might be UnknownDomainID
   startTransaction(transactionDomain, transactionDomainId);
 
   return true;

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2489,6 +2489,8 @@ bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
     info.kind = kind;
     info.primaries = primaries;
     info.account = account;
+    info.backend = this;
+    info.serial = 0;
 
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     info.id = static_cast<domainid_t>(txn.put(info, 0, d_random_ids, domain.hash()));
@@ -2496,7 +2498,7 @@ bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
     writeTransientDomainInfo(info);
   }
 
-  return getDomainInfo(domain, info);
+  return true;
 }
 
 void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow)

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1991,6 +1991,7 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
 
   for (auto id : idvec) {
 
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     startDomainCreationTransaction(domain, id);
 
     { // Remove metadata
@@ -2031,8 +2032,12 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
     txn.commit();
   }
 
-  // Use startTransaction() here as transactionDomainId might be UnknownDomainID
-  startTransaction(transactionDomain, transactionDomainId);
+  if (transactionDomainId == UnknownDomainID) {
+    startDomainModificationTransaction(transactionDomain);
+  }
+  else {
+    startDomainCreationTransaction(transactionDomain, transactionDomainId);
+  }
 
   return true;
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1999,6 +1999,7 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
 
   for (auto id : idvec) {
 
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     startDomainCreationTransaction(domain, id);
 
     { // Remove metadata
@@ -2039,8 +2040,12 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
     txn.commit();
   }
 
-  // Use startTransaction() here as transactionDomainId might be UnknownDomainID
-  startTransaction(transactionDomain, transactionDomainId);
+  if (transactionDomainId == UnknownDomainID) {
+    startDomainModificationTransaction(transactionDomain);
+  }
+  else {
+    startDomainCreationTransaction(transactionDomain, transactionDomainId);
+  }
 
   return true;
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -1285,8 +1285,8 @@ static uint32_t peekAtTtl(const string_view& buffer)
 /* A note on the design.
 
    If you ask a question without a zone id (this can be the case for lookup(),
-   and of course also for startTransaction if you don't want to delete the
-   domain contents), we lookup the best zone id for you, and answer from that.
+   and of course also for startDomainModificationTransaction), we lookup the
+   best zone id for you, and answer from that.
 
    The index we use is "zoneid,canonical relative name". This index is also used
    for AXFR.
@@ -1405,43 +1405,38 @@ void LMDBBackend::updateDomainInfo(const DomainInfo& info)
   writeTransientDomainInfo(info);
 }
 
-/* Here's the complicated story. Other backends have just one transaction, which is either
-   on or not.
-
-   You can't call feedRecord without a transaction started with startTransaction.
-
-   However, other functions can be called after startTransaction() or without startTransaction()
-     (like updateDNSSECOrderNameAndAuth)
-
-
-
-*/
-
-bool LMDBBackend::startTransaction(const ZoneName& domain, domainid_t domain_id)
+bool LMDBBackend::startDomainCreationTransaction(const ZoneName& domain, domainid_t domain_id)
 {
-  // cout <<"startTransaction("<<domain<<", "<<domain_id<<")"<<endl;
-  domainid_t real_id = domain_id;
-  if (real_id == UnknownDomainID) {
-    DomainInfo info;
-    if (!findDomain(domain, info)) {
-      return false;
-    }
-    real_id = info.id;
-  }
   if (d_rwtxn) {
     throw DBException("Attempt to start a transaction while one was open already");
   }
-  d_rwtxn = getRecordsRWTransaction(real_id);
+  d_rwtxn = getRecordsRWTransaction(domain_id);
   d_txnorder = false;
-
   d_transactiondomain = domain;
-  d_transactiondomainid = real_id;
-  if (domain_id != UnknownDomainID) {
-    compoundOrdername order;
-    string match = order(domain_id);
-    LMDBBackend::deleteDomainRecords(*d_rwtxn, match);
-  }
+  d_transactiondomainid = domain_id;
 
+  // In the current state of transactions, the domain must be created in the
+  // domains table first, so that its domain id can be passed to this function.
+  compoundOrdername order;
+  string match = order(domain_id);
+  LMDBBackend::deleteDomainRecords(*d_rwtxn, match);
+
+  return true;
+}
+
+bool LMDBBackend::startDomainModificationTransaction(const ZoneName& domain)
+{
+  if (d_rwtxn) {
+    throw DBException("Attempt to start a transaction while one was open already");
+  }
+  DomainInfo info;
+  if (!findDomain(domain, info)) {
+    return false;
+  }
+  d_rwtxn = getRecordsRWTransaction(info.id);
+  d_txnorder = false;
+  d_transactiondomain = domain;
+  d_transactiondomainid = info.id;
   return true;
 }
 
@@ -1967,9 +1962,12 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
     throw DBException(std::string(__PRETTY_FUNCTION__) + " called without a transaction");
   }
 
+  // Save the current transaction details, and abort it.
+  // TODO: this needs to be revisited to allow this to be part of a larger
+  // transaction without having to abort it. Or should this call be rejected
+  // if a transaction is active?
   int transactionDomainId = d_transactiondomainid;
   ZoneName transactionDomain = d_transactiondomain;
-
   abortTransaction();
 
   LmdbIdVec idvec;
@@ -1993,7 +1991,7 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
 
   for (auto id : idvec) {
 
-    startTransaction(domain, id);
+    startDomainCreationTransaction(domain, id);
 
     { // Remove metadata
       auto txn = d_tmeta->getRWTransaction();
@@ -2033,6 +2031,7 @@ bool LMDBBackend::deleteDomain(const ZoneName& domain)
     txn.commit();
   }
 
+  // Use startTransaction() here as transactionDomainId might be UnknownDomainID
   startTransaction(transactionDomain, transactionDomainId);
 
   return true;

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2477,10 +2477,8 @@ bool LMDBBackend::setPrimaries(const ZoneName& domain, const vector<ComboAddress
   });
 }
 
-bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account)
+bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info)
 {
-  DomainInfo info;
-
   if (findDomain(domain, info)) {
     throw DBException("Domain '" + domain.toLogString() + "' exists already");
   }
@@ -2498,7 +2496,7 @@ bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
     writeTransientDomainInfo(info);
   }
 
-  return true;
+  return getDomainInfo(domain, info);
 }
 
 void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow)

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2476,7 +2476,7 @@ bool LMDBBackend::setPrimaries(const ZoneName& domain, const vector<ComboAddress
   });
 }
 
-bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info)
+bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool /* startTransaction */)
 {
   if (findDomain(domain, info)) {
     throw DBException("Domain '" + domain.toLogString() + "' exists already");

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2468,7 +2468,7 @@ bool LMDBBackend::setPrimaries(const ZoneName& domain, const vector<ComboAddress
   });
 }
 
-bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info)
+bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool /* startTransaction */)
 {
   if (findDomain(domain, info)) {
     throw DBException("Domain '" + domain.toLogString() + "' exists already");

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2481,6 +2481,8 @@ bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
     info.kind = kind;
     info.primaries = primaries;
     info.account = account;
+    info.backend = this;
+    info.serial = 0;
 
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     info.id = static_cast<domainid_t>(txn.put(info, 0, d_random_ids, domain.hash()));
@@ -2488,7 +2490,7 @@ bool LMDBBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
     writeTransientDomainInfo(info);
   }
 
-  return getDomainInfo(domain, info);
+  return true;
 }
 
 void LMDBBackend::getAllDomainsFiltered(vector<DomainInfo>* domains, const std::function<bool(DomainInfo&)>& allow)

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -78,7 +78,7 @@ public:
   bool listSubZone(const ZoneName& target, domainid_t domain_id) override;
 
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool getserial = true) override;
-  bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account) override;
+  bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info) override;
 
   bool startTransaction(const ZoneName& domain, domainid_t domain_id = UnknownDomainID) override;
   bool commitTransaction() override;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -80,7 +80,8 @@ public:
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool getserial = true) override;
   bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info) override;
 
-  bool startTransaction(const ZoneName& domain, domainid_t domain_id = UnknownDomainID) override;
+  bool startDomainCreationTransaction(const ZoneName& domain, domainid_t domain_id) override;
+  bool startDomainModificationTransaction(const ZoneName& domain) override;
   bool commitTransaction() override;
   bool abortTransaction() override;
   bool feedRecord(const DNSResourceRecord& r, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -80,7 +80,7 @@ public:
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool getserial = true) override;
   bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool startTransaction) override;
 
-  bool startDomainCreationTransaction(const ZoneName& domain, domainid_t domain_id) override;
+  bool startDomainReplacementTransaction(const ZoneName& domain, domainid_t domain_id) override;
   bool startDomainModificationTransaction(const ZoneName& domain) override;
   bool commitTransaction() override;
   bool abortTransaction() override;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -78,7 +78,7 @@ public:
   bool listSubZone(const ZoneName& target, domainid_t domain_id) override;
 
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool getserial = true) override;
-  bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info) override;
+  bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool startTransaction) override;
 
   bool startDomainCreationTransaction(const ZoneName& domain, domainid_t domain_id) override;
   bool startDomainModificationTransaction(const ZoneName& domain) override;

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -718,7 +718,7 @@ bool RemoteBackend::autoPrimaryBackend(const string& ipAddress, const ZoneName& 
   return true;
 }
 
-bool RemoteBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account)
+bool RemoteBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info)
 {
   Json query = Json::object{
     {"method", "createSlaveDomain"},
@@ -730,7 +730,10 @@ bool RemoteBackend::createSecondaryDomain(const string& ipAddress, const ZoneNam
                    }}};
 
   Json answer;
-  return this->send(query) && this->recv(answer);
+  if (!this->send(query) || !this->recv(answer)) {
+    return false;
+  }
+  return getDomainInfo(domain, info, false);
 }
 
 bool RemoteBackend::replaceRRSet(domainid_t domain_id, const DNSName& qname, const QType& qtype, const vector<DNSResourceRecord>& rrset)

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -733,6 +733,8 @@ bool RemoteBackend::createSecondaryDomain(const string& ipAddress, const ZoneNam
   if (!this->send(query) || !this->recv(answer)) {
     return false;
   }
+  // Although we know most of the information to be returned in [info], we
+  // do not know the domain id, so we need to query the remote.
   return getDomainInfo(domain, info, false);
 }
 

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -718,7 +718,7 @@ bool RemoteBackend::autoPrimaryBackend(const string& ipAddress, const ZoneName& 
   return true;
 }
 
-bool RemoteBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info)
+bool RemoteBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool /* startTransaction */)
 {
   Json query = Json::object{
     {"method", "createSlaveDomain"},

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -810,7 +810,7 @@ bool RemoteBackend::feedEnts3(domainid_t domain_id, const DNSName& domain, map<D
   return this->send(query) && this->recv(answer);
 }
 
-bool RemoteBackend::startTransaction(const ZoneName& domain, domainid_t domain_id)
+bool RemoteBackend::startTransactionInternal(const ZoneName& domain, domainid_t domain_id)
 {
   this->d_trxid = time((time_t*)nullptr);
 
@@ -824,6 +824,14 @@ bool RemoteBackend::startTransaction(const ZoneName& domain, domainid_t domain_i
     return false;
   }
   return true;
+}
+bool RemoteBackend::startDomainCreationTransaction(const ZoneName& qname, domainid_t domainId)
+{
+  return startTransactionInternal(qname, domainId);
+}
+bool RemoteBackend::startDomainModificationTransaction(const ZoneName& qname)
+{
+  return startTransactionInternal(qname, UnknownDomainID);
 }
 
 bool RemoteBackend::commitTransaction()

--- a/modules/remotebackend/remotebackend.cc
+++ b/modules/remotebackend/remotebackend.cc
@@ -825,7 +825,7 @@ bool RemoteBackend::startTransactionInternal(const ZoneName& domain, domainid_t 
   }
   return true;
 }
-bool RemoteBackend::startDomainCreationTransaction(const ZoneName& qname, domainid_t domainId)
+bool RemoteBackend::startDomainReplacementTransaction(const ZoneName& qname, domainid_t domainId)
 {
   return startTransactionInternal(qname, domainId);
 }

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -190,7 +190,7 @@ public:
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool getSerial = true) override;
   void setNotified(domainid_t id, uint32_t serial) override;
   bool autoPrimaryBackend(const string& ipAddress, const ZoneName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** ddb) override;
-  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account) override;
+  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info) override;
   bool replaceRRSet(domainid_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
   bool feedRecord(const DNSResourceRecord& r, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
   bool feedEnts(domainid_t domain_id, map<DNSName, bool>& nonterm) override;

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -195,7 +195,7 @@ public:
   bool feedRecord(const DNSResourceRecord& r, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
   bool feedEnts(domainid_t domain_id, map<DNSName, bool>& nonterm) override;
   bool feedEnts3(domainid_t domain_id, const DNSName& domain, map<DNSName, bool>& nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
-  bool startDomainCreationTransaction(const ZoneName& qname, domainid_t domainId) override;
+  bool startDomainReplacementTransaction(const ZoneName& qname, domainid_t domainId) override;
   bool startDomainModificationTransaction(const ZoneName& qname) override;
   bool commitTransaction() override;
   bool abortTransaction() override;

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -190,7 +190,7 @@ public:
   bool getDomainInfo(const ZoneName& domain, DomainInfo& info, bool getSerial = true) override;
   void setNotified(domainid_t id, uint32_t serial) override;
   bool autoPrimaryBackend(const string& ipAddress, const ZoneName& domain, const vector<DNSResourceRecord>& nsset, string* nameserver, string* account, DNSBackend** ddb) override;
-  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info) override;
+  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool startTransaction) override;
   bool replaceRRSet(domainid_t domain_id, const DNSName& qname, const QType& qt, const vector<DNSResourceRecord>& rrset) override;
   bool feedRecord(const DNSResourceRecord& r, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
   bool feedEnts(domainid_t domain_id, map<DNSName, bool>& nonterm) override;

--- a/modules/remotebackend/remotebackend.hh
+++ b/modules/remotebackend/remotebackend.hh
@@ -195,7 +195,8 @@ public:
   bool feedRecord(const DNSResourceRecord& r, const DNSName& ordername, bool ordernameIsNSEC3 = false) override;
   bool feedEnts(domainid_t domain_id, map<DNSName, bool>& nonterm) override;
   bool feedEnts3(domainid_t domain_id, const DNSName& domain, map<DNSName, bool>& nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
-  bool startTransaction(const ZoneName& domain, domainid_t domain_id) override;
+  bool startDomainCreationTransaction(const ZoneName& qname, domainid_t domainId) override;
+  bool startDomainModificationTransaction(const ZoneName& qname) override;
   bool commitTransaction() override;
   bool abortTransaction() override;
   bool setTSIGKey(const DNSName& name, const DNSName& algorithm, const string& content) override;
@@ -256,4 +257,5 @@ private:
   };
 
   void parseDomainInfo(const json11::Json& obj, DomainInfo& di);
+  bool startTransactionInternal(const ZoneName& domain, domainid_t domain_id);
 };

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -306,8 +306,9 @@ BOOST_AUTO_TEST_CASE(test_method_autoPrimaryBackend)
 
 BOOST_AUTO_TEST_CASE(test_method_createSecondaryDomain)
 {
+  DomainInfo unused;
   BOOST_TEST_MESSAGE("Testing createSecondaryDomain method");
-  BOOST_CHECK(backendUnderTest->createSecondaryDomain("10.0.0.1", ZoneName("pirate.unit.test."), "", ""));
+  BOOST_CHECK(backendUnderTest->createSecondaryDomain("10.0.0.1", ZoneName("pirate.unit.test."), "", "", unused));
 }
 
 BOOST_AUTO_TEST_CASE(test_method_feedRecord)

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(test_method_createSecondaryDomain)
 {
   DomainInfo unused;
   BOOST_TEST_MESSAGE("Testing createSecondaryDomain method");
-  BOOST_CHECK(backendUnderTest->createSecondaryDomain("10.0.0.1", ZoneName("pirate.unit.test."), "", "", unused));
+  BOOST_CHECK(backendUnderTest->createSecondaryDomain("10.0.0.1", ZoneName("pirate.unit.test."), "", "", unused, false));
 }
 
 BOOST_AUTO_TEST_CASE(test_method_feedRecord)

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(test_method_feedRecord)
 {
   DNSResourceRecord resourceRecord;
   BOOST_TEST_MESSAGE("Testing feedRecord method");
-  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com."), 3);
+  backendUnderTest->startDomainReplacementTransaction(ZoneName("example.com."), 3);
   resourceRecord.qname = DNSName("example.com.");
   resourceRecord.qtype = QType::SOA;
   resourceRecord.qclass = QClass::IN;
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(test_method_feedRecord)
 
 BOOST_AUTO_TEST_CASE(test_method_replaceRRSet)
 {
-  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com."), 3);
+  backendUnderTest->startDomainReplacementTransaction(ZoneName("example.com."), 3);
   DNSResourceRecord resourceRecord;
   std::vector<DNSResourceRecord> rrset;
   BOOST_TEST_MESSAGE("Testing replaceRRSet method");
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(test_method_replaceRRSet)
 BOOST_AUTO_TEST_CASE(test_method_feedEnts)
 {
   BOOST_TEST_MESSAGE("Testing feedEnts method");
-  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com."), 3);
+  backendUnderTest->startDomainReplacementTransaction(ZoneName("example.com."), 3);
   map<DNSName, bool> nonterm = boost::assign::map_list_of(DNSName("_udp"), true)(DNSName("_sip._udp"), true);
   BOOST_CHECK(backendUnderTest->feedEnts(2, nonterm));
   backendUnderTest->commitTransaction();
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(test_method_feedEnts)
 BOOST_AUTO_TEST_CASE(test_method_feedEnts3)
 {
   BOOST_TEST_MESSAGE("Testing feedEnts3 method");
-  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com"), 3);
+  backendUnderTest->startDomainReplacementTransaction(ZoneName("example.com"), 3);
   NSEC3PARAMRecordContent ns3prc;
   ns3prc.d_iterations = 1;
   ns3prc.d_salt = "\u00aa\u00bb\u00cc\u00dd";
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(test_method_feedEnts3)
 BOOST_AUTO_TEST_CASE(test_method_abortTransaction)
 {
   BOOST_TEST_MESSAGE("Testing abortTransaction method");
-  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com."), 3);
+  backendUnderTest->startDomainReplacementTransaction(ZoneName("example.com."), 3);
   BOOST_CHECK(backendUnderTest->abortTransaction());
 }
 

--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(test_method_feedRecord)
 {
   DNSResourceRecord resourceRecord;
   BOOST_TEST_MESSAGE("Testing feedRecord method");
-  backendUnderTest->startTransaction(ZoneName("example.com."), 3);
+  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com."), 3);
   resourceRecord.qname = DNSName("example.com.");
   resourceRecord.qtype = QType::SOA;
   resourceRecord.qclass = QClass::IN;
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(test_method_feedRecord)
 
 BOOST_AUTO_TEST_CASE(test_method_replaceRRSet)
 {
-  backendUnderTest->startTransaction(ZoneName("example.com."), 3);
+  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com."), 3);
   DNSResourceRecord resourceRecord;
   std::vector<DNSResourceRecord> rrset;
   BOOST_TEST_MESSAGE("Testing replaceRRSet method");
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(test_method_replaceRRSet)
 BOOST_AUTO_TEST_CASE(test_method_feedEnts)
 {
   BOOST_TEST_MESSAGE("Testing feedEnts method");
-  backendUnderTest->startTransaction(ZoneName("example.com."), 3);
+  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com."), 3);
   map<DNSName, bool> nonterm = boost::assign::map_list_of(DNSName("_udp"), true)(DNSName("_sip._udp"), true);
   BOOST_CHECK(backendUnderTest->feedEnts(2, nonterm));
   backendUnderTest->commitTransaction();
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(test_method_feedEnts)
 BOOST_AUTO_TEST_CASE(test_method_feedEnts3)
 {
   BOOST_TEST_MESSAGE("Testing feedEnts3 method");
-  backendUnderTest->startTransaction(ZoneName("example.com"), 3);
+  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com"), 3);
   NSEC3PARAMRecordContent ns3prc;
   ns3prc.d_iterations = 1;
   ns3prc.d_salt = "\u00aa\u00bb\u00cc\u00dd";
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(test_method_feedEnts3)
 BOOST_AUTO_TEST_CASE(test_method_abortTransaction)
 {
   BOOST_TEST_MESSAGE("Testing abortTransaction method");
-  backendUnderTest->startTransaction(ZoneName("example.com."), 3);
+  backendUnderTest->startDomainCreationTransaction(ZoneName("example.com."), 3);
   BOOST_CHECK(backendUnderTest->abortTransaction());
 }
 

--- a/pdns/auth-primarycommunicator.cc
+++ b/pdns/auth-primarycommunicator.cc
@@ -192,7 +192,7 @@ void CommunicatorClass::getUpdatedProducers(UeberBackend* B, vector<DomainInfo>&
 
         DNSResourceRecord rr;
         makeIncreasedSOARecord(sd, "EPOCH", "", rr, d_slog);
-        di.backend->startTransaction(sd.zonename, UnknownDomainID);
+        di.backend->startDomainModificationTransaction(sd.zonename);
         if (!di.backend->replaceRRSet(di.id, rr.qname, rr.qtype, {rr})) {
           di.backend->abortTransaction();
           throw PDNSException("backend hosting producer zone '" + sd.zonename.toLogString() + "' does not support editing records");

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -293,7 +293,8 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
         SLOG(g_log << Logger::Warning << ctx.logPrefix << "create zone '" << ciCreate.d_zone << "'" << endl,
              ctx.slog->info(Logr::Warning, "Catalog-Zone: create zone", "zone", Logging::Loggable(ciCreate.d_zone)));
         d.kind = !empty(g_memberCatalogGroup) && ciCreate.d_group.count(g_memberCatalogGroup) != 0 ? DomainInfo::Consumer : DomainInfo::Secondary;
-        ctx.domain.backend->createDomain(ciCreate.d_zone, d.kind, ciCreate.d_primaries, "");
+        DomainInfo unused;
+        ctx.domain.backend->createDomain(ciCreate.d_zone, d.kind, ciCreate.d_primaries, "", unused);
 
         ctx.domain.backend->setPrimaries(ciCreate.d_zone, ctx.domain.primaries);
         ctx.domain.backend->setOptions(ciCreate.d_zone, ciCreate.toJson());

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -162,7 +162,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
           }
 
           if (doOptions) { // update zone options
-            if (doTransaction && (inTransaction = ctx.domain.backend->startTransaction(ctx.domain.zone))) {
+            if (doTransaction && (inTransaction = ctx.domain.backend->startDomainModificationTransaction(ctx.domain.zone))) {
               SLOG(g_log << Logger::Warning << ctx.logPrefix << "backend transaction started" << endl,
                    ctx.slog->info(Logr::Warning, "Catalog-Zone: backend transaction started"));
               doTransaction = false;
@@ -174,7 +174,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
           }
 
           if (doType) { // update zone type
-            if (doTransaction && (inTransaction = ctx.domain.backend->startTransaction(ctx.domain.zone))) {
+            if (doTransaction && (inTransaction = ctx.domain.backend->startDomainModificationTransaction(ctx.domain.zone))) {
               SLOG(g_log << Logger::Warning << ctx.logPrefix << "backend transaction started" << endl,
                    ctx.slog->info(Logr::Warning, "Catalog-Zone: backend transaction started"));
               doTransaction = false;
@@ -187,7 +187,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
           }
 
           if (ctx.domain.primaries != ciDB.d_primaries) { // update primaries
-            if (doTransaction && (inTransaction = ctx.domain.backend->startTransaction(ctx.domain.zone))) {
+            if (doTransaction && (inTransaction = ctx.domain.backend->startDomainModificationTransaction(ctx.domain.zone))) {
               SLOG(g_log << Logger::Warning << ctx.logPrefix << "backend transaction started" << endl,
                    ctx.slog->info(Logr::Warning, "Catalog-Zone: backend transaction started"));
               doTransaction = false;
@@ -228,7 +228,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
             SLOG(g_log << Logger::Warning << ctx.logPrefix << "zone '" << d.zone << "' owner change without state reset, old catalog '" << d.catalog << "', new catalog '" << ctx.domain.zone << "'" << endl,
                  ctx.slog->info(Logr::Warning, "Catalog-Zone: owner change without state reset", "zone", Logging::Loggable(d.zone), "old catalog", Logging::Loggable(d.catalog), "new catalog", Logging::Loggable(ctx.domain.zone)));
 
-            if (doTransaction && (inTransaction = ctx.domain.backend->startTransaction(ctx.domain.zone))) {
+            if (doTransaction && (inTransaction = ctx.domain.backend->startDomainModificationTransaction(ctx.domain.zone))) {
               SLOG(g_log << Logger::Warning << ctx.logPrefix << "backend transaction started" << endl,
                    ctx.slog->info(Logr::Warning, "Catalog-Zone: backend transaction started"));
               doTransaction = false;
@@ -268,7 +268,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
       }
 
       if (remove) { // delete zone
-        if (doTransaction && (inTransaction = ctx.domain.backend->startTransaction(ctx.domain.zone))) {
+        if (doTransaction && (inTransaction = ctx.domain.backend->startDomainModificationTransaction(ctx.domain.zone))) {
           SLOG(g_log << Logger::Warning << ctx.logPrefix << "backend transaction started" << endl,
                ctx.slog->info(Logr::Warning, "Catalog-Zone: backend transaction started"));
           doTransaction = false;
@@ -284,7 +284,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
       }
 
       if (create) { // create zone
-        if (doTransaction && (inTransaction = ctx.domain.backend->startTransaction(ctx.domain.zone))) {
+        if (doTransaction && (inTransaction = ctx.domain.backend->startDomainModificationTransaction(ctx.domain.zone))) {
           SLOG(g_log << Logger::Warning << ctx.logPrefix << "backend transaction started" << endl,
                ctx.slog->info(Logr::Warning, "Catalog-Zone: backend transaction started"));
           doTransaction = false;
@@ -577,7 +577,7 @@ void CommunicatorClass::ixfrSuck(const TSIGTriplet& tsig, const ComboAddress& la
         grouped[{ZoneName(x.d_name), x.d_type}].second.push_back(x);
       }
 
-      ctx.domain.backend->startTransaction(ctx.domain.zone, UnknownDomainID);
+      ctx.domain.backend->startDomainModificationTransaction(ctx.domain.zone);
       for (const auto& g : grouped) { // NOLINT(readability-identifier-length)
         vector<DNSRecord> rrset;
         {
@@ -974,7 +974,7 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
         }
       }
     }
-    transaction = ctx.domain.backend->startTransaction(domain, ctx.domain.id);
+    transaction = ctx.domain.backend->startDomainCreationTransaction(domain, ctx.domain.id);
     SLOG(g_log << Logger::Info << ctx.logPrefix << "storage transaction started" << endl,
          ctx.slog->info(Logr::Info, "AXFR: storage transaction started"));
 

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -294,7 +294,7 @@ static bool catalogDiff(const XFRContext& ctx, vector<CatalogInfo>& fromXFR, vec
              ctx.slog->info(Logr::Warning, "Catalog-Zone: create zone", "zone", Logging::Loggable(ciCreate.d_zone)));
         d.kind = !empty(g_memberCatalogGroup) && ciCreate.d_group.count(g_memberCatalogGroup) != 0 ? DomainInfo::Consumer : DomainInfo::Secondary;
         DomainInfo unused;
-        ctx.domain.backend->createDomain(ciCreate.d_zone, d.kind, ciCreate.d_primaries, "", unused);
+        ctx.domain.backend->createDomain(ciCreate.d_zone, d.kind, ciCreate.d_primaries, "", unused, false);
 
         ctx.domain.backend->setPrimaries(ciCreate.d_zone, ctx.domain.primaries);
         ctx.domain.backend->setOptions(ciCreate.d_zone, ciCreate.toJson());

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -974,7 +974,7 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
         }
       }
     }
-    transaction = ctx.domain.backend->startDomainCreationTransaction(domain, ctx.domain.id);
+    transaction = ctx.domain.backend->startDomainReplacementTransaction(domain, ctx.domain.id);
     SLOG(g_log << Logger::Info << ctx.logPrefix << "storage transaction started" << endl,
          ctx.slog->info(Logr::Info, "AXFR: storage transaction started"));
 

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -912,7 +912,7 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
         }
         else {
           SLOG(g_log << Logger::Warning << ctx.logPrefix << "got " << ctx.numDeltas << " delta" << addS(ctx.numDeltas) << ", zone committed with serial " << ctx.soa_serial << endl,
-               ctx.slog->info(Logr::Warning, "IXFR: zone commited", "serial", Logging::Loggable(ctx.soa_serial), "deltas", Logging::Loggable(ctx.numDeltas)));
+               ctx.slog->info(Logr::Warning, "IXFR: zone committed", "serial", Logging::Loggable(ctx.soa_serial), "deltas", Logging::Loggable(ctx.numDeltas)));
           purgeAuthCaches(domain.operator const DNSName&().toString() + "$");
           return;
         }

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1924,7 +1924,7 @@ bool GSQLBackend::autoPrimaryBackend(const string& ipAddress, const ZoneName& do
   return false;
 }
 
-bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account)
+bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info)
 {
   vector<string> primaries_s;
   primaries_s.reserve(primaries.size());
@@ -1948,10 +1948,10 @@ bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
   catch(SSqlException &e) {
     throw PDNSException("Database error trying to insert new domain '"+domain.toLogString()+"': "+ e.txtReason());
   }
-  return true;
+  return getDomainInfo(domain, info, false);
 }
 
-bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account)
+bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info)
 {
   string name;
   vector<ComboAddress> primaries({ComboAddress(ipAddress, 53)});
@@ -1980,12 +1980,12 @@ bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName&
         primaries = std::move(tmp);
       }
     }
-    createDomain(domain, DomainInfo::Secondary, primaries, account);
+    createDomain(domain, DomainInfo::Secondary, primaries, account, info);
   }
   catch(SSqlException &e) {
     throw PDNSException("Database error trying to insert new secondary domain '" + domain.toLogString() + "': " + e.txtReason());
   }
-  return true;
+  return getDomainInfo(domain, info, false);
 }
 
 bool GSQLBackend::deleteDomain(const ZoneName &domain)

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1932,7 +1932,7 @@ bool GSQLBackend::autoPrimaryBackend(const string& ipAddress, const ZoneName& do
   return false;
 }
 
-bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info)
+bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool /* startTransaction */)
 {
   vector<string> primaries_s;
   primaries_s.reserve(primaries.size());
@@ -1959,7 +1959,7 @@ bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
   return getDomainInfo(domain, info, false);
 }
 
-bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info)
+bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool /* startTransaction */)
 {
   string name;
   vector<ComboAddress> primaries({ComboAddress(ipAddress, 53)});
@@ -1988,7 +1988,7 @@ bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName&
         primaries = std::move(tmp);
       }
     }
-    createDomain(domain, DomainInfo::Secondary, primaries, account, info);
+    createDomain(domain, DomainInfo::Secondary, primaries, account, info, false);
   }
   catch(SSqlException &e) {
     throw PDNSException("Database error trying to insert new secondary domain '" + domain.toLogString() + "': " + e.txtReason());

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1069,7 +1069,7 @@ bool GSQLBackend::updateEmptyNonTerminals(domainid_t domain_id, set<DNSName>& in
 
 unsigned int GSQLBackend::getCapabilities()
 {
-  unsigned int caps = CAP_COMMENTS | CAP_DIRECT | CAP_LIST | CAP_CREATE | CAP_SEARCH;
+  unsigned int caps = CAP_COMMENTS | CAP_DIRECT | CAP_LIST | CAP_CREATE | CAP_SEARCH | CAP_DOMAIN_TRANSACTION;
   if (d_dnssecQueries) {
     caps |= CAP_DNSSEC;
   }
@@ -1924,7 +1924,7 @@ bool GSQLBackend::autoPrimaryBackend(const string& ipAddress, const ZoneName& do
   return false;
 }
 
-bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool /* startTransaction */)
+bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool startTransaction)
 {
   vector<string> primaries_s;
   primaries_s.reserve(primaries.size());
@@ -1932,6 +1932,10 @@ bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
     primaries_s.push_back(primary.toStringWithPortExcept(53));
   }
 
+  if (startTransaction) {
+    info.backend = this; // to be able to abortTransaction if the operation fails
+    startDomainModificationTransaction(domain);
+  }
   try {
     reconnectIfNeeded();
 
@@ -1951,10 +1955,15 @@ bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
   return getDomainInfo(domain, info, false);
 }
 
-bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool /* startTransaction */)
+bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool startTransaction)
 {
   string name;
   vector<ComboAddress> primaries({ComboAddress(ipAddress, 53)});
+
+  if (startTransaction) {
+    info.backend = this; // to be able to abortTransaction if the operation fails
+    startDomainModificationTransaction(domain);
+  }
   try {
     if (!nameserver.empty()) {
       // figure out all IP addresses for the primary

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -2319,7 +2319,7 @@ bool GSQLBackend::feedEnts3(domainid_t domain_id, const DNSName& /* domain */, m
   return true;
 }
 
-bool GSQLBackend::startDomainCreationTransaction(const ZoneName &domain, domainid_t domain_id)
+bool GSQLBackend::startDomainReplacementTransaction(const ZoneName &domain, domainid_t domain_id)
 {
   startDomainModificationTransaction(domain);
   try {

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1924,7 +1924,7 @@ bool GSQLBackend::autoPrimaryBackend(const string& ipAddress, const ZoneName& do
   return false;
 }
 
-bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info)
+bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool /* startTransaction */)
 {
   vector<string> primaries_s;
   primaries_s.reserve(primaries.size());
@@ -1951,7 +1951,7 @@ bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
   return getDomainInfo(domain, info, false);
 }
 
-bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info)
+bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool /* startTransaction */)
 {
   string name;
   vector<ComboAddress> primaries({ComboAddress(ipAddress, 53)});
@@ -1980,7 +1980,7 @@ bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName&
         primaries = std::move(tmp);
       }
     }
-    createDomain(domain, DomainInfo::Secondary, primaries, account, info);
+    createDomain(domain, DomainInfo::Secondary, primaries, account, info, false);
   }
   catch(SSqlException &e) {
     throw PDNSException("Database error trying to insert new secondary domain '" + domain.toLogString() + "': " + e.txtReason());

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1932,7 +1932,7 @@ bool GSQLBackend::autoPrimaryBackend(const string& ipAddress, const ZoneName& do
   return false;
 }
 
-bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account)
+bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info)
 {
   vector<string> primaries_s;
   primaries_s.reserve(primaries.size());
@@ -1956,10 +1956,10 @@ bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
   catch(SSqlException &e) {
     throw PDNSException("Database error trying to insert new domain '"+domain.toLogString()+"': "+ e.txtReason());
   }
-  return true;
+  return getDomainInfo(domain, info, false);
 }
 
-bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account)
+bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info)
 {
   string name;
   vector<ComboAddress> primaries({ComboAddress(ipAddress, 53)});
@@ -1988,12 +1988,12 @@ bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName&
         primaries = std::move(tmp);
       }
     }
-    createDomain(domain, DomainInfo::Secondary, primaries, account);
+    createDomain(domain, DomainInfo::Secondary, primaries, account, info);
   }
   catch(SSqlException &e) {
     throw PDNSException("Database error trying to insert new secondary domain '" + domain.toLogString() + "': " + e.txtReason());
   }
-  return true;
+  return getDomainInfo(domain, info, false);
 }
 
 bool GSQLBackend::deleteDomain(const ZoneName &domain)

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -1077,7 +1077,7 @@ bool GSQLBackend::updateEmptyNonTerminals(domainid_t domain_id, set<DNSName>& in
 
 unsigned int GSQLBackend::getCapabilities()
 {
-  unsigned int caps = CAP_COMMENTS | CAP_DIRECT | CAP_LIST | CAP_CREATE | CAP_SEARCH;
+  unsigned int caps = CAP_COMMENTS | CAP_DIRECT | CAP_LIST | CAP_CREATE | CAP_SEARCH | CAP_DOMAIN_TRANSACTION;
   if (d_dnssecQueries) {
     caps |= CAP_DNSSEC;
   }
@@ -1932,7 +1932,7 @@ bool GSQLBackend::autoPrimaryBackend(const string& ipAddress, const ZoneName& do
   return false;
 }
 
-bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool /* startTransaction */)
+bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool startTransaction)
 {
   vector<string> primaries_s;
   primaries_s.reserve(primaries.size());
@@ -1940,6 +1940,10 @@ bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
     primaries_s.push_back(primary.toStringWithPortExcept(53));
   }
 
+  if (startTransaction) {
+    info.backend = this; // to be able to abortTransaction if the operation fails
+    startDomainModificationTransaction(domain);
+  }
   try {
     reconnectIfNeeded();
 
@@ -1959,10 +1963,15 @@ bool GSQLBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainK
   return getDomainInfo(domain, info, false);
 }
 
-bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool /* startTransaction */)
+bool GSQLBackend::createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool startTransaction)
 {
   string name;
   vector<ComboAddress> primaries({ComboAddress(ipAddress, 53)});
+
+  if (startTransaction) {
+    info.backend = this; // to be able to abortTransaction if the operation fails
+    startDomainModificationTransaction(domain);
+  }
   try {
     if (!nameserver.empty()) {
       // figure out all IP addresses for the primary

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -2302,7 +2302,26 @@ bool GSQLBackend::feedEnts3(domainid_t domain_id, const DNSName& /* domain */, m
   return true;
 }
 
-bool GSQLBackend::startTransaction(const ZoneName &domain, domainid_t domain_id)
+bool GSQLBackend::startDomainCreationTransaction(const ZoneName &domain, domainid_t domain_id)
+{
+  startDomainModificationTransaction(domain);
+  try {
+    // clang-format off
+    d_DeleteZoneQuery_stmt->
+      bind("domain_id", domain_id)->
+      execute()->
+      reset();
+    // clang-format on
+  }
+  catch (SSqlException &e) {
+    d_inTransaction = false;
+    throw PDNSException("Database failed to delete contents of domain '" + domain.toLogString() + "': "+e.txtReason());
+  }
+
+  return true;
+}
+
+bool GSQLBackend::startDomainModificationTransaction(const ZoneName &domain)
 {
   try {
     reconnectIfNeeded();
@@ -2312,14 +2331,6 @@ bool GSQLBackend::startTransaction(const ZoneName &domain, domainid_t domain_id)
     }
     d_db->startTransaction();
     d_inTransaction = true;
-    if(domain_id != UnknownDomainID) {
-      // clang-format off
-      d_DeleteZoneQuery_stmt->
-        bind("domain_id", domain_id)->
-        execute()->
-        reset();
-      // clang-format on
-    }
   }
   catch (SSqlException &e) {
     d_inTransaction = false;

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -2310,7 +2310,26 @@ bool GSQLBackend::feedEnts3(domainid_t domain_id, const DNSName& /* domain */, m
   return true;
 }
 
-bool GSQLBackend::startTransaction(const ZoneName &domain, domainid_t domain_id)
+bool GSQLBackend::startDomainCreationTransaction(const ZoneName &domain, domainid_t domain_id)
+{
+  startDomainModificationTransaction(domain);
+  try {
+    // clang-format off
+    d_DeleteZoneQuery_stmt->
+      bind("domain_id", domain_id)->
+      execute()->
+      reset();
+    // clang-format on
+  }
+  catch (SSqlException &e) {
+    d_inTransaction = false;
+    throw PDNSException("Database failed to delete contents of domain '" + domain.toLogString() + "': "+e.txtReason());
+  }
+
+  return true;
+}
+
+bool GSQLBackend::startDomainModificationTransaction(const ZoneName &domain)
 {
   try {
     reconnectIfNeeded();
@@ -2320,14 +2339,6 @@ bool GSQLBackend::startTransaction(const ZoneName &domain, domainid_t domain_id)
     }
     d_db->startTransaction();
     d_inTransaction = true;
-    if(domain_id != UnknownDomainID) {
-      // clang-format off
-      d_DeleteZoneQuery_stmt->
-        bind("domain_id", domain_id)->
-        execute()->
-        reset();
-      // clang-format on
-    }
   }
   catch (SSqlException &e) {
     d_inTransaction = false;

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -68,8 +68,8 @@ public:
   bool feedRecord(const DNSResourceRecord &r, const DNSName &ordername, bool ordernameIsNSEC3=false) override;
   bool feedEnts(domainid_t domain_id, map<DNSName,bool>& nonterm) override;
   bool feedEnts3(domainid_t domain_id, const DNSName &domain, map<DNSName,bool> &nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
-  bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account) override;
-  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account) override;
+  bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info) override;
+  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info) override;
   bool deleteDomain(const ZoneName &domain) override;
   bool autoPrimaryAdd(const AutoPrimary& primary) override;
   bool autoPrimaryRemove(const AutoPrimary& primary) override;

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -69,8 +69,8 @@ public:
   bool feedRecord(const DNSResourceRecord &r, const DNSName &ordername, bool ordernameIsNSEC3=false) override;
   bool feedEnts(domainid_t domain_id, map<DNSName,bool>& nonterm) override;
   bool feedEnts3(domainid_t domain_id, const DNSName &domain, map<DNSName,bool> &nonterm, const NSEC3PARAMRecordContent& ns3prc, bool narrow) override;
-  bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info) override;
-  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info) override;
+  bool createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& info, bool startTransaction) override;
+  bool createSecondaryDomain(const string& ipAddress, const ZoneName& domain, const string& nameserver, const string& account, DomainInfo& info, bool startTransaction) override;
   bool deleteDomain(const ZoneName &domain) override;
   bool autoPrimaryAdd(const AutoPrimary& primary) override;
   bool autoPrimaryRemove(const AutoPrimary& primary) override;

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -62,7 +62,8 @@ public:
   bool list(const ZoneName &target, domainid_t domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
-  bool startTransaction(const ZoneName &domain, domainid_t domain_id=UnknownDomainID) override;
+  bool startDomainCreationTransaction(const ZoneName &domain, domainid_t domain_id) override;
+  bool startDomainModificationTransaction(const ZoneName &domain) override;
   bool commitTransaction() override;
   bool abortTransaction() override;
   bool feedRecord(const DNSResourceRecord &r, const DNSName &ordername, bool ordernameIsNSEC3=false) override;

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -62,7 +62,7 @@ public:
   bool list(const ZoneName &target, domainid_t domain_id, bool include_disabled=false) override;
   bool get(DNSResourceRecord &r) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
-  bool startDomainCreationTransaction(const ZoneName &domain, domainid_t domain_id) override;
+  bool startDomainReplacementTransaction(const ZoneName &domain, domainid_t domain_id) override;
   bool startDomainModificationTransaction(const ZoneName &domain) override;
   bool commitTransaction() override;
   bool abortTransaction() override;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -862,7 +862,7 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
   }
 
   if (doTransaction) {
-    sd.db->startTransaction(zone, UnknownDomainID);
+    sd.db->startDomainModificationTransaction(zone);
   }
 
   int updates{0};

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -145,6 +145,14 @@ bool DNSBackend::searchComments(const string& pattern, size_t maxResults, vector
   return true;
 }
 
+bool DNSBackend::startTransaction(const ZoneName& qname, domainid_t domainId)
+{
+  if (domainId == UnknownDomainID) {
+    return startDomainModificationTransaction(qname);
+  }
+  return startDomainCreationTransaction(qname, domainId);
+}
+
 void BackendFactory::declare(const string& suffix, const string& param, const string& explanation, const string& value)
 {
   string fullname = d_name + suffix + "-" + param;

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -145,14 +145,6 @@ bool DNSBackend::searchComments(const string& pattern, size_t maxResults, vector
   return true;
 }
 
-bool DNSBackend::startTransaction(const ZoneName& qname, domainid_t domainId)
-{
-  if (domainId == UnknownDomainID) {
-    return startDomainModificationTransaction(qname);
-  }
-  return startDomainCreationTransaction(qname, domainId);
-}
-
 void BackendFactory::declare(const string& suffix, const string& param, const string& explanation, const string& value)
 {
   string fullname = d_name + suffix + "-" + param;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -449,13 +449,13 @@ public:
   }
 
   //! called by PowerDNS to create a new domain
-  virtual bool createDomain(const ZoneName& /* domain */, const DomainInfo::DomainKind /* kind */, const vector<ComboAddress>& /* primaries */, const string& /* account */)
+  virtual bool createDomain(const ZoneName& /* domain */, const DomainInfo::DomainKind /* kind */, const vector<ComboAddress>& /* primaries */, const string& /* account */, DomainInfo& /* info */)
   {
     return false;
   }
 
   //! called by PowerDNS to create a secondary record for an autoprimary
-  virtual bool createSecondaryDomain(const string& /* ip */, const ZoneName& /* domain */, const string& /* nameserver */, const string& /* account */)
+  virtual bool createSecondaryDomain(const string& /* ip */, const ZoneName& /* domain */, const string& /* nameserver */, const string& /* account */, DomainInfo& /* info */)
   {
     return false;
   }

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -299,14 +299,6 @@ public:
     return false;
   }
 
-  //! starts the transaction for updating domain qname, destroying all
-  //! existing data for that domain if id is != UnknownDomainID. In this case,
-  //! the id MUST match the DomainInfo information for qname, or very bad things
-  //! will happen.
-  //! This is a legacy interface. Code should use one of the
-  //! startDomain*Transaction below.
-  bool startTransaction(const ZoneName& /* qname */, domainid_t /* id */ = UnknownDomainID);
-
   //! starts the transaction for replacing existing domain qname of id domainId.
   virtual bool startDomainCreationTransaction(const ZoneName& /* qname */, domainid_t /* domainId */)
   {

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -166,6 +166,7 @@ public:
     CAP_CREATE = 1 << 4, // Backend supports domain creation
     CAP_VIEWS = 1 << 5, // Backend supports views
     CAP_SEARCH = 1 << 6, // Backend supports record search
+    CAP_DOMAIN_TRANSACTION = 1 << 7, // Backend supports starting transactions in create*Domain()
   };
 
   virtual unsigned int getCapabilities() = 0;
@@ -459,13 +460,13 @@ public:
   }
 
   //! called by PowerDNS to create a new domain
-  virtual bool createDomain(const ZoneName& /* domain */, const DomainInfo::DomainKind /* kind */, const vector<ComboAddress>& /* primaries */, const string& /* account */, DomainInfo& /* info */)
+  virtual bool createDomain(const ZoneName& /* domain */, const DomainInfo::DomainKind /* kind */, const vector<ComboAddress>& /* primaries */, const string& /* account */, DomainInfo& /* info */, bool /* startTransaction */)
   {
     return false;
   }
 
   //! called by PowerDNS to create a secondary record for an autoprimary
-  virtual bool createSecondaryDomain(const string& /* ip */, const ZoneName& /* domain */, const string& /* nameserver */, const string& /* account */, DomainInfo& /* info */)
+  virtual bool createSecondaryDomain(const string& /* ip */, const ZoneName& /* domain */, const string& /* nameserver */, const string& /* account */, DomainInfo& /* info */, bool /* startTransaction */)
   {
     return false;
   }

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -299,13 +299,13 @@ public:
     return false;
   }
 
-  //! starts the transaction for replacing existing domain qname of id domainId.
+  //! starts the transaction for replacing existing zone qname of id domainId.
   virtual bool startDomainCreationTransaction(const ZoneName& /* qname */, domainid_t /* domainId */)
   {
     return false;
   }
 
-  //! starts the transaction for modifying existing domain qname.
+  //! starts the transaction for modifying existing zone qname.
   virtual bool startDomainModificationTransaction(const ZoneName& /* qname */)
   {
     return false;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -300,7 +300,7 @@ public:
   }
 
   //! starts the transaction for replacing existing zone qname of id domainId.
-  virtual bool startDomainCreationTransaction(const ZoneName& /* qname */, domainid_t /* domainId */)
+  virtual bool startDomainReplacementTransaction(const ZoneName& /* qname */, domainid_t /* domainId */)
   {
     return false;
   }

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -302,19 +302,29 @@ public:
   //! existing data for that domain if id is != UnknownDomainID. In this case,
   //! the id MUST match the DomainInfo information for qname, or very bad things
   //! will happen.
-  //! FIXME: replace this with a bool to make this a less error-prone interface.
-  virtual bool startTransaction(const ZoneName& /* qname */, domainid_t /* id */ = UnknownDomainID)
+  //! This is a legacy interface. Code should use one of the
+  //! startDomain*Transaction below.
+  bool startTransaction(const ZoneName& /* qname */, domainid_t /* id */ = UnknownDomainID);
+
+  //! starts the transaction for replacing existing domain qname of id domainId.
+  virtual bool startDomainCreationTransaction(const ZoneName& /* qname */, domainid_t /* domainId */)
   {
     return false;
   }
 
-  //! commits the transaction started by startTransaction
+  //! starts the transaction for modifying existing domain qname.
+  virtual bool startDomainModificationTransaction(const ZoneName& /* qname */)
+  {
+    return false;
+  }
+
+  //! commits the transaction started by start*Transaction
   virtual bool commitTransaction()
   {
     return false;
   }
 
-  //! aborts the transaction started by startTransaction, should leave state unaltered
+  //! aborts the transaction started by start*Transaction, should leave state unaltered
   virtual bool abortTransaction()
   {
     return false;
@@ -333,7 +343,7 @@ public:
   {
   }
 
-  //! feeds a record to a zone, needs a call to startTransaction first
+  //! feeds a record to a zone, needs a call to start*Transaction first
   virtual bool feedRecord(const DNSResourceRecord& /* rr */, const DNSName& /* ordername */, bool /* ordernameIsNSEC3 */ = false)
   {
     return false; // no problem!

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -118,7 +118,7 @@ public:
 
   void startTransaction(const ZoneName& zone)
   {
-    (*d_keymetadb->backends.begin())->startTransaction(zone);
+    (*d_keymetadb->backends.begin())->startDomainModificationTransaction(zone);
   }
 
   void commitTransaction()

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1134,9 +1134,8 @@ int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& 
     return RCode::Refused;
   }
   try {
-    db->createSecondaryDomain(remote.toString(), zonename, nameserver, account);
     DomainInfo di;
-    if (!db->getDomainInfo(zonename, di, false)) {
+    if (!db->createSecondaryDomain(remote.toString(), zonename, nameserver, account, di)) {
       SLOG(g_log << Logger::Error << "Failed to create " << zonename << " for potential autoprimary " << remote << endl,
            d_slog->info(Logr::Error, "Failed to create zone for potential autoprimary", "zone", Logging::Loggable(zonename), "potential autoprimary", Logging::Loggable(remote)));
       return RCode::ServFail;

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -1135,7 +1135,7 @@ int PacketHandler::tryAutoPrimarySynchronous(const DNSPacket& p, const DNSName& 
   }
   try {
     DomainInfo di;
-    if (!db->createSecondaryDomain(remote.toString(), zonename, nameserver, account, di)) {
+    if (!db->createSecondaryDomain(remote.toString(), zonename, nameserver, account, di, false)) {
       SLOG(g_log << Logger::Error << "Failed to create " << zonename << " for potential autoprimary " << remote << endl,
            d_slog->info(Logr::Error, "Failed to create zone for potential autoprimary", "zone", Logging::Loggable(zonename), "potential autoprimary", Logging::Loggable(remote)));
       return RCode::ServFail;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1995,7 +1995,7 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   DomainInfo dstinfo;
   DNSResourceRecord rr; // NOLINT(readability-identifier-length)
 
-  uint32_t tgt_caps = tgt->getCapabilities();
+  auto tgt_caps = tgt->getCapabilities();
   // Check target backend fits the requirements (only matters for b2b-migrate)
   // TODO: figure a way to quickly know if there are comments and reject a
   // target backend without comments support

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2001,7 +2001,7 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   }
 
   // Create zone
-  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo)) {
+  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo, false)) {
     throw PDNSException("Failed to create zone " + dstzone.toLogString());
   }
 
@@ -2659,7 +2659,7 @@ static int zonemdVerifyFile(const ZoneName& zone, const string& fname) {
 // default metadata, matching the behaviour of the REST API.
 static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const ZoneName& zone, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries)
 {
-  if (!backend.createDomain(zone, kind, primaries, "", info)) {
+  if (!backend.createDomain(zone, kind, primaries, "", info, false)) {
     cerr << "Zone '" << zone << "' was not created." << endl;
     return false;
   }
@@ -3701,7 +3701,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   DNSBackend *db = B.backends[0].get();
   cout << "Creating secondary zone " << zone << endl;
   DomainInfo di;
-  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di)) {
+  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di, false)) {
     cout << "Can't create secondary zone, aborting" << endl;
     return EXIT_FAILURE;
   }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1710,7 +1710,7 @@ static int increaseSerial(const ZoneName& zone, DNSSECKeeper &dsk)
   DNSResourceRecord rr;
   makeIncreasedSOARecord(sd, "SOA-EDIT-INCREASE", soaEditKind, rr, nullptr); // no structured logger in pdnsutil yet
 
-  sd.db->startTransaction(zone, UnknownDomainID);
+  sd.db->startDomainModificationTransaction(zone);
 
   auto rrs = vector<DNSResourceRecord>{rr};
   if (!sd.db->replaceRRSet(sd.domain_id, zone.operator const DNSName&(), rr.qtype, rrs)) {
@@ -1749,7 +1749,7 @@ static int deleteZone(const ZoneName &zone) {
     return EXIT_FAILURE;
   }
 
-  di.backend->startTransaction(zone, UnknownDomainID);
+  di.backend->startDomainModificationTransaction(zone);
   try {
     if(di.backend->deleteDomain(zone)) {
       di.backend->commitTransaction();
@@ -1973,7 +1973,7 @@ static int clearZone(const ZoneName &zone) {
     cerr << "Zone '" << zone << "' not found!" << endl;
     return EXIT_FAILURE;
   }
-  if(!di.backend->startTransaction(zone, di.id)) {
+  if(!di.backend->startDomainCreationTransaction(zone, di.id)) {
     cerr<<"Unable to start transaction for load of zone '"<<zone<<"'"<<endl;
     return EXIT_FAILURE;
   }
@@ -2019,7 +2019,7 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   rewriteNames = srcinfo.zone != dstzone;
 
   if (!makeDomainTransaction) {
-    tgt->startTransaction(dstzone, dstinfo.id);
+    tgt->startDomainCreationTransaction(dstzone, dstinfo.id);
   }
 
   while(src->get(rr)) {
@@ -2578,7 +2578,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
       // If there are invalid records, we'll recreate the complete zone, as
       // this is the only reliable way to make them disappear.
       if (invalid != 0) {
-        info.backend->startTransaction(zone, info.id);
+        info.backend->startDomainCreationTransaction(zone, info.id);
         for (const auto& record : post) {
           DNSResourceRecord resrec = DNSResourceRecord::fromWire(record);
           resrec.domain_id = info.id;
@@ -2586,7 +2586,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
         }
       }
       else {
-        info.backend->startTransaction(zone, UnknownDomainID);
+        info.backend->startDomainModificationTransaction(zone);
         {
           map<pair<DNSName,uint16_t>, vector<DNSRecord>> grouped;
           for (const auto& rec : post) {
@@ -2679,7 +2679,7 @@ static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const
     return false;
   }
   if (!makeDomainTransaction) {
-    info.backend->startTransaction(zone, info.id);
+    info.backend->startDomainCreationTransaction(zone, info.id);
   }
   info.backend->setDomainMetadataOne(zone, "SOA-EDIT-API", "DEFAULT");
   info.backend->commitTransaction();
@@ -2715,7 +2715,7 @@ static int loadZone(const ZoneName& zone, const string& fname) {
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
 
   DNSResourceRecord rr;
-  if(!db->startTransaction(zone, di.id)) {
+  if(!db->startDomainCreationTransaction(zone, di.id)) {
     cerr<<"Unable to start transaction for load of zone '"<<zone<<"'"<<endl;
     return EXIT_FAILURE;
   }
@@ -2797,7 +2797,7 @@ static int createZone(const ZoneName &zone, const DNSName& nsname) {
   }
 
   rr.domain_id = di.id;
-  di.backend->startTransaction(zone, di.id);
+  di.backend->startDomainCreationTransaction(zone, di.id);
   di.backend->feedRecord(rr, DNSName());
   if(!nsname.empty()) {
     cout<<"Also adding one NS record"<<endl;
@@ -2919,7 +2919,7 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds)
 
   bool allowUnderscores = areUnderscoresAllowed(zone, di);
 
-  di.backend->startTransaction(zone, UnknownDomainID);
+  di.backend->startDomainModificationTransaction(zone);
 
   DNSResourceRecord oldrr;
   vector<DNSResourceRecord> oldrrs;
@@ -3045,7 +3045,7 @@ static int deleteRRSet(const std::string& zone_, const std::string& name_, const
   }
 
   QType qt(QType::chartocode(type_.c_str()));
-  di.backend->startTransaction(zone, UnknownDomainID);
+  di.backend->startDomainModificationTransaction(zone);
   di.backend->replaceRRSet(di.id, name, qt, vector<DNSResourceRecord>());
   di.backend->commitTransaction();
   return EXIT_SUCCESS;
@@ -3735,7 +3735,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   }
   else {
     cout<<"Starting transaction to feed records"<<endl;
-    db->startTransaction(zone, di.id);
+    db->startDomainCreationTransaction(zone, di.id);
   }
 
   rr.qtype=QType::SOA;
@@ -3773,7 +3773,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   cout<<"[+] content field is over 255 bytes"<<endl;
 
   cout<<"Dropping all records, inserting SOA+2xA"<<endl;
-  db->startTransaction(zone, di.id);
+  db->startDomainCreationTransaction(zone, di.id);
 
   rr.qtype=QType::SOA;
   rr.qname=zone.operator const DNSName&();
@@ -4527,7 +4527,7 @@ static int addComment(vector<string>& cmds, const std::string_view synopsis)
     return EXIT_FAILURE;
   }
 
-  di.backend->startTransaction(zone, UnknownDomainID);
+  di.backend->startDomainModificationTransaction(zone);
   if (!di.backend->feedComment(comment)) {
     cerr << "Backend does not support comments" << endl;
     di.backend->abortTransaction();

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2004,10 +2004,7 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   }
 
   // Create zone
-  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account)) {
-    throw PDNSException("Failed to create zone " + dstzone.toLogString());
-  }
-  if (!tgt->getDomainInfo(dstzone, dstinfo)) {
+  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo)) {
     throw PDNSException("Failed to create zone " + dstzone.toLogString());
   }
 
@@ -2665,8 +2662,7 @@ static int zonemdVerifyFile(const ZoneName& zone, const string& fname) {
 // default metadata, matching the behaviour of the REST API.
 static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const ZoneName& zone, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries)
 {
-  backend.createDomain(zone, kind, primaries, "");
-  if (!backend.getDomainInfo(zone, info)) {
+  if (!backend.createDomain(zone, kind, primaries, "", info)) {
     cerr << "Zone '" << zone << "' was not created." << endl;
     return false;
   }
@@ -3707,15 +3703,13 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   cout<<"Picking first backend - if this is not what you want, edit launch line!"<<endl;
   DNSBackend *db = B.backends[0].get();
   cout << "Creating secondary zone " << zone << endl;
-  db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema");
-  cout << "Secondary zone created" << endl;
-
   DomainInfo di;
-  // di.backend and B are mostly identical
-  if(!B.getDomainInfo(zone, di) || di.backend == nullptr) {
-    cout << "Can't find zone we just created, aborting" << endl;
+  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di)) {
+    cout << "Can't create secondary zone, aborting" << endl;
     return EXIT_FAILURE;
   }
+  cout << "Secondary zone created" << endl;
+
   db=di.backend;
   DNSResourceRecord rr, rrget;
   cout<<"Starting transaction to feed records"<<endl;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2004,7 +2004,7 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   }
 
   // Create zone
-  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo)) {
+  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo, false)) {
     throw PDNSException("Failed to create zone " + dstzone.toLogString());
   }
 
@@ -2662,7 +2662,7 @@ static int zonemdVerifyFile(const ZoneName& zone, const string& fname) {
 // default metadata, matching the behaviour of the REST API.
 static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const ZoneName& zone, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries)
 {
-  if (!backend.createDomain(zone, kind, primaries, "", info)) {
+  if (!backend.createDomain(zone, kind, primaries, "", info, false)) {
     cerr << "Zone '" << zone << "' was not created." << endl;
     return false;
   }
@@ -3704,7 +3704,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   DNSBackend *db = B.backends[0].get();
   cout << "Creating secondary zone " << zone << endl;
   DomainInfo di;
-  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di)) {
+  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di, false)) {
     cout << "Can't create secondary zone, aborting" << endl;
     return EXIT_FAILURE;
   }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1973,7 +1973,7 @@ static int clearZone(const ZoneName &zone) {
     cerr << "Zone '" << zone << "' not found!" << endl;
     return EXIT_FAILURE;
   }
-  if(!di.backend->startDomainCreationTransaction(zone, di.id)) {
+  if(!di.backend->startDomainReplacementTransaction(zone, di.id)) {
     cerr<<"Unable to start transaction for load of zone '"<<zone<<"'"<<endl;
     return EXIT_FAILURE;
   }
@@ -2019,7 +2019,7 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   rewriteNames = srcinfo.zone != dstzone;
 
   if (!makeDomainTransaction) {
-    tgt->startDomainCreationTransaction(dstzone, dstinfo.id);
+    tgt->startDomainReplacementTransaction(dstzone, dstinfo.id);
   }
 
   while(src->get(rr)) {
@@ -2578,7 +2578,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
       // If there are invalid records, we'll recreate the complete zone, as
       // this is the only reliable way to make them disappear.
       if (invalid != 0) {
-        info.backend->startDomainCreationTransaction(zone, info.id);
+        info.backend->startDomainReplacementTransaction(zone, info.id);
         for (const auto& record : post) {
           DNSResourceRecord resrec = DNSResourceRecord::fromWire(record);
           resrec.domain_id = info.id;
@@ -2679,7 +2679,7 @@ static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const
     return false;
   }
   if (!makeDomainTransaction) {
-    info.backend->startDomainCreationTransaction(zone, info.id);
+    info.backend->startDomainReplacementTransaction(zone, info.id);
   }
   info.backend->setDomainMetadataOne(zone, "SOA-EDIT-API", "DEFAULT");
   info.backend->commitTransaction();
@@ -2715,7 +2715,7 @@ static int loadZone(const ZoneName& zone, const string& fname) {
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
 
   DNSResourceRecord rr;
-  if(!db->startDomainCreationTransaction(zone, di.id)) {
+  if(!db->startDomainReplacementTransaction(zone, di.id)) {
     cerr<<"Unable to start transaction for load of zone '"<<zone<<"'"<<endl;
     return EXIT_FAILURE;
   }
@@ -2797,7 +2797,7 @@ static int createZone(const ZoneName &zone, const DNSName& nsname) {
   }
 
   rr.domain_id = di.id;
-  di.backend->startDomainCreationTransaction(zone, di.id);
+  di.backend->startDomainReplacementTransaction(zone, di.id);
   di.backend->feedRecord(rr, DNSName());
   if(!nsname.empty()) {
     cout<<"Also adding one NS record"<<endl;
@@ -3735,7 +3735,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   }
   else {
     cout<<"Starting transaction to feed records"<<endl;
-    db->startDomainCreationTransaction(zone, di.id);
+    db->startDomainReplacementTransaction(zone, di.id);
   }
 
   rr.qtype=QType::SOA;
@@ -3773,7 +3773,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   cout<<"[+] content field is over 255 bytes"<<endl;
 
   cout<<"Dropping all records, inserting SOA+2xA"<<endl;
-  db->startDomainCreationTransaction(zone, di.id);
+  db->startDomainReplacementTransaction(zone, di.id);
 
   rr.qtype=QType::SOA;
   rr.qname=zone.operator const DNSName&();

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1992,16 +1992,19 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   DomainInfo dstinfo;
   DNSResourceRecord rr; // NOLINT(readability-identifier-length)
 
+  uint32_t tgt_caps = tgt->getCapabilities();
   // Check target backend fits the requirements (only matters for b2b-migrate)
   // TODO: figure a way to quickly know if there are comments and reject a
   // target backend without comments support
-  if (srcinfo.zone.hasVariant() && (tgt->getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
+  if (srcinfo.zone.hasVariant() && (tgt_caps & DNSBackend::CAP_VIEWS) == 0) {
     cerr << "Target backend does not support views." << endl;
     throw PDNSException("Failed to create zone");
   }
 
   // Create zone
-  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo, false)) {
+  bool makeDomainTransaction = (tgt_caps & DNSBackend::CAP_DOMAIN_TRANSACTION) != 0;
+  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo, makeDomainTransaction)) {
+    tgt->abortTransaction();
     throw PDNSException("Failed to create zone " + dstzone.toLogString());
   }
 
@@ -2012,7 +2015,9 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
 
   rewriteNames = srcinfo.zone != dstzone;
 
-  tgt->startTransaction(dstzone, dstinfo.id);
+  if (!makeDomainTransaction) {
+    tgt->startTransaction(dstzone, dstinfo.id);
+  }
 
   while(src->get(rr)) {
     rr.domain_id = dstinfo.id;
@@ -2659,11 +2664,20 @@ static int zonemdVerifyFile(const ZoneName& zone, const string& fname) {
 // default metadata, matching the behaviour of the REST API.
 static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const ZoneName& zone, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries)
 {
-  if (!backend.createDomain(zone, kind, primaries, "", info, false)) {
+  // As we don't know which backend will get to create the zone yet, ask for
+  // a domain transaction anyway, and we'll adjust our expectations after that.
+  bool success = backend.createDomain(zone, kind, primaries, "", info, true /* startTransaction */);
+  bool makeDomainTransaction = info.backend != nullptr && (info.backend->getCapabilities() & DNSBackend::CAP_DOMAIN_TRANSACTION) != 0;
+  if (!success) {
     cerr << "Zone '" << zone << "' was not created." << endl;
+    if (makeDomainTransaction) {
+      info.backend->abortTransaction();
+    }
     return false;
   }
-  info.backend->startTransaction(zone, static_cast<int>(info.id));
+  if (!makeDomainTransaction) {
+    info.backend->startTransaction(zone, info.id);
+  }
   info.backend->setDomainMetadataOne(zone, "SOA-EDIT-API", "DEFAULT");
   info.backend->commitTransaction();
   return true;
@@ -3701,7 +3715,11 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   DNSBackend *db = B.backends[0].get();
   cout << "Creating secondary zone " << zone << endl;
   DomainInfo di;
-  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di, false)) {
+  bool makeDomainTransaction = (db->getCapabilities() & DNSBackend::CAP_DOMAIN_TRANSACTION) != 0;
+  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di, makeDomainTransaction)) {
+    if (makeDomainTransaction) {
+      di.backend->abortTransaction();
+    }
     cout << "Can't create secondary zone, aborting" << endl;
     return EXIT_FAILURE;
   }
@@ -3709,8 +3727,13 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
 
   db=di.backend;
   DNSResourceRecord rr, rrget;
-  cout<<"Starting transaction to feed records"<<endl;
-  db->startTransaction(zone, di.id);
+  if (makeDomainTransaction) {
+    cout<<"Feeding records"<<endl;
+  }
+  else {
+    cout<<"Starting transaction to feed records"<<endl;
+    db->startTransaction(zone, di.id);
+  }
 
   rr.qtype=QType::SOA;
   rr.qname=zone.operator const DNSName&();

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1707,7 +1707,7 @@ static int increaseSerial(const ZoneName& zone, DNSSECKeeper &dsk)
   DNSResourceRecord rr;
   makeIncreasedSOARecord(sd, "SOA-EDIT-INCREASE", soaEditKind, rr, nullptr); // no structured logger in pdnsutil yet
 
-  sd.db->startTransaction(zone, UnknownDomainID);
+  sd.db->startDomainModificationTransaction(zone);
 
   auto rrs = vector<DNSResourceRecord>{rr};
   if (!sd.db->replaceRRSet(sd.domain_id, zone.operator const DNSName&(), rr.qtype, rrs)) {
@@ -1746,7 +1746,7 @@ static int deleteZone(const ZoneName &zone) {
     return EXIT_FAILURE;
   }
 
-  di.backend->startTransaction(zone, UnknownDomainID);
+  di.backend->startDomainModificationTransaction(zone);
   try {
     if(di.backend->deleteDomain(zone)) {
       di.backend->commitTransaction();
@@ -1970,7 +1970,7 @@ static int clearZone(const ZoneName &zone) {
     cerr << "Zone '" << zone << "' not found!" << endl;
     return EXIT_FAILURE;
   }
-  if(!di.backend->startTransaction(zone, di.id)) {
+  if(!di.backend->startDomainCreationTransaction(zone, di.id)) {
     cerr<<"Unable to start transaction for load of zone '"<<zone<<"'"<<endl;
     return EXIT_FAILURE;
   }
@@ -2016,7 +2016,7 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   rewriteNames = srcinfo.zone != dstzone;
 
   if (!makeDomainTransaction) {
-    tgt->startTransaction(dstzone, dstinfo.id);
+    tgt->startDomainCreationTransaction(dstzone, dstinfo.id);
   }
 
   while(src->get(rr)) {
@@ -2575,7 +2575,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
       // If there are invalid records, we'll recreate the complete zone, as
       // this is the only reliable way to make them disappear.
       if (invalid != 0) {
-        info.backend->startTransaction(zone, info.id);
+        info.backend->startDomainCreationTransaction(zone, info.id);
         for (const auto& record : post) {
           DNSResourceRecord resrec = DNSResourceRecord::fromWire(record);
           resrec.domain_id = info.id;
@@ -2583,7 +2583,7 @@ static int editZone(const ZoneName &zone, const PDNSColors& col)
         }
       }
       else {
-        info.backend->startTransaction(zone, UnknownDomainID);
+        info.backend->startDomainModificationTransaction(zone);
         {
           map<pair<DNSName,uint16_t>, vector<DNSRecord>> grouped;
           for (const auto& rec : post) {
@@ -2676,7 +2676,7 @@ static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const
     return false;
   }
   if (!makeDomainTransaction) {
-    info.backend->startTransaction(zone, info.id);
+    info.backend->startDomainCreationTransaction(zone, info.id);
   }
   info.backend->setDomainMetadataOne(zone, "SOA-EDIT-API", "DEFAULT");
   info.backend->commitTransaction();
@@ -2712,7 +2712,7 @@ static int loadZone(const ZoneName& zone, const string& fname) {
   zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
 
   DNSResourceRecord rr;
-  if(!db->startTransaction(zone, di.id)) {
+  if(!db->startDomainCreationTransaction(zone, di.id)) {
     cerr<<"Unable to start transaction for load of zone '"<<zone<<"'"<<endl;
     return EXIT_FAILURE;
   }
@@ -2794,7 +2794,7 @@ static int createZone(const ZoneName &zone, const DNSName& nsname) {
   }
 
   rr.domain_id = di.id;
-  di.backend->startTransaction(zone, di.id);
+  di.backend->startDomainCreationTransaction(zone, di.id);
   di.backend->feedRecord(rr, DNSName());
   if(!nsname.empty()) {
     cout<<"Also adding one NS record"<<endl;
@@ -2916,7 +2916,7 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds)
 
   bool allowUnderscores = areUnderscoresAllowed(zone, di);
 
-  di.backend->startTransaction(zone, UnknownDomainID);
+  di.backend->startDomainModificationTransaction(zone);
 
   DNSResourceRecord oldrr;
   vector<DNSResourceRecord> oldrrs;
@@ -3042,7 +3042,7 @@ static int deleteRRSet(const std::string& zone_, const std::string& name_, const
   }
 
   QType qt(QType::chartocode(type_.c_str()));
-  di.backend->startTransaction(zone, UnknownDomainID);
+  di.backend->startDomainModificationTransaction(zone);
   di.backend->replaceRRSet(di.id, name, qt, vector<DNSResourceRecord>());
   di.backend->commitTransaction();
   return EXIT_SUCCESS;
@@ -3732,7 +3732,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   }
   else {
     cout<<"Starting transaction to feed records"<<endl;
-    db->startTransaction(zone, di.id);
+    db->startDomainCreationTransaction(zone, di.id);
   }
 
   rr.qtype=QType::SOA;
@@ -3770,7 +3770,7 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   cout<<"[+] content field is over 255 bytes"<<endl;
 
   cout<<"Dropping all records, inserting SOA+2xA"<<endl;
-  db->startTransaction(zone, di.id);
+  db->startDomainCreationTransaction(zone, di.id);
 
   rr.qtype=QType::SOA;
   rr.qname=zone.operator const DNSName&();
@@ -4517,7 +4517,7 @@ static int addComment(vector<string>& cmds, const std::string_view synopsis)
     return EXIT_FAILURE;
   }
 
-  di.backend->startTransaction(zone, UnknownDomainID);
+  di.backend->startDomainModificationTransaction(zone);
   if (!di.backend->feedComment(comment)) {
     cerr << "Backend does not support comments" << endl;
     di.backend->abortTransaction();

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1995,16 +1995,19 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   DomainInfo dstinfo;
   DNSResourceRecord rr; // NOLINT(readability-identifier-length)
 
+  uint32_t tgt_caps = tgt->getCapabilities();
   // Check target backend fits the requirements (only matters for b2b-migrate)
   // TODO: figure a way to quickly know if there are comments and reject a
   // target backend without comments support
-  if (srcinfo.zone.hasVariant() && (tgt->getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
+  if (srcinfo.zone.hasVariant() && (tgt_caps & DNSBackend::CAP_VIEWS) == 0) {
     cerr << "Target backend does not support views." << endl;
     throw PDNSException("Failed to create zone");
   }
 
   // Create zone
-  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo, false)) {
+  bool makeDomainTransaction = (tgt_caps & DNSBackend::CAP_DOMAIN_TRANSACTION) != 0;
+  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo, makeDomainTransaction)) {
+    tgt->abortTransaction();
     throw PDNSException("Failed to create zone " + dstzone.toLogString());
   }
 
@@ -2015,7 +2018,9 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
 
   rewriteNames = srcinfo.zone != dstzone;
 
-  tgt->startTransaction(dstzone, dstinfo.id);
+  if (!makeDomainTransaction) {
+    tgt->startTransaction(dstzone, dstinfo.id);
+  }
 
   while(src->get(rr)) {
     rr.domain_id = dstinfo.id;
@@ -2662,11 +2667,20 @@ static int zonemdVerifyFile(const ZoneName& zone, const string& fname) {
 // default metadata, matching the behaviour of the REST API.
 static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const ZoneName& zone, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries)
 {
-  if (!backend.createDomain(zone, kind, primaries, "", info, false)) {
+  // As we don't know which backend will get to create the zone yet, ask for
+  // a domain transaction anyway, and we'll adjust our expectations after that.
+  bool success = backend.createDomain(zone, kind, primaries, "", info, true /* startTransaction */);
+  bool makeDomainTransaction = info.backend != nullptr && (info.backend->getCapabilities() & DNSBackend::CAP_DOMAIN_TRANSACTION) != 0;
+  if (!success) {
     cerr << "Zone '" << zone << "' was not created." << endl;
+    if (makeDomainTransaction) {
+      info.backend->abortTransaction();
+    }
     return false;
   }
-  info.backend->startTransaction(zone, static_cast<int>(info.id));
+  if (!makeDomainTransaction) {
+    info.backend->startTransaction(zone, info.id);
+  }
   info.backend->setDomainMetadataOne(zone, "SOA-EDIT-API", "DEFAULT");
   info.backend->commitTransaction();
   return true;
@@ -3704,7 +3718,11 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   DNSBackend *db = B.backends[0].get();
   cout << "Creating secondary zone " << zone << endl;
   DomainInfo di;
-  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di, false)) {
+  bool makeDomainTransaction = (db->getCapabilities() & DNSBackend::CAP_DOMAIN_TRANSACTION) != 0;
+  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di, makeDomainTransaction)) {
+    if (makeDomainTransaction) {
+      di.backend->abortTransaction();
+    }
     cout << "Can't create secondary zone, aborting" << endl;
     return EXIT_FAILURE;
   }
@@ -3712,8 +3730,13 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
 
   db=di.backend;
   DNSResourceRecord rr, rrget;
-  cout<<"Starting transaction to feed records"<<endl;
-  db->startTransaction(zone, di.id);
+  if (makeDomainTransaction) {
+    cout<<"Feeding records"<<endl;
+  }
+  else {
+    cout<<"Starting transaction to feed records"<<endl;
+    db->startTransaction(zone, di.id);
+  }
 
   rr.qtype=QType::SOA;
   rr.qname=zone.operator const DNSName&();

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2001,10 +2001,7 @@ static void copyZoneContents(const DomainInfo& srcinfo, const ZoneName& dstzone,
   }
 
   // Create zone
-  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account)) {
-    throw PDNSException("Failed to create zone " + dstzone.toLogString());
-  }
-  if (!tgt->getDomainInfo(dstzone, dstinfo)) {
+  if (!tgt->createDomain(dstzone, srcinfo.kind, srcinfo.primaries, srcinfo.account, dstinfo)) {
     throw PDNSException("Failed to create zone " + dstzone.toLogString());
   }
 
@@ -2662,8 +2659,7 @@ static int zonemdVerifyFile(const ZoneName& zone, const string& fname) {
 // default metadata, matching the behaviour of the REST API.
 static bool createZoneWithDefaults(UtilBackend &backend, DomainInfo &info, const ZoneName& zone, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries)
 {
-  backend.createDomain(zone, kind, primaries, "");
-  if (!backend.getDomainInfo(zone, info)) {
+  if (!backend.createDomain(zone, kind, primaries, "", info)) {
     cerr << "Zone '" << zone << "' was not created." << endl;
     return false;
   }
@@ -3704,15 +3700,13 @@ static int testSchema(DNSSECKeeper& dsk, const ZoneName& zone)
   cout<<"Picking first backend - if this is not what you want, edit launch line!"<<endl;
   DNSBackend *db = B.backends[0].get();
   cout << "Creating secondary zone " << zone << endl;
-  db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema");
-  cout << "Secondary zone created" << endl;
-
   DomainInfo di;
-  // di.backend and B are mostly identical
-  if(!B.getDomainInfo(zone, di) || di.backend == nullptr) {
-    cout << "Can't find zone we just created, aborting" << endl;
+  if (!db->createSecondaryDomain("127.0.0.1", zone, "", "_testschema", di)) {
+    cout << "Can't create secondary zone, aborting" << endl;
     return EXIT_FAILURE;
   }
+  cout << "Secondary zone created" << endl;
+
   db=di.backend;
   DNSResourceRecord rr, rrget;
   cout<<"Starting transaction to feed records"<<endl;

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -1107,7 +1107,7 @@ int PacketHandler::processUpdate(DNSPacket& packet)
   auto lock = std::scoped_lock(s_rfc2136lock); //TODO: i think this lock can be per zone, not for everything
   SLOG(g_log << Logger::Info << ctx.msgPrefix << "starting transaction." << endl,
        ctx.slog->info(Logr::Info, "Update: starting transaction"));
-  if (!ctx.di.backend->startTransaction(packet.qdomainzone, UnknownDomainID)) { // Not giving the domain_id means that we do not delete the existing records.
+  if (!ctx.di.backend->startDomainModificationTransaction(packet.qdomainzone)) { // Not giving the domain_id means that we do not delete the existing records.
     SLOG(g_log << Logger::Error << ctx.msgPrefix << "Backend does not support transaction. Can't do Update packet." << endl,
          ctx.slog->info(Logr::Error, "Update: backend does not support transaction. Can't process Update packet."));
     return RCode::NotImp;

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -144,14 +144,14 @@ bool UeberBackend::getDomainInfo(const ZoneName& domain, DomainInfo& domainInfo,
   return false;
 }
 
-bool UeberBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account)
+bool UeberBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& domainInfo)
 {
   for (auto& backend : backends) {
     // Do not risk passing variant zones to variant-unaware backends.
     if (domain.hasVariant() && (backend->getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
       continue;
     }
-    if (backend->createDomain(domain, kind, primaries, account)) {
+    if (backend->createDomain(domain, kind, primaries, account, domainInfo)) {
       return true;
     }
   }

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -144,14 +144,14 @@ bool UeberBackend::getDomainInfo(const ZoneName& domain, DomainInfo& domainInfo,
   return false;
 }
 
-bool UeberBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& domainInfo)
+bool UeberBackend::createDomain(const ZoneName& domain, const DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& domainInfo, bool startTransaction)
 {
   for (auto& backend : backends) {
     // Do not risk passing variant zones to variant-unaware backends.
     if (domain.hasVariant() && (backend->getCapabilities() & DNSBackend::CAP_VIEWS) == 0) {
       continue;
     }
-    if (backend->createDomain(domain, kind, primaries, account, domainInfo)) {
+    if (backend->createDomain(domain, kind, primaries, account, domainInfo, startTransaction)) {
       return true;
     }
   }

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -77,7 +77,7 @@ public:
   void getUnfreshSecondaryInfos(vector<DomainInfo>* domains);
   void getUpdatedPrimaries(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes);
   bool getDomainInfo(const ZoneName& domain, DomainInfo& domainInfo, bool getSerial = true);
-  bool createDomain(const ZoneName& domain, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account);
+  bool createDomain(const ZoneName& domain, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& domainInfo);
 
   bool doesDNSSEC();
   bool addDomainKey(const ZoneName& name, const DNSBackend::KeyData& key, int64_t& keyID);

--- a/pdns/ueberbackend.hh
+++ b/pdns/ueberbackend.hh
@@ -77,7 +77,7 @@ public:
   void getUnfreshSecondaryInfos(vector<DomainInfo>* domains);
   void getUpdatedPrimaries(vector<DomainInfo>& domains, std::unordered_set<DNSName>& catalogs, CatalogHashMap& catalogHashes);
   bool getDomainInfo(const ZoneName& domain, DomainInfo& domainInfo, bool getSerial = true);
-  bool createDomain(const ZoneName& domain, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& domainInfo);
+  bool createDomain(const ZoneName& domain, DomainInfo::DomainKind kind, const vector<ComboAddress>& primaries, const string& account, DomainInfo& domainInfo, bool startTransaction);
 
   bool doesDNSSEC();
   bool addDomainKey(const ZoneName& name, const DNSBackend::KeyData& key, int64_t& keyID);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2248,12 +2248,8 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   }
 
   // no going back after this
-  if (!backend.createDomain(zonename, kind.value_or(DomainInfo::Native), primaries.value_or(vector<ComboAddress>()), account.value_or(""))) {
+  if (!backend.createDomain(zonename, kind.value_or(DomainInfo::Native), primaries.value_or(vector<ComboAddress>()), account.value_or(""), domainInfo)) {
     throw ApiException("Creating domain '" + zonename.toString() + "' failed: backend refused");
-  }
-
-  if (!backend.getDomainInfo(zonename, domainInfo)) {
-    throw ApiException("Creating domain '" + zonename.toString() + "' failed: lookup of domain ID failed");
   }
 
   domainInfo.backend->startTransaction(zonename, domainInfo.id);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2248,11 +2248,20 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   }
 
   // no going back after this
-  if (!backend.createDomain(zonename, kind.value_or(DomainInfo::Native), primaries.value_or(vector<ComboAddress>()), account.value_or(""), domainInfo, false)) {
+  // As we don't know which backend will get to create the zone yet, ask for
+  // a domain transaction anyway, and we'll adjust our expectations after that.
+  bool success = backend.createDomain(zonename, kind.value_or(DomainInfo::Native), primaries.value_or(vector<ComboAddress>()), account.value_or(""), domainInfo, true /* startTransaction */);
+  bool makeDomainTransaction = domainInfo.backend != nullptr && (domainInfo.backend->getCapabilities() & DNSBackend::CAP_DOMAIN_TRANSACTION) != 0;
+  if (!success) {
+    if (makeDomainTransaction) {
+      domainInfo.backend->abortTransaction();
+    }
     throw ApiException("Creating domain '" + zonename.toString() + "' failed: backend refused");
   }
 
-  domainInfo.backend->startTransaction(zonename, domainInfo.id);
+  if (!makeDomainTransaction) {
+    domainInfo.backend->startTransaction(zonename, domainInfo.id);
+  }
 
   try {
     // will be overridden by updateDomainSettingsFromDocument, if given in document.

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2863,7 +2863,7 @@ static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInf
     // RRset, and will need to fetch it from the backend. But we may have
     // processed a DELETE or REPLACE operation for the same RRset first, in
     // which case we can't assume querying the backend will be consistent with
-    // the results of that last operation, since we are within a not commited
+    // the results of that last operation, since we are within a not committed
     // yet transaction.
     // To be sure to work on consistent contents, without having to rely upon
     // specific backend behaviour, we will need to cache the RRset values

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2248,7 +2248,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   }
 
   // no going back after this
-  if (!backend.createDomain(zonename, kind.value_or(DomainInfo::Native), primaries.value_or(vector<ComboAddress>()), account.value_or(""), domainInfo)) {
+  if (!backend.createDomain(zonename, kind.value_or(DomainInfo::Native), primaries.value_or(vector<ComboAddress>()), account.value_or(""), domainInfo, false)) {
     throw ApiException("Creating domain '" + zonename.toString() + "' failed: backend refused");
   }
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1567,7 +1567,7 @@ static void apiZoneCryptokeysPostProcessing(ZoneData& zoneData, Logr::log_t slog
 
       zoneData.domainInfo.backend->getDomainMetadataOne(zoneData.zoneName, "SOA-EDIT-API", soa_edit_api_kind);
       zoneData.domainInfo.backend->getDomainMetadataOne(zoneData.zoneName, "SOA-EDIT", soa_edit_kind);
-      zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, UnknownDomainID);
+      zoneData.domainInfo.backend->startDomainModificationTransaction(zoneData.zoneName);
       updateZoneSerial(zoneData.domainInfo, soaData, soa_edit_api_kind, soa_edit_kind, slog);
       zoneData.domainInfo.backend->commitTransaction();
     }
@@ -2260,7 +2260,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   }
 
   if (!makeDomainTransaction) {
-    domainInfo.backend->startTransaction(zonename, domainInfo.id);
+    domainInfo.backend->startDomainCreationTransaction(zonename, domainInfo.id);
   }
 
   try {
@@ -2420,7 +2420,7 @@ static void apiServerZoneDetailPUT(HttpRequest* req, HttpResponse* resp)
       return;
     }
 
-    zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, zoneData.domainInfo.id);
+    zoneData.domainInfo.backend->startDomainCreationTransaction(zoneData.zoneName, zoneData.domainInfo.id);
     for (auto& resourceRecord : new_records) {
       resourceRecord.domain_id = static_cast<int>(zoneData.domainInfo.id);
       zoneData.domainInfo.backend->feedRecord(resourceRecord, DNSName());
@@ -2436,7 +2436,7 @@ static void apiServerZoneDetailPUT(HttpRequest* req, HttpResponse* resp)
   }
   else {
     // avoid deleting current zone contents
-    zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, UnknownDomainID);
+    zoneData.domainInfo.backend->startDomainModificationTransaction(zoneData.zoneName);
   }
 
   // updateDomainSettingsFromDocument will rectify the zone and update SOA serial.
@@ -2455,7 +2455,7 @@ static void apiServerZoneDetailDELETE(HttpRequest* req, HttpResponse* resp)
 
   // delete domain
 
-  zoneData.domainInfo.backend->startTransaction(zoneData.zoneName, UnknownDomainID);
+  zoneData.domainInfo.backend->startDomainModificationTransaction(zoneData.zoneName);
   try {
     if (!zoneData.domainInfo.backend->deleteDomain(zoneData.zoneName)) {
       throw ApiException("Deleting domain '" + zoneData.zoneName.toString() + "' failed: backend delete failed/unsupported");
@@ -2852,7 +2852,7 @@ static applyResult applyPruneOrExtend(const DomainInfo& domainInfo, const ZoneNa
 static void patchZone(UeberBackend& backend, const ZoneName& zonename, DomainInfo& domainInfo, const vector<Json>& rrsets, HttpResponse* resp)
 {
   bool madeAnyChanges{false};
-  domainInfo.backend->startTransaction(zonename);
+  domainInfo.backend->startDomainModificationTransaction(zonename);
   try {
     soaEditSettings soa;
     domainInfo.backend->getDomainMetadataOne(zonename, "SOA-EDIT-API", soa.edit_api_kind);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2260,7 +2260,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   }
 
   if (!makeDomainTransaction) {
-    domainInfo.backend->startDomainCreationTransaction(zonename, domainInfo.id);
+    domainInfo.backend->startDomainReplacementTransaction(zonename, domainInfo.id);
   }
 
   try {
@@ -2420,7 +2420,7 @@ static void apiServerZoneDetailPUT(HttpRequest* req, HttpResponse* resp)
       return;
     }
 
-    zoneData.domainInfo.backend->startDomainCreationTransaction(zoneData.zoneName, zoneData.domainInfo.id);
+    zoneData.domainInfo.backend->startDomainReplacementTransaction(zoneData.zoneName, zoneData.domainInfo.id);
     for (auto& resourceRecord : new_records) {
       resourceRecord.domain_id = static_cast<int>(zoneData.domainInfo.id);
       zoneData.domainInfo.backend->feedRecord(resourceRecord, DNSName());

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2256,7 +2256,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
     if (makeDomainTransaction) {
       domainInfo.backend->abortTransaction();
     }
-    throw ApiException("Creating domain '" + zonename.toString() + "' failed: backend refused");
+    throw ApiException("Creating domain '" + zonename.toString() + "' failed: backend refused or failed");
   }
 
   if (!makeDomainTransaction) {


### PR DESCRIPTION
### Short description
It has been noticed for a while, that the current transaction model used in the authoritative server only covers records (and comments). Which means that attempts to create and populate a domain from invalid data would first, create an empty domain, then start a transaction to fill it, then abort it due to the data being invalid, leaving an empty domain.

This PR tries to make the domain creation part of the transaction, so that aborting it will correctly leave no trace of the new domain.

It is better reviewed on a per-commit basis.

The reason why domains are not part of transactions, is that transactions are tied to a backend domain id, which can't be known unless the domain exist. The first commits perform plumbing, first to make domain creation calls return a filled `DomainInfo` struct (i.e. perform an immediate `getDomainInfo` call which would have been issued by the caller soon anyway).

Then we can add the ability to these create domain routines to start a transaction at domain creation time as well. This depends upon backend support, which is why a new capability, `CAP_DOMAIN_TRANSACTION`, is added to report that ability.

At the moment only the SQL backends and the Bind backend (in secondary mode) support this. I am still wrestling with the LMDB backend, with no success yet.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
