### PR TITLE
geoipbackend: create DNSSEC key files with mode 0600

### DIFF
--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -1135,9 +1135,22 @@ bool GeoIPBackend::addDomainKey(const ZoneName& name, const KeyData& key, int64_
       globfree(&glob_result);
       pathname.str("");
       pathname << getArg("dnssec-keydir") << "/" << dom.domain.toStringNoDot() << "." << key.flags << "." << nextid << "." << (key.active ? "1" : "0") << ".key";
-      ofstream ofs(pathname.str().c_str());
-      ofs.write(key.content.c_str(), key.content.size());
-      ofs.close();
+      auto keyFile = pdns::openFileForWriting(pathname.str(), 0600, true, false);
+      if (!keyFile) {
+        int error = errno;
+        SLOG(g_log << Logger::Error << "Cannot create key file " << pathname.str() << ": " << stringerror(error) << endl,
+             d_slog->error(Logr::Error, stringerror(error), "Cannot create key file", "file", Logging::Loggable(pathname.str())));
+        return false;
+      }
+      if (fwrite(key.content.c_str(), 1, key.content.size(), keyFile.get()) != key.content.size()) {
+        int error = errno;
+        SLOG(g_log << Logger::Error << "Cannot write key file " << pathname.str() << ": " << stringerror(error) << endl,
+             d_slog->error(Logr::Error, stringerror(error), "Cannot write key file", "file", Logging::Loggable(pathname.str())));
+        keyFile.reset();
+        unlink(pathname.str().c_str());
+        return false;
+      }
+      keyFile.reset();
       keyId = nextid;
       return true;
     }


### PR DESCRIPTION
### Short description

`GeoIPBackend::addDomainKey` stores the ISC-format private key through a plain `ofstream`, so the file is created 0666 masked only by the process umask:

- with the usual 022 umask that is mode 0644, and `pdns_server` sets no umask of its own, so every local account can read the zone signing key out of `geoip-dnssec-keydir`
- no `O_EXCL` either, so a symlink planted at the path of the next key id gets followed and the key is written through it
- the write result was dropped and the function returned true either way, so a failed store was reported to the caller as a success

`pdns::openFileForWriting` is what the pcap writer and the TLS keylog file already use for this. Checked with `pdnsutil add-zone-key` against a geoip zone: the key file comes out 0644 before, 0600 after, and `show-zone` still reads it back.

The other backends keep key material in their database, so this is the only place a private key reaches the filesystem.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
