### PR TITLE
auth 5.0: backport "Properly reject 256-bytes wire-encoded DNS names"

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -128,6 +128,7 @@ static void checkLabelLength(uint8_t length)
 size_t DNSName::parsePacketUncompressed(const pdns::views::UnsignedCharView& view, size_t pos, bool uncompress)
 {
   const size_t initialPos = pos;
+  const size_t neededSizeForFinalLabel = /* final empty label length */ (d_storage.empty() ? 1U : 0U);
   size_t totalLength = 0;
   unsigned char labellen = 0;
 
@@ -152,8 +153,8 @@ size_t DNSName::parsePacketUncompressed(const pdns::views::UnsignedCharView& vie
       throw std::range_error("Found an invalid label length in qname (only one of the first two bits is set)");
     }
     checkLabelLength(labellen);
-    // reserve one byte for the label length
-    if (totalLength + labellen > s_maxDNSNameLength - 1) {
+    // reserve one byte for the label length, plus one byte for the final empty label if we were empty before
+    if (totalLength + labellen > s_maxDNSNameLength - (neededSizeForFinalLabel + 1)) {
       throw std::range_error("name too long to append");
     }
     if (pos + labellen >= view.size()) {

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -845,7 +845,7 @@ BOOST_AUTO_TEST_CASE(test_invalid_label_length) { // Invalid label length in qna
 BOOST_AUTO_TEST_CASE(test_name_length_too_long_from_wire) {
 
   string name("\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x05""stats""\x05""stats""\x02""fr""\x00", 256);
-  BOOST_CHECK_THROW(DNSName dn(name.c_str(), name.size(), 0, true), std::range_error);
+  BOOST_CHECK_THROW(DNSName(name.c_str(), name.size(), 0, true), std::range_error);
 }
 
 BOOST_AUTO_TEST_CASE(test_compression) { // Compression test

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -842,6 +842,12 @@ BOOST_AUTO_TEST_CASE(test_invalid_label_length) { // Invalid label length in qna
   BOOST_CHECK_THROW(DNSName dn(name.c_str(), name.size(), 0, true), std::range_error);
 }
 
+BOOST_AUTO_TEST_CASE(test_name_length_too_long_from_wire) {
+
+  string name("\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x05""stats""\x05""stats""\x02""fr""\x00", 256);
+  BOOST_CHECK_THROW(DNSName dn(name.c_str(), name.size(), 0, true), std::range_error);
+}
+
 BOOST_AUTO_TEST_CASE(test_compression) { // Compression test
 
   string name("\x03""com\x00""\x07""example\xc0""\x00""\x03""www\xc0""\x05", 21);


### PR DESCRIPTION
### Short description
Backport of #17790.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
