### PR TITLE
auth 4.9: partially backport "more lmdb stability"

### DIFF
--- a/ext/lmdb-safe/lmdb-safe.cc
+++ b/ext/lmdb-safe/lmdb-safe.cc
@@ -263,28 +263,28 @@ MDBRWTransactionImpl::~MDBRWTransactionImpl()
 void MDBRWTransactionImpl::commit()
 {
   closeRORWCursors();
-  if (!d_txn) {
-    return;
+  if (d_txn != nullptr) {
+    int retCode = mdb_txn_commit(d_txn);
+    // Upon failure, mdb_txn_commit() performs an mdb_txn_abort() call,
+    // so we need to consider the transaction aborted and correctly
+    // deallocated.
+    d_txn = nullptr;
+    environment().decRWTX();
+    if (retCode != 0) {
+      throw std::runtime_error("committing: " + std::string(mdb_strerror(retCode)));
+    }
   }
-
-  if(int rc = mdb_txn_commit(d_txn)) {
-    throw std::runtime_error("committing: " + std::string(mdb_strerror(rc)));
-  }
-  environment().decRWTX();
-  d_txn = nullptr;
 }
 
 void MDBRWTransactionImpl::abort()
 {
   closeRORWCursors();
-  if (!d_txn) {
-    return;
+  if (d_txn != nullptr) {
+    mdb_txn_abort(d_txn);
+    d_txn = nullptr;
+    // prevent the RO destructor from cleaning up the transaction itself
+    environment().decRWTX();
   }
-
-  mdb_txn_abort(d_txn);
-  // prevent the RO destructor from cleaning up the transaction itself
-  environment().decRWTX();
-  d_txn = nullptr;
 }
 
 MDBROTransactionImpl::MDBROTransactionImpl(MDBEnv *parent, MDB_txn *txn):
@@ -338,7 +338,7 @@ void MDBROTransactionImpl::abort()
 {
   closeROCursors();
   // if d_txn is non-nullptr here, either the transaction object was invalidated earlier (e.g. by moving from it), or it is an RW transaction which has already cleaned up the d_txn pointer (with an abort).
-  if (d_txn) {
+  if (d_txn != nullptr) {
     d_parent->decROTX();
     mdb_txn_abort(d_txn); // this appears to work better than abort for r/o database opening
     d_txn = nullptr;
@@ -349,7 +349,7 @@ void MDBROTransactionImpl::commit()
 {
   closeROCursors();
   // if d_txn is non-nullptr here, either the transaction object was invalidated earlier (e.g. by moving from it), or it is an RW transaction which has already cleaned up the d_txn pointer (with an abort).
-  if (d_txn) {
+  if (d_txn != nullptr) {
     d_parent->decROTX();
     mdb_txn_commit(d_txn); // this appears to work better than abort for r/o database opening
     d_txn = nullptr;


### PR DESCRIPTION
### Short description
Partial backport of #17774 (only commit 2a09f8ca8af636be22d2cb9cc2edbbb5d3ad5e87)

<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
