### PR TITLE
auth: better handling of sqlite read-only databases

### DIFF
--- a/pdns/ssqlite3.cc
+++ b/pdns/ssqlite3.cc
@@ -297,19 +297,25 @@ SSQLite3::SSQLite3(Logr::log_t log, const std::string& database, const std::stri
   d_slog = log;
   m_dolog = false;
 
+  int flags{SQLITE_OPEN_READWRITE};
+  if (creat) {
+    flags |= SQLITE_OPEN_CREATE;
+  }
   if (access(database.c_str(), W_OK) == -1) {
     if (!creat && errno == ENOENT) {
       throw SSqlException("SQLite database '" + database + "' does not exist yet");
     }
-    if (errno == EACCES) {
-      throw SSqlException("SQLite database '" + database + "' is not writable");
-    }
-    // Other errors will cause sqlite3_open() to fail anyway. We needed to
-    // explicitly check for write access here, for SQLite < 3.46 in some
-    // configuration will leak file descriptors if the database can not be
-    // open read-write; refer to
+    // We needed to explicitly check for write access here, for SQLite < 3.46
+    // in some configuration will leak file descriptors if the database can not
+    // be open read-write; refer to
     // https://github.com/PowerDNS/pdns/issues/13952#issuecomment-2008254248
     // for details.
+    if (errno == EACCES) {
+      flags &= ~SQLITE_OPEN_READWRITE;
+      flags |= SQLITE_OPEN_READONLY;
+      SLOG(g_log << Logger::Warning << "SQLite database '" << database << "' will be open in read-only mode due to filesystem permissions" << endl,
+           d_slog->info(Logr::Warning, "SQLite database will be open in read-only mode due to filesystem permissions", "database", Logging::Loggable(database)));
+    }
   }
   else {
     if (creat) {
@@ -317,7 +323,7 @@ SSQLite3::SSQLite3(Logr::log_t log, const std::string& database, const std::stri
     }
   }
 
-  if (sqlite3_open(database.c_str(), &m_pDB) != SQLITE_OK) {
+  if (sqlite3_open_v2(database.c_str(), &m_pDB, flags, nullptr) != SQLITE_OK) {
     throw SSqlException("Could not connect to the SQLite database '" + database + "'");
   }
   m_in_transaction = false;

--- a/regression-tests.nobackend/gsqlite3-corrupted-record/command
+++ b/regression-tests.nobackend/gsqlite3-corrupted-record/command
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-rm -f pdns-gsqlite3.conf pdns.sqlite3
+rm -f pdns-gsqlite3.conf pdns.sqlite3*
 
 cat > pdns-gsqlite3.conf << __EOF__
 launch=gsqlite3
 gsqlite3-database=pdns.sqlite3
 module-dir=../regression-tests/modules
+loglevel=4
 __EOF__
 
 ARGS="--config-dir=. --config-name=gsqlite3"
@@ -25,11 +26,19 @@ $PDNSUTIL $ARGS rrset add bug.less never.bug.less A 1.2.3.4
 echo "UPDATE records SET name='this-name-turns-out-to-be-an-invalid-dns-name-because-it-is-way-larger-than-sixty-three-characters-and-this-is-not-allowed-for-labels.bug.less' WHERE name='no.bug.less';" | sqlite3 pdns.sqlite3 2>&1
 echo "UPDATE records SET ordername='..' WHERE name='never.bug.less';" | sqlite3 pdns.sqlite3 2>&1
 
+# Make the database file non-writable, and let pdnsutil cope.
+chmod -w pdns.sqlite3
+
 # Check that pdnsutil zone list doesn't show the invalid records
 $PDNSUTIL -s $ARGS zone list bug.less
 
 # Check that pdnsutil zone check reports the invalid records
 $PDNSUTIL $ARGS zone check bug.less
+
+# For the sake of the following tests... note the wildcard, for the database
+# being read-only may cause sqlite to create -wal and -shm files read-only
+# as well.
+chmod +w pdns.sqlite3*
 
 # Check that pdnsutil zone edit deletes the invalid records (causing zone
 # check to no longer report any)


### PR DESCRIPTION
### Short description
The recent changes in #17780 would always throw an exception when facing a read-only SQLite3 database.

This PR replaces the use of `sqlite3_open` with `sqlite3_open_v2` which takes extra flags, in which we can specify whether we would like to open the database in read-write or read-only mode.

We will no longer throw an exception if the database can not be opened read-write, but instead will log a warning.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
