### PR TITLE
auth 5.1: backport "Account for the existing content when parsing labels"

### DIFF
--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -143,6 +143,8 @@ static void checkLabelLength(uint8_t length)
 size_t DNSName::parsePacketUncompressed(const pdns::views::UnsignedCharView& view, size_t pos, bool uncompress)
 {
   const size_t initialPos = pos;
+  auto existingSize = d_storage.size();
+  const size_t neededSizeForFinalLabel = /* final empty label length */ (existingSize == 0 ? 1U : 0U);
   size_t totalLength = 0;
   unsigned char labellen = 0;
 
@@ -167,8 +169,9 @@ size_t DNSName::parsePacketUncompressed(const pdns::views::UnsignedCharView& vie
       throw std::range_error("Found an invalid label length in qname (only one of the first two bits is set)");
     }
     checkLabelLength(labellen);
-    // reserve one byte for the label length
-    if (totalLength + labellen > s_maxDNSNameLength - 1) {
+
+    // reserve one byte for the label length, plus one byte for the final empty label if we were empty before
+    if ((existingSize + totalLength + labellen) > (s_maxDNSNameLength - (neededSizeForFinalLabel + 1))) {
       throw std::range_error("name too long to append");
     }
     if (pos + labellen >= view.size()) {
@@ -180,10 +183,12 @@ size_t DNSName::parsePacketUncompressed(const pdns::views::UnsignedCharView& vie
   while (pos < view.size());
 
   if (totalLength != 0) {
-    auto existingSize = d_storage.size();
     if (existingSize > 0) {
       // remove the last label count, we are about to override it */
       --existingSize;
+    }
+    if ((existingSize + totalLength + 1) > s_maxDNSNameLength) {
+      throw std::range_error("name too long to append");
     }
     d_storage.reserve(existingSize + totalLength + 1);
     d_storage.resize(existingSize + totalLength);

--- a/pdns/dnsname.cc
+++ b/pdns/dnsname.cc
@@ -171,14 +171,14 @@ size_t DNSName::parsePacketUncompressed(const pdns::views::UnsignedCharView& vie
     checkLabelLength(labellen);
 
     // reserve one byte for the label length, plus one byte for the final empty label if we were empty before
-    if ((existingSize + totalLength + labellen) > (s_maxDNSNameLength - (neededSizeForFinalLabel + 1))) {
+    if ((existingSize + totalLength + labellen + 1U + neededSizeForFinalLabel) > s_maxDNSNameLength) {
       throw std::range_error("name too long to append");
     }
     if (pos + labellen >= view.size()) {
       throw std::range_error("Found an invalid label length in qname");
     }
     pos += labellen;
-    totalLength += 1 + labellen;
+    totalLength += 1U + labellen;
   }
   while (pos < view.size());
 
@@ -187,7 +187,7 @@ size_t DNSName::parsePacketUncompressed(const pdns::views::UnsignedCharView& vie
       // remove the last label count, we are about to override it */
       --existingSize;
     }
-    if ((existingSize + totalLength + 1) > s_maxDNSNameLength) {
+    if ((existingSize + totalLength + 1U) > s_maxDNSNameLength) {
       throw std::range_error("name too long to append");
     }
     d_storage.reserve(existingSize + totalLength + 1);

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -865,8 +865,8 @@ BOOST_AUTO_TEST_CASE(test_name_length_too_long_from_wire) {
 }
 
 BOOST_AUTO_TEST_CASE(test_name_length_too_long_from_wire_compressed) {
-  string name("\x0a""wwwwwwwwww""\x00""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x05""stats""\x05""stats""\x02""fr""\xc0""\x00", 266);
-  BOOST_CHECK_THROW(DNSName dn(name.c_str(), name.size(), 12, true), std::range_error);
+  string name("\x0a""wwwwwwwwww""\x00""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x05""stats""\x05""stats""\x02""fr""\xc0""\x00", 265);
+  BOOST_CHECK_THROW(DNSName(name.c_str(), name.size(), 12, true), std::range_error);
 }
 
 BOOST_AUTO_TEST_CASE(test_compression) { // Compression test

--- a/pdns/test-dnsname_cc.cc
+++ b/pdns/test-dnsname_cc.cc
@@ -858,6 +858,17 @@ BOOST_AUTO_TEST_CASE(test_invalid_label_length) { // Invalid label length in qna
   BOOST_CHECK_THROW(DNSName dn(name.c_str(), name.size(), 0, true), std::range_error);
 }
 
+BOOST_AUTO_TEST_CASE(test_name_length_too_long_from_wire) {
+
+  string name("\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x05""stats""\x05""stats""\x02""fr""\x00", 256);
+  BOOST_CHECK_THROW(DNSName(name.c_str(), name.size(), 0, true), std::range_error);
+}
+
+BOOST_AUTO_TEST_CASE(test_name_length_too_long_from_wire_compressed) {
+  string name("\x0a""wwwwwwwwww""\x00""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x03""www""\x05""stats""\x05""stats""\x02""fr""\xc0""\x00", 266);
+  BOOST_CHECK_THROW(DNSName dn(name.c_str(), name.size(), 12, true), std::range_error);
+}
+
 BOOST_AUTO_TEST_CASE(test_compression) { // Compression test
 
   string name("\x03""com\x00""\x07""example\xc0""\x00""\x03""www\xc0""\x05", 21);


### PR DESCRIPTION
### Short description
Backport of #17797
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
