### PR TITLE
auth: do not log x-api-key value in 'detailed' log level

### DIFF
--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -423,7 +423,13 @@ void WebServer::logRequest(const HttpRequest& req, [[maybe_unused]] const ComboA
           first = false;
           g_log<<Logger::Notice<<logprefix<<" Headers:"<<endl;
         }
-        g_log<<Logger::Notice<<logprefix<<"  "<<h.first<<": "<<h.second<<endl;
+        bool redacted = h.first == "x-api-key";
+        if (redacted) {
+          g_log<<Logger::Notice<<logprefix<<"  "<<h.first<<": (redacted)"<<endl;
+        }
+        else {
+          g_log<<Logger::Notice<<logprefix<<"  "<<h.first<<": "<<h.second<<endl;
+        }
       }
 
       if (req.body.empty()) {


### PR DESCRIPTION
### Short description
As noticed by @nvaatstra, we probably should not log the value of the `X-API-Key` header in extra verbose webserver log mode.
 
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
