### PR TITLE
dnsdist: add backend redirections (EDSR)

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -625,8 +625,13 @@ static std::shared_ptr<DownstreamState> createBackendFromConfiguration(const Con
 #endif /* defined(HAVE_XSK) */
 
   const auto& autoUpgradeConf = config.auto_upgrade;
+  const auto& autoRedirectConf = config.auto_redirect;
   if (autoUpgradeConf.enabled && downstream->getProtocol() != dnsdist::Protocol::DoT && downstream->getProtocol() != dnsdist::Protocol::DoH) {
-    dnsdist::ServiceDiscovery::addUpgradeableServer(downstream, autoUpgradeConf.interval, std::string(autoUpgradeConf.pool), autoUpgradeConf.doh_key, autoUpgradeConf.keep);
+    dnsdist::ServiceDiscovery::addUpgradeableServer(downstream, autoUpgradeConf.interval, std::string(autoUpgradeConf.pool), autoUpgradeConf.doh_key, autoUpgradeConf.keep, autoRedirectConf.enabled, autoRedirectConf.retry_interval, std::string(autoRedirectConf.pool), autoRedirectConf.doh_key, autoRedirectConf.keep, autoRedirectConf.max_follow_count);
+  }
+
+  if (autoRedirectConf.enabled && (downstream->getProtocol() == dnsdist::Protocol::DoT || downstream->getProtocol() == dnsdist::Protocol::DoH)) {
+    dnsdist::ServiceDiscovery::addRedirectableServer(downstream, autoRedirectConf.retry_interval, std::string(autoRedirectConf.pool), autoRedirectConf.doh_key, autoRedirectConf.keep, autoRedirectConf.max_follow_count);
   }
 
   return downstream;

--- a/pdns/dnsdistdist/dnsdist-discovery.cc
+++ b/pdns/dnsdistdist/dnsdist-discovery.cc
@@ -23,12 +23,16 @@
 #include "config.h"
 #include "dnsdist-discovery.hh"
 #include "dnsdist-backend.hh"
+#include "dnsdist-nghttp2.hh"
+#include "dnsdist-tcp.hh"
 #include "dnsdist.hh"
 #include "dnsdist-random.hh"
 #include "dnsparser.hh"
 #include "dolog.hh"
+#include "logging.hh"
 #include "sstuff.hh"
 #include "threadname.hh"
+#include <unordered_set>
 
 namespace dnsdist
 {
@@ -37,9 +41,15 @@ const DNSName ServiceDiscovery::s_discoveryDomain{"_dns.resolver.arpa."};
 const QType ServiceDiscovery::s_discoveryType{QType::SVCB};
 const uint16_t ServiceDiscovery::s_defaultDoHSVCKey{7};
 
-bool ServiceDiscovery::addUpgradeableServer(std::shared_ptr<DownstreamState>& server, uint32_t interval, std::string poolAfterUpgrade, uint16_t dohSVCKey, bool keepAfterUpgrade)
+bool ServiceDiscovery::addUpgradeableServer(std::shared_ptr<DownstreamState>& server, uint32_t interval, std::string poolAfterUpgrade, uint16_t dohSVCKey, bool keepAfterUpgrade, bool enableRedirection, uint32_t redirectInterval, std::string poolAfterRedirect, uint16_t redirectDohSVCKey, bool keepAfterRedirect, uint32_t redirectMaxFollowCount)
 {
-  s_upgradeableBackends.lock()->push_back(std::make_shared<UpgradeableBackend>(UpgradeableBackend{server, std::move(poolAfterUpgrade), 0, interval, dohSVCKey, keepAfterUpgrade}));
+  s_upgradeableBackends.lock()->push_back(std::make_shared<UpgradeableBackend>(UpgradeableBackend{server, std::move(poolAfterUpgrade), 0, interval, dohSVCKey, keepAfterUpgrade, enableRedirection, std::move(poolAfterRedirect), redirectInterval, redirectDohSVCKey, keepAfterRedirect, redirectMaxFollowCount}));
+  return true;
+}
+
+bool ServiceDiscovery::addRedirectableServer(std::shared_ptr<DownstreamState>& server, uint32_t interval, std::string poolAfterUpgrade, uint16_t dohSVCKey, bool keepAfterRedirect, uint32_t maxFollowCount)
+{
+  s_redirectableBackends.lock()->push_back(std::make_shared<RedirectableBackend>(RedirectableBackend{server, server, std::move(poolAfterUpgrade), 0, interval, dohSVCKey, keepAfterRedirect, maxFollowCount}));
   return true;
 }
 
@@ -48,6 +58,7 @@ struct DesignatedResolvers
   DNSName target;
   std::set<SvcParam> params;
   std::vector<ComboAddress> hints;
+  uint32_t ttl;
 };
 
 static bool parseSVCParams(const PacketBuffer& answer, std::map<uint16_t, DesignatedResolvers>& resolvers)
@@ -90,7 +101,7 @@ static bool parseSVCParams(const PacketBuffer& answer, std::map<uint16_t, Design
         pr.xfrSvcParamKeyVals(params);
       }
 
-      resolvers[prio] = {std::move(target), std::move(params), {}};
+      resolvers[prio] = {std::move(target), std::move(params), {}, ah.d_ttl};
     }
     else {
       pr.xfrBlob(blob);
@@ -228,6 +239,7 @@ static bool handleSVCResult(const Logr::Logger& logger, const PacketBuffer& answ
 
     tempConfig.d_subjectName = resolver.target.toStringNoDot();
     tempConfig.d_addr.sin4.sin_port = tempConfig.d_port;
+    tempConfig.d_ttl = resolver.ttl;
 
     config = std::move(tempConfig);
     return true;
@@ -236,10 +248,9 @@ static bool handleSVCResult(const Logr::Logger& logger, const PacketBuffer& answ
   return false;
 }
 
-bool ServiceDiscovery::getDiscoveredConfig(const Logr::Logger& topLogger, const UpgradeableBackend& upgradeableBackend, ServiceDiscovery::DiscoveredResolverConfig& config)
+bool ServiceDiscovery::getDiscoveredConfig(const Logr::Logger& topLogger, const std::shared_ptr<DownstreamState>& backend, uint16_t dohKey, ServiceDiscovery::DiscoveredResolverConfig& config)
 {
   const auto verbose = dnsdist::configuration::getCurrentRuntimeConfiguration().d_verbose;
-  const auto& backend = upgradeableBackend.d_ds;
   const auto& addr = backend->d_config.remote;
   try {
     auto id = dnsdist::getRandomDNSID();
@@ -252,60 +263,123 @@ bool ServiceDiscovery::getDiscoveredConfig(const Logr::Logger& topLogger, const 
 
     auto logger = topLogger.withValues("dns.query.id", Logging::Loggable(id), "dns.query.name", Logging::Loggable(s_discoveryDomain), "dns.query.type", Logging::Loggable(s_discoveryType));
 
-    uint16_t querySize = static_cast<uint16_t>(packet.size());
-    const uint8_t sizeBytes[] = {static_cast<uint8_t>(querySize / 256), static_cast<uint8_t>(querySize % 256)};
-    packet.insert(packet.begin(), sizeBytes, sizeBytes + 2);
+    if (backend->getProtocol() != dnsdist::Protocol::DoH) {
+      uint16_t querySize = static_cast<uint16_t>(packet.size());
+      const uint8_t sizeBytes[] = {static_cast<uint8_t>(querySize / 256), static_cast<uint8_t>(querySize % 256)};
+      packet.insert(packet.begin(), sizeBytes, sizeBytes + 2);
+    }
 
     Socket sock(addr.sin4.sin_family, SOCK_STREAM);
-    sock.setNonBlocking();
+    if (backend->getProtocol() != dnsdist::Protocol::DoH) {
+      sock.setNonBlocking();
 
 #ifdef SO_BINDTODEVICE
-    if (!backend->d_config.sourceItfName.empty()) {
-      (void)setsockopt(sock.getHandle(), SOL_SOCKET, SO_BINDTODEVICE, backend->d_config.sourceItfName.c_str(), backend->d_config.sourceItfName.length());
-    }
+      if (!backend->d_config.sourceItfName.empty()) {
+        (void)setsockopt(sock.getHandle(), SOL_SOCKET, SO_BINDTODEVICE, backend->d_config.sourceItfName.c_str(), backend->d_config.sourceItfName.length());
+      }
 #endif
 
-    if (!IsAnyAddress(backend->d_config.sourceAddr)) {
-      sock.setReuseAddr();
+      if (!IsAnyAddress(backend->d_config.sourceAddr)) {
+        sock.setReuseAddr();
 #ifdef IP_BIND_ADDRESS_NO_PORT
-      if (backend->d_config.ipBindAddrNoPort) {
-        SSetsockopt(sock.getHandle(), SOL_IP, IP_BIND_ADDRESS_NO_PORT, 1);
-      }
+        if (backend->d_config.ipBindAddrNoPort) {
+          SSetsockopt(sock.getHandle(), SOL_IP, IP_BIND_ADDRESS_NO_PORT, 1);
+        }
 #endif
-      sock.bind(backend->d_config.sourceAddr);
-    }
-    sock.connect(addr, backend->d_config.tcpConnectTimeout);
-
-    sock.writenWithTimeout(reinterpret_cast<const char*>(packet.data()), packet.size(), backend->d_config.tcpSendTimeout);
-
-    const struct timeval remainingTime = {.tv_sec = backend->d_config.tcpRecvTimeout, .tv_usec = 0};
-    uint16_t responseSize = 0;
-    auto got = readn2WithTimeout(sock.getHandle(), &responseSize, sizeof(responseSize), remainingTime);
-    if (got != sizeof(responseSize)) {
-      if (verbose) {
-        SLOG(warnlog("Error while waiting for the ADD upgrade response size from backend %s: %d", addr.toStringWithPort(), got),
-             logger->info(Logr::Warning, "Error while waiting for the ADD upgrade response size from backend", "value", Logging::Loggable(got), "expected", Logging::Loggable(sizeof(responseSize))));
+        sock.bind(backend->d_config.sourceAddr);
       }
-      return false;
+      sock.connect(addr, backend->d_config.tcpConnectTimeout);
     }
 
-    packet.resize(ntohs(responseSize));
+    if (backend->getProtocol() == dnsdist::Protocol::DoT) {
+      auto handler = std::make_unique<TCPIOHandler>(backend->d_config.d_tlsSubjectName, backend->d_config.d_tlsSubjectIsAddr, sock.releaseHandle(), timeval{backend->d_config.checkTimeout, 0}, backend->d_tlsCtx);
+      handler->connect(backend->d_config.tcpFastOpen, backend->d_config.remote, timeval{backend->d_config.checkTimeout, 0});
+      handler->write(reinterpret_cast<const char*>(packet.data()), packet.size(), timeval{backend->d_config.checkTimeout, 0});
 
-    got = readn2WithTimeout(sock.getHandle(), packet.data(), packet.size(), remainingTime);
-    if (got != packet.size()) {
-      if (verbose) {
-        SLOG(warnlog("Error while waiting for the ADD upgrade response from backend %s: %d", addr.toStringWithPort(), got),
-             logger->info(Logr::Warning, "Error while waiting for the ADD upgrade response from backend", "value", Logging::Loggable(got), "expected", Logging::Loggable(packet.size())));
+      const struct timeval remainingTime = {.tv_sec = backend->d_config.tcpRecvTimeout, .tv_usec = 0};
+      uint16_t responseSize = 0;
+      auto got = handler->read(&responseSize, sizeof(responseSize), remainingTime);
+      if (got != sizeof(responseSize)) {
+        if (verbose) {
+          SLOG(warnlog("Error while waiting for the ADD upgrade response size from backend %s: %d", addr.toStringWithPort(), got),
+               logger->info(Logr::Warning, "Error while waiting for the ADD upgrade response size from backend", "value", Logging::Loggable(got), "expected", Logging::Loggable(sizeof(responseSize))));
+        }
+        return false;
       }
-      return false;
+
+      packet.resize(ntohs(responseSize));
+
+      got = handler->read(packet.data(), packet.size(), remainingTime);
+      if (got != packet.size()) {
+        if (verbose) {
+          SLOG(warnlog("Error while waiting for the ADD upgrade response from backend %s: %d", addr.toStringWithPort(), got),
+               logger->info(Logr::Warning, "Error while waiting for the ADD upgrade response from backend", "value", Logging::Loggable(got), "expected", Logging::Loggable(packet.size())));
+        }
+        return false;
+      }
     }
+    else if (backend->getProtocol() == dnsdist::Protocol::DoH) {
+      auto sender = std::make_shared<RedirectionQuerySender>();
+      auto sliced = std::shared_ptr<TCPQuerySender>(sender);
+      auto multiplexer = std::unique_ptr<FDMultiplexer>(FDMultiplexer::getMultiplexerSilent());
+      auto queryBuffer = packet;
+      auto query = InternalQuery(std::move(queryBuffer), InternalQueryState());
 
-    if (packet.size() <= sizeof(struct dnsheader)) {
-      if (verbose) {
-        SLOG(warnlog("Too short answer of size %d received from the backend %s", packet.size(), addr.toStringWithPort()),
-             logger->info(Logr::Warning, "Too short answer received from the backend", "dns.response.size", Logging::Loggable(packet.size())));
+      bool result = sendH2Query(backend, multiplexer, sliced, std::move(query), true);
+      if (!result) {
+        if (verbose) {
+          SLOG(warnlog("Error sending a discovery DoH query to backend: %d", addr.toStringWithPort()),
+               logger->info(Logr::Warning, "Error sending a discovery DoH query to backend"));
+        }
+        return false;
       }
-      return false;
+      struct timeval now;
+      gettimeofday(&now, nullptr);
+      while ((multiplexer->getWatchedFDCount(false) != 0 || multiplexer->getWatchedFDCount(true) != 0) && !sender->d_error) {
+        multiplexer->run(&now);
+        handleH2Timeouts(*multiplexer, now);
+      }
+      if (sender->d_error) {
+        if (verbose) {
+          SLOG(warnlog("Error sending a discovery DoH query to backend: %d", addr.toStringWithPort()),
+               logger->info(Logr::Warning, "Error sending a discovery DoH query to backend"));
+        }
+        return false;
+      }
+      packet = sender->d_response;
+    }
+    else {
+      sock.writenWithTimeout(reinterpret_cast<const char*>(packet.data()), packet.size(), backend->d_config.tcpSendTimeout);
+
+      const struct timeval remainingTime = {.tv_sec = backend->d_config.tcpRecvTimeout, .tv_usec = 0};
+      uint16_t responseSize = 0;
+      auto got = readn2WithTimeout(sock.getHandle(), &responseSize, sizeof(responseSize), remainingTime);
+      if (got != sizeof(responseSize)) {
+        if (verbose) {
+          SLOG(warnlog("Error while waiting for the ADD upgrade response size from backend %s: %d", addr.toStringWithPort(), got),
+               logger->info(Logr::Warning, "Error while waiting for the ADD upgrade response size from backend", "value", Logging::Loggable(got), "expected", Logging::Loggable(sizeof(responseSize))));
+        }
+        return false;
+      }
+
+      packet.resize(ntohs(responseSize));
+
+      got = readn2WithTimeout(sock.getHandle(), packet.data(), packet.size(), remainingTime);
+      if (got != packet.size()) {
+        if (verbose) {
+          SLOG(warnlog("Error while waiting for the ADD upgrade response from backend %s: %d", addr.toStringWithPort(), got),
+               logger->info(Logr::Warning, "Error while waiting for the ADD upgrade response from backend", "value", Logging::Loggable(got), "expected", Logging::Loggable(packet.size())));
+        }
+        return false;
+      }
+
+      if (packet.size() <= sizeof(struct dnsheader)) {
+        if (verbose) {
+          SLOG(warnlog("Too short answer of size %d received from the backend %s", packet.size(), addr.toStringWithPort()),
+               logger->info(Logr::Warning, "Too short answer received from the backend", "dns.response.size", Logging::Loggable(packet.size())));
+        }
+        return false;
+      }
     }
 
     struct dnsheader d;
@@ -347,7 +421,7 @@ bool ServiceDiscovery::getDiscoveredConfig(const Logr::Logger& topLogger, const 
       return false;
     }
 
-    return handleSVCResult(*logger, packet, addr, upgradeableBackend.d_dohKey, config);
+    return handleSVCResult(*logger, packet, addr, dohKey, config);
   }
   catch (const std::exception& e) {
     SLOG(warnlog("Error while trying to discover backend upgrade for %s: %s", addr.toStringWithPort(), e.what()),
@@ -399,14 +473,14 @@ static bool checkBackendUsability(const Logr::Logger& logger, std::shared_ptr<Do
   return false;
 }
 
-bool ServiceDiscovery::tryToUpgradeBackend(const Logr::Logger& logger, const UpgradeableBackend& backend)
+bool ServiceDiscovery::tryToUpgradeBackend(const Logr::Logger& logger, const UpgradeableBackend& backend, std::shared_ptr<DownstreamState>& upgradedBackend)
 {
   ServiceDiscovery::DiscoveredResolverConfig discoveredConfig;
 
   VERBOSESLOG(infolog("Trying to discover configuration for backend %s", backend.d_ds->getNameWithAddr()),
               logger.info(Logr::Info, "Trying to discover upgrade configuration for backend"));
 
-  if (!ServiceDiscovery::getDiscoveredConfig(logger, backend, discoveredConfig)) {
+  if (!ServiceDiscovery::getDiscoveredConfig(logger, backend.d_ds, backend.d_dohKey, discoveredConfig)) {
     return false;
   }
 
@@ -501,6 +575,7 @@ bool ServiceDiscovery::tryToUpgradeBackend(const Logr::Logger& logger, const Upg
     }
 
     dnsdist::backend::registerNewBackend(newServer);
+    upgradedBackend = newServer;
 
     if (!backend.keepAfterUpgrade) {
       backend.d_ds->stop();
@@ -511,6 +586,154 @@ bool ServiceDiscovery::tryToUpgradeBackend(const Logr::Logger& logger, const Upg
   catch (const std::exception& e) {
     SLOG(warnlog("Error when trying to upgrade a discovered backend: %s", e.what()),
          logger.error(Logr::Warning, e.what(), "Error when trying to upgrade a discovered backend"));
+  }
+
+  return false;
+}
+
+bool ServiceDiscovery::tryToRedirectBackend(const Logr::Logger& logger, RedirectableBackend& backend, uint32_t& ttl)
+{
+  ServiceDiscovery::DiscoveredResolverConfig discoveredConfig;
+
+  VERBOSESLOG(infolog("Trying to discover redirection configuration for backend %s", backend.d_origDs->getNameWithAddr()),
+              logger.info(Logr::Info, "Trying to discover redirection configuration for backend"));
+
+  // Start the redirection from the original server always
+  std::shared_ptr<DownstreamState> newServer = backend.d_origDs;
+  ttl = std::numeric_limits<uint32_t>::max();
+
+  uint32_t redirects = 0;
+  std::unordered_set<ServiceDiscovery::DiscoveredResolverConfig> discoveredResolvers = {discoveredConfig};
+
+  try {
+    while (redirects < backend.d_maxFollowCount) {
+      discoveredConfig = {};
+      if (!ServiceDiscovery::getDiscoveredConfig(logger, newServer, backend.d_dohKey, discoveredConfig)) {
+        return false;
+      }
+
+      if (discoveredConfig.d_protocol != dnsdist::Protocol::DoT && discoveredConfig.d_protocol != dnsdist::Protocol::DoH) {
+        return false;
+      }
+
+      // Loop detected, exit
+      if (discoveredResolvers.find(discoveredConfig) != discoveredResolvers.end()) {
+        break;
+      }
+
+      discoveredResolvers.insert(discoveredConfig);
+
+      DownstreamState::Config config(newServer->d_config);
+      config.remote = discoveredConfig.d_addr;
+      config.remote.setPort(discoveredConfig.d_port);
+
+      if (backend.d_keepAfterRedirect && config.d_availability == DownstreamState::Availability::Up) {
+        config.d_availability = DownstreamState::Availability::Auto;
+        config.d_healthCheckMode = DownstreamState::HealthCheckMode::Active;
+      }
+
+      ComboAddress::addressOnlyEqual comparator;
+      config.d_dohPath = discoveredConfig.d_dohPath;
+      if (!discoveredConfig.d_subjectName.empty() && comparator(config.remote, newServer->d_config.remote) && !config.d_tlsSubjectIsAddr) {
+        /* same address, we can used the supplied name for validation */
+        config.d_tlsSubjectName = discoveredConfig.d_subjectName;
+        config.d_tlsSubjectIsAddr = false;
+      }
+      else {
+        /* different name, or using IP address and
+           draft-ietf-add-encrypted-dns-server-redirection Section 6.3 states:
+           When a resolver is discovered using DDR's Discovery Using Resolver IP
+           Addresses mechanism defined in Section 4 of [RFC9462], the server's
+           identity used for TLS purposes is its IP address, not its domain
+           name.  This means servers and clients MUST use the original server's
+           IP address, not the IP address of the previous server in the event of
+           redirection chains, in the SAN field of destination servers to
+           validate the redirection.
+        */
+        config.d_tlsSubjectName = backend.d_origDs->d_config.remote.toString();
+        config.d_tlsSubjectIsAddr = true;
+      }
+
+      if (!backend.d_poolAfterRedirect.empty()) {
+        config.pools.clear();
+        config.pools.insert(backend.d_poolAfterRedirect);
+      }
+
+      /* create new backend, put it into the right pool(s) */
+      auto tlsCtx = getTLSContext(config.d_tlsParams);
+      auto nextServer = std::make_shared<DownstreamState>(std::move(config), std::move(tlsCtx), true);
+
+      /* check that we can connect to the backend (including certificate validation */
+      if (!checkBackendUsability(logger, nextServer)) {
+        VERBOSESLOG(infolog("Failed to use the redirected server %s, skipping for now", newServer->getNameWithAddr()),
+                    logger.info(Logr::Info, "Failed to use the redirected server, skipping for now"));
+        break;
+      }
+
+      newServer->stop();
+      newServer = nextServer;
+      ttl = std::min(discoveredConfig.d_ttl, ttl);
+    }
+
+    if (newServer == backend.d_origDs) {
+      return false;
+    }
+
+    if (!newServer->d_config.pools.empty()) {
+      for (const auto& poolName : newServer->d_config.pools) {
+        addServerToPool(poolName, newServer);
+      }
+    }
+    else {
+      addServerToPool("", newServer);
+    }
+
+    newServer->start();
+
+    SLOG(infolog("Added redirected server %s", newServer->getNameWithAddr()),
+         logger.info(Logr::Info, "Added redirected server", "server", Logging::Loggable(newServer->getNameWithAddr()), "server22", Logging::Loggable(newServer->d_config.remote.toStringWithPort())));
+
+    /* remove the existing backend */
+    if (!backend.d_keepAfterRedirect) {
+      dnsdist::configuration::updateRuntimeConfiguration([&backend](dnsdist::configuration::RuntimeConfiguration& runtimeConfig) {
+        auto& backends = runtimeConfig.d_backends;
+        for (auto backendIt = backends.begin(); backendIt != backends.end(); ++backendIt) {
+          if (*backendIt == backend.d_origDs || *backendIt == backend.d_currentDs) {
+            backends.erase(backendIt);
+            break;
+          }
+        }
+      });
+
+      // Remove the original
+      for (const string& poolName : backend.d_origDs->d_config.pools) {
+        removeServerFromPool(poolName, backend.d_origDs);
+      }
+      /* the server might also be in the default pool */
+      removeServerFromPool("", backend.d_origDs);
+    }
+
+    if (backend.d_currentDs) {
+      for (const string& poolName : backend.d_currentDs->d_config.pools) {
+        removeServerFromPool(poolName, backend.d_currentDs);
+      }
+      /* the server might also be in the default pool */
+      removeServerFromPool("", backend.d_currentDs);
+
+      backend.d_currentDs->stop();
+    }
+
+    dnsdist::backend::registerNewBackend(newServer);
+    if (!backend.d_keepAfterRedirect) {
+      backend.d_origDs->stop();
+    }
+    backend.d_currentDs = newServer;
+
+    return true;
+  }
+  catch (const std::exception& e) {
+    SLOG(warnlog("Error when trying to redirect a backend: %s", e.what()),
+         logger.error(Logr::Warning, e.what(), "Error when trying to redirect a backend"));
   }
 
   return false;
@@ -538,9 +761,13 @@ void ServiceDiscovery::worker()
           continue;
         }
 
-        auto upgraded = tryToUpgradeBackend(*backendLogger, *backend);
+        std::shared_ptr<DownstreamState> newServer;
+        auto upgraded = tryToUpgradeBackend(*backendLogger, *backend, newServer);
         if (upgraded) {
           upgradedBackends.insert(backend->d_ds);
+          if (backend->d_enableRedirect) {
+            addRedirectableServer(newServer, backend->d_redirectInterval, backend->d_poolAfterRedirect, backend->d_redirectDohKey, backend->d_keepAfterRedirect, backend->d_redirectMaxFollowCount);
+          }
           backendIt = upgradeables.erase(backendIt);
           continue;
         }
@@ -570,6 +797,53 @@ void ServiceDiscovery::worker()
       }
     }
 
+    auto redirectables = *(s_redirectableBackends.lock());
+
+    for (auto backendIt = redirectables.begin(); backendIt != redirectables.end();) {
+      auto& backend = *backendIt;
+      auto backendLogger = logger->withValues("backend.name", Logging::Loggable(backend->d_origDs->getName()), "backend.address", Logging::Loggable(backend->d_origDs->d_config.remote));
+
+      if (backend->d_nextCheck > now) {
+        ++backendIt;
+        continue;
+      }
+
+      try {
+        uint32_t ttl = 0;
+        auto redirected = tryToRedirectBackend(*backendLogger, *backend, ttl);
+        if (!redirected) {
+          // If original server is stopped and we failed to redirect, restart the original
+          if (!backend->d_keepAfterRedirect && backend->d_origDs->isStopped()) {
+            auto originalServer = backend->d_origDs;
+            if (!originalServer->d_config.pools.empty()) {
+              for (const auto& poolName : originalServer->d_config.pools) {
+                addServerToPool(poolName, originalServer);
+              }
+            }
+            else {
+              addServerToPool("", originalServer);
+            }
+            dnsdist::backend::registerNewBackend(originalServer);
+            originalServer->start();
+          }
+          backend->d_nextCheck = now + backend->d_interval;
+        }
+        else {
+          backend->d_nextCheck = now + ttl;
+        }
+      }
+      catch (const std::exception& e) {
+        VERBOSESLOG(infolog("Exception in the Service Discovery thread: %s", e.what()),
+                    backendLogger->error(Logr::Info, e.what(), "Exception in the Service Discovery thread"));
+      }
+      catch (...) {
+        VERBOSESLOG(infolog("Exception in the Service Discovery thread"),
+                    backendLogger->info(Logr::Info, "Exception in the Service Discovery thread"));
+      }
+
+      ++backendIt;
+    }
+
     /* we could sleep until the next check but a new backend
        could be added in the meantime, so let's just check every
        minute if we have something to do */
@@ -586,5 +860,6 @@ bool ServiceDiscovery::run()
 }
 
 LockGuarded<std::vector<std::shared_ptr<ServiceDiscovery::UpgradeableBackend>>> ServiceDiscovery::s_upgradeableBackends;
+LockGuarded<std::vector<std::shared_ptr<ServiceDiscovery::RedirectableBackend>>> ServiceDiscovery::s_redirectableBackends;
 std::thread ServiceDiscovery::s_thread;
 }

--- a/pdns/dnsdistdist/dnsdist-discovery.hh
+++ b/pdns/dnsdistdist/dnsdist-discovery.hh
@@ -23,6 +23,7 @@
 #include <vector>
 #include <thread>
 
+#include "dnsdist-tcp.hh"
 #include "dnsname.hh"
 #include "dnsdist-protocols.hh"
 #include "iputils.hh"
@@ -37,10 +38,38 @@ class Logger;
 namespace dnsdist
 {
 
+class RedirectionQuerySender : public TCPQuerySender
+{
+public:
+  [[nodiscard]] bool active() const override
+  {
+    return true;
+  }
+
+  void handleResponse([[maybe_unused]] const struct timeval& now, TCPResponse&& response) override
+  {
+    d_response = response.d_buffer;
+  }
+
+  void handleXFRResponse([[maybe_unused]] const struct timeval& now, [[maybe_unused]] TCPResponse&& response) override
+  {
+    handleResponse(now, std::move(response));
+  }
+
+  void notifyIOError([[maybe_unused]] const struct timeval& now, [[maybe_unused]] TCPResponse&& response) override
+  {
+    d_error = true;
+  }
+
+  PacketBuffer d_response;
+  bool d_error{false};
+};
+
 class ServiceDiscovery
 {
 public:
-  static bool addUpgradeableServer(std::shared_ptr<DownstreamState>& server, uint32_t interval, std::string poolAfterUpgrade, uint16_t dohSVCKey, bool keepAfterUpgrade);
+  static bool addUpgradeableServer(std::shared_ptr<DownstreamState>& server, uint32_t interval, std::string poolAfterUpgrade, uint16_t dohSVCKey, bool keepAfterUpgrade, bool enableRedirection, uint32_t redirectInterval, std::string poolAfterRedirect, uint16_t redirectDohSVCKey, bool keepAfterRedirect, uint32_t redirectMaxFollowCount);
+  static bool addRedirectableServer(std::shared_ptr<DownstreamState>& server, uint32_t interval, std::string poolAfterUpgrade, uint16_t dohSVCKey, bool keepAfterRedirect, uint32_t maxFollowCount);
 
   /* starts a background thread if needed */
   static bool run();
@@ -52,6 +81,12 @@ public:
     std::string d_dohPath;
     uint16_t d_port{0};
     dnsdist::Protocol d_protocol;
+    uint32_t d_ttl;
+
+    bool operator==(const DiscoveredResolverConfig& rhs) const
+    {
+      return d_addr == rhs.d_addr && d_subjectName == rhs.d_subjectName && d_dohPath == rhs.d_dohPath && d_port == rhs.d_port && d_protocol == rhs.d_protocol && d_ttl == rhs.d_ttl;
+    }
   };
 
   static const uint16_t s_defaultDoHSVCKey;
@@ -68,15 +103,53 @@ private:
     uint32_t d_interval;
     uint16_t d_dohKey;
     bool keepAfterUpgrade;
+    bool d_enableRedirect;
+    std::string d_poolAfterRedirect;
+    uint32_t d_redirectInterval;
+    uint16_t d_redirectDohKey;
+    bool d_keepAfterRedirect;
+    uint32_t d_redirectMaxFollowCount;
   };
 
-  static bool getDiscoveredConfig(const Logr::Logger& logger, const UpgradeableBackend& backend, DiscoveredResolverConfig& config);
-  static bool tryToUpgradeBackend(const Logr::Logger& logger, const UpgradeableBackend& backend);
+  struct RedirectableBackend
+  {
+    std::shared_ptr<DownstreamState> d_origDs;
+    std::shared_ptr<DownstreamState> d_currentDs;
+    std::string d_poolAfterRedirect;
+    time_t d_nextCheck;
+    uint32_t d_interval;
+    uint16_t d_dohKey;
+    bool d_keepAfterRedirect;
+    uint32_t d_maxFollowCount;
+  };
+
+  static bool getDiscoveredConfig(const Logr::Logger& logger, const std::shared_ptr<DownstreamState>& backend, uint16_t dohKey, DiscoveredResolverConfig& config);
+  static bool tryToUpgradeBackend(const Logr::Logger& logger, const UpgradeableBackend& backend, std::shared_ptr<DownstreamState>& upgradedBackend);
+  static bool tryToRedirectBackend(const Logr::Logger& logger, RedirectableBackend& backend, uint32_t& ttl);
 
   static void worker();
 
   static LockGuarded<std::vector<std::shared_ptr<UpgradeableBackend>>> s_upgradeableBackends;
+  static LockGuarded<std::vector<std::shared_ptr<ServiceDiscovery::RedirectableBackend>>> s_redirectableBackends;
   static std::thread s_thread;
 };
 
+}
+
+namespace std
+{
+template <>
+struct hash<dnsdist::ServiceDiscovery::DiscoveredResolverConfig>
+{
+  auto operator()(const dnsdist::ServiceDiscovery::DiscoveredResolverConfig& config) const
+  {
+    size_t currentHash = ComboAddress::addressOnlyHash{}(config.d_addr);
+    boost::hash_combine(currentHash, std::hash<std::string>{}(config.d_subjectName));
+    boost::hash_combine(currentHash, std::hash<std::string>{}(config.d_dohPath));
+    boost::hash_combine(currentHash, std::hash<uint16_t>{}(config.d_port));
+    boost::hash_combine(currentHash, std::hash<uint8_t>{}(config.d_protocol.toNumber()));
+    boost::hash_combine(currentHash, std::hash<uint32_t>{}(config.d_ttl));
+    return currentHash;
+  }
+};
 }

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -667,6 +667,45 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
                            }
                          }
 
+                         bool enableRedirection = false;
+                         getOptionalValue<bool>(vars, "enableRedirection", enableRedirection);
+                         uint32_t redirectRetryInterval = 3600;
+                         uint32_t redirectMaxFollowCount = 10;
+                         uint16_t redirectDoHKey = dnsdist::ServiceDiscovery::s_defaultDoHSVCKey;
+                         bool keepAfterRedirect = false;
+                         std::string redirectionPool;
+                         if (enableRedirection) {
+                           if (getOptionalValue<std::string>(vars, "redirectionRetryInterval", valueStr) > 0) {
+                             try {
+                               redirectRetryInterval = static_cast<uint32_t>(std::stoul(valueStr));
+                             }
+                             catch (const std::exception& e) {
+                               SLOG(warnlog("Error parsing 'redirectionRetryInterval' value: %s", e.what()),
+                                    getLogger("newServer")->error(Logr::Warning, e.what(), "Error parsing 'redirectionRetryInterval' value", "backend.address", Logging::Loggable(serverAddressStr), "value", Logging::Loggable(valueStr)));
+                             }
+                           }
+                           getOptionalValue<bool>(vars, "redirectionKeep", keepAfterRedirect);
+                           getOptionalValue<std::string>(vars, "redirectionPool", redirectionPool);
+                           if (getOptionalValue<std::string>(vars, "redirectionDoHKey", valueStr) > 0) {
+                             try {
+                               redirectDoHKey = static_cast<uint16_t>(std::stoul(valueStr));
+                             }
+                             catch (const std::exception& e) {
+                               SLOG(warnlog("Error parsing 'redirectionDoHKey' value: %s", e.what()),
+                                    getLogger("newServer")->error(Logr::Warning, e.what(), "Error parsing 'redirectionDoHKey' value", "backend.address", Logging::Loggable(serverAddressStr), "value", Logging::Loggable(valueStr)));
+                             }
+                           }
+                           if (getOptionalValue<std::string>(vars, "redirectionMaxFollowCount", valueStr) > 0) {
+                             try {
+                               redirectMaxFollowCount = static_cast<uint32_t>(std::stoul(valueStr));
+                             }
+                             catch (const std::exception& e) {
+                               SLOG(warnlog("Error parsing 'redirectionMaxFollowCount' value: %s", e.what()),
+                                    getLogger("newServer")->error(Logr::Warning, e.what(), "Error parsing 'redirectionMaxFollowCount' value", "backend.address", Logging::Loggable(serverAddressStr), "value", Logging::Loggable(valueStr)));
+                             }
+                           }
+                         }
+
                          // create but don't connect the socket in client or check-config modes
                          auto ret = std::make_shared<DownstreamState>(std::move(config), std::move(tlsCtx), !(client || configCheck));
 #ifdef HAVE_XSK
@@ -714,7 +753,11 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
                          }
 #endif /* HAVE_XSK */
                          if (autoUpgrade && ret->getProtocol() != dnsdist::Protocol::DoT && ret->getProtocol() != dnsdist::Protocol::DoH) {
-                           dnsdist::ServiceDiscovery::addUpgradeableServer(ret, upgradeInterval, std::move(upgradePool), upgradeDoHKey, keepAfterUpgrade);
+                           dnsdist::ServiceDiscovery::addUpgradeableServer(ret, upgradeInterval, std::move(upgradePool), upgradeDoHKey, keepAfterUpgrade, enableRedirection, redirectRetryInterval, std::move(redirectionPool), redirectDoHKey, keepAfterRedirect, redirectMaxFollowCount);
+                         }
+
+                         if (enableRedirection && ret->getProtocol() != dnsdist::Protocol::DoUDP && (ret->getProtocol() == dnsdist::Protocol::DoH || ret->getProtocol() == dnsdist::Protocol::DoT)) {
+                           dnsdist::ServiceDiscovery::addRedirectableServer(ret, redirectRetryInterval, std::move(redirectionPool), redirectDoHKey, keepAfterRedirect, redirectMaxFollowCount);
                          }
 
                          /* this needs to be done _AFTER_ the order has been set,

--- a/pdns/dnsdistdist/dnsdist-settings-definitions.yml
+++ b/pdns/dnsdistdist/dnsdist-settings-definitions.yml
@@ -1464,6 +1464,34 @@ outgoing_auto_upgrade:
       default: "false"
       description: "Whether the auto-upgraded version of this backend should use the lazy health-checking mode. Default is false, which means it will use the regular health-checking mode"
 
+outgoing_auto_redirect:
+  description: "Setting to automatically use a more desirable resolver if a backend supports it"
+  parameters:
+    - name: "enabled"
+      type: "bool"
+      default: "false"
+      description: "Whether to use the 'Encrypted DNS Server Redirection' mechanism to automatically use a more desirable resolver, depending on the priorities present in the SVCB record returned by the backend"
+    - name: "retry_interval"
+      type: "u32"
+      default: "3600"
+      description: "If ``enabled`` is set, how often to retry if redirection has failed"
+    - name: "pool"
+      type: "String"
+      default: ""
+      description: "If ``enabled`` is set, in which pool to place the newly redirected backend. Default is empty which means the backend is placed in the default pool"
+    - name: "doh_key"
+      type: "u8"
+      default: "7"
+      description: "If ``enabled`` is set, the value to use for the SVC key corresponding to the DoH path. Default is 7"
+    - name: "max_follow_count"
+      type: "u32"
+      default: "10"
+      description: "If ``enabled`` is set, how many redirections to follow before stopping, to prevent long redirection chains"
+    - name: "keep"
+      type: "bool"
+      default: "false"
+      description: "If ``enabled`` is set, whether to keep the pre-redirection backend around after a redirection. Default is false which means it will be replaced, until the process is repeated"
+
 backend:
   description: "Generic settings for backends"
   parameters:
@@ -1576,6 +1604,10 @@ backend:
       type: "OutgoingAutoUpgradeConfiguration"
       default: true
       description: "Auto-upgrade related settings"
+    - name: "auto_redirect"
+      type: "OutgoingAutoRedirectConfiguration"
+      default: true
+      description: "Auto-redirect related settings"
     - name: "max_concurrent_tcp_connections"
       type: "u32"
       default: 0

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -626,7 +626,7 @@ Servers
     Removed ``addXPF`` from server_table.
 
   .. versionchanged:: 2.2.0
-    Added ``ecdheCurves`` and ``maxOutstandingQueries`` to server_table.
+    Added ``ecdheCurves`` and ``maxOutstandingQueries`` to server_table. Added redirection feature with ``enableRedirection``, ``redirectionRetryInterval``, ``redirectMaxFollowCount``, ``redirectionPool``, ``redirectionDoHKey`` and ``redirectionKeep`` options in server_table.
 
   :param str server_string: A simple IP:PORT string.
   :param table server_table: A table with at least an ``address`` key
@@ -721,6 +721,12 @@ Servers
     ``keyLogFile``                           ``str``               "Write the TLS keys in the specified file so that an external program can decrypt TLS exchanges, in the format described in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format. Note that this feature requires OpenSSL >= 1.1.1."
     ``dscp``                                 ``number``            "The DSCP marking value to be applied. Range 0-63. Default is 0 which means no action for DSCP marking."
     ``maxOutstandingQueries``                ``number``            "Maximum number of outstanding queries assigned to this backend, no matter the protocol used and over all connections (see ``maxInFlight`` for the maximum number of outstanding queries per connection). Default is 0 which means unlimited"
+    ``enableRedirection``                    ``bool``              "Whether to use the 'Encrypted DNS Server Redirection' mechanism to automatically switch out an encrypted backend for a more preferable backend, depending on the priorities present in the SVCB record returned by the backend. Default to false."
+    ``redirectionRetryInterval``             ``number``            "If ``enableRedirection`` is set, how often to check if a redirection is available, in seconds. This only applies if redirection failed. Default is 3600 seconds."
+    ``redirectMaxFollowCount``               ``number``            "If ``enableRedirection`` is set, how many redirections should be followed in a chain before stopping. Default is 10, meaning at most 10 redirections will be followed and that last redirection will be used."
+    ``redirectionPool``                      ``string``            "If ``enableRedirection`` is set, in which pool to place the newly redirected backend. Default is empty which means the backend is placed in the default pool."
+    ``redirectionDoHKey``                    ``number``            "If ``enableRedirection`` is set, the value to use for the SVC key corresponding to the DoH path. Default is 7."
+    ``redirectionKeep``                      ``bool``              "If ``enableRedirection`` is set, whether to keep the pre-redirection backend around after a redirection. Default is false which means the backend will be replaced until the process is repeated."
 
 .. function:: getServer(index) -> Server
 

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -721,6 +721,12 @@ Servers
     ``keyLogFile``                           ``str``               "Write the TLS keys in the specified file so that an external program can decrypt TLS exchanges, in the format described in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format. Note that this feature requires OpenSSL >= 1.1.1."
     ``dscp``                                 ``number``            "The DSCP marking value to be applied. Range 0-63. Default is 0 which means no action for DSCP marking."
     ``maxOutstandingQueries``                ``number``            "Maximum number of outstanding queries assigned to this backend, no matter the protocol used and over all connections (see ``maxInFlight`` for the maximum number of outstanding queries per connection). Default is 0 which means unlimited"
+    ``enableRedirection``                    ``bool``              "Whether to use the 'Encrypted DNS Server Redirection' mechanism to automatically switch out an encrypted backend for a more preferable backend, depending on the priorities present in the SVCB record returned by the backend. Default to false."
+    ``redirectionRetryInterval``             ``number``            "If ``enableRedirection`` is set, how often to check if a redirection is available, in seconds. This only applies if redirection failed. Default is 3600 seconds."
+    ``redirectMaxFollowCount``               ``number``            "If ``enableRedirection`` is set, how many redirections should be followed in a chain before stopping. Default is 10, meaning at most 10 redirections will be followed and that last redirection will be used."
+    ``redirectionPool``                      ``string``            "If ``enableRedirection`` is set, in which pool to place the newly redirected backend. Default is empty which means the backend is placed in the default pool."
+    ``redirectionDoHKey``                    ``number``            "If ``enableRedirection`` is set, the value to use for the SVC key corresponding to the DoH path. Default is 7."
+    ``redirectionKeep``                      ``bool``              "If ``enableRedirection`` is set, whether to keep the pre-redirection backend around after a redirection. Default is false which means the backend will be replaced until the process is repeated."
 
 .. function:: getServer(index) -> Server
 

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -28,6 +28,11 @@ class TestBackendDiscovery(DNSDistTest):
     _badQNameBackendPort = 10615
     _svcUpgradeDoTNoPortBackendPort = 10616
     _svcUpgradeDoHNoPortBackendPort = 10617
+    _svcUpgradeDoTThenRedirect = 10618
+    _svcUpgradeDoHThenRedirect = 10619
+    _svcUpgradeDoHThenRedirectIntoFailure = 10620
+    _svcUpgradeDoTThenRedirectLoop = 10621
+    _svcUpgradeDoTRedirectAndKeep = 10622
     _upgradedBackendsPool = "upgraded"
 
     _consoleKey = DNSDistTest.generateConsoleKey()
@@ -54,6 +59,11 @@ class TestBackendDiscovery(DNSDistTest):
         "_badQNameBackendPort",
         "_svcUpgradeDoTNoPortBackendPort",
         "_svcUpgradeDoHNoPortBackendPort",
+        "_svcUpgradeDoTThenRedirect",
+        "_svcUpgradeDoHThenRedirect",
+        "_svcUpgradeDoHThenRedirectIntoFailure",
+        "_svcUpgradeDoTThenRedirectLoop",
+        "_svcUpgradeDoTRedirectAndKeep",
     ]
     _config_template = """
     setKey("%s")
@@ -114,6 +124,22 @@ class TestBackendDiscovery(DNSDistTest):
 
     -- SVCB upgrade to DoH, same address, no port specified via SVCB
     newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, autoUpgradeKeep=false}:setUp()
+
+    -- SVCB upgrade to DoT, then redirect from upgraded
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, enableRedirection=true}:setUp()
+
+    -- SVCB upgrade to DoH, then redirect from upgraded
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, enableRedirection=true}:setUp()
+
+    -- SVCB upgrade to DoH, then redirect from upgraded into failure, so
+    -- upgraded should be kept
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, enableRedirection=true}:setUp()
+
+    -- SVCB upgrade to DoT, then redirect into loop, which should be stopped
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, enableRedirection=true}:setUp()
+
+    -- SVCB upgrade to DoT, then redirect and keep
+    newServer{address="127.0.0.1:%d", caStore='ca.pem', autoUpgrade=true, enableRedirection=true, redirectionKeep=true}:setUp()
     """
     _verboseMode = True
 
@@ -288,6 +314,74 @@ class TestBackendDiscovery(DNSDistTest):
         )
         response.answer.append(rrset)
         return response.to_wire()
+
+    @staticmethod
+    def RedirectionGenericCallback(request, alpn, port, extra=""):
+        response = dns.message.make_response(request)
+        rrset = dns.rrset.from_text(
+            request.question[0].name,
+            60,
+            dns.rdataclass.IN,
+            dns.rdatatype.SVCB,
+            f'1 tls.tests.dnsdist.org. alpn="{alpn}" port={port} ipv4hint=127.0.0.1 {extra}',
+        )
+        response.answer.append(rrset)
+        # add a useless A record for good measure
+        rrset = dns.rrset.from_text(request.question[0].name, 60, dns.rdataclass.IN, dns.rdatatype.A, "192.0.2.1")
+        response.answer.append(rrset)
+        # plus more useless records in authority
+        rrset = dns.rrset.from_text(request.question[0].name, 60, dns.rdataclass.IN, dns.rdatatype.A, "192.0.2.1")
+        response.authority.append(rrset)
+        # and finally valid, albeit useless, hints
+        rrset = dns.rrset.from_text("tls.tests.dnsdist.org.", 60, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        response.additional.append(rrset)
+        rrset = dns.rrset.from_text("tls.tests.dnsdist.org.", 60, dns.rdataclass.IN, dns.rdatatype.AAAA, "::1")
+        response.additional.append(rrset)
+        return response.to_wire()
+
+    @staticmethod
+    def UpgradeDoTToRedirectCallback(request):
+        return TestBackendDiscovery.RedirectionGenericCallback(request, "dot", 10657)
+
+    @staticmethod
+    def RedirectDoTCallback(request):
+        return TestBackendDiscovery.RedirectionGenericCallback(request, "dot", 10658)
+
+    @staticmethod
+    def UpgradeDoHToRedirectCallback(request):
+        return TestBackendDiscovery.RedirectionGenericCallback(request, "h2", 10659, 'key7="/dns-query{?dns}"')
+
+    @staticmethod
+    def RedirectDoHCallback(request, requestHeaders, fromQueue, toQueue, conn):
+        return 200, TestBackendDiscovery.RedirectionGenericCallback(request, "h2", 10660, 'key7="/dns-query{?dns}"')
+
+    @staticmethod
+    def UpgradeDoHToRedirectIntoFailureCallback(request):
+        return TestBackendDiscovery.RedirectionGenericCallback(request, "h2", 10661, 'key7="/dns-query{?dns}"')
+
+    @staticmethod
+    def RedirectDoHFailureCallback(request, requestHeaders, fromQueue, toQueue, conn):
+        return 400, ""
+
+    @staticmethod
+    def UpgradeDoTToRedirectLoopCallback(request):
+        return TestBackendDiscovery.RedirectionGenericCallback(request, "dot", 10662)
+
+    @staticmethod
+    def RedirectLoop1Callback(request):
+        return TestBackendDiscovery.RedirectionGenericCallback(request, "dot", 10663)
+
+    @staticmethod
+    def RedirectLoop2Callback(request):
+        return TestBackendDiscovery.RedirectionGenericCallback(request, "dot", 10662)
+
+    @staticmethod
+    def UpgradeDoTThenKeepCallback(request):
+        return TestBackendDiscovery.RedirectionGenericCallback(request, "dot", 10664)
+
+    @staticmethod
+    def RedirectDoTThenKeepCallback(request):
+        return TestBackendDiscovery.RedirectionGenericCallback(request, "dot", 10665)
 
     @classmethod
     def startResponders(cls):
@@ -594,6 +688,227 @@ class TestBackendDiscovery(DNSDistTest):
         TCPUpgradeToDoHNoPortResponder.daemon = True
         TCPUpgradeToDoHNoPortResponder.start()
 
+        UpgradeToRedirectResponder = threading.Thread(
+            name="upgrade to DoT redirection Responder",
+            target=cls.TCPResponder,
+            args=[
+                cls._svcUpgradeDoTThenRedirect,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.UpgradeDoTToRedirectCallback,
+                None,
+                False,
+                "127.0.0.1",
+                True,
+            ],
+        )
+        UpgradeToRedirectResponder.daemon = True
+        UpgradeToRedirectResponder.start()
+        RedirectionResponder = threading.Thread(
+            name="DoT Redirection Responder",
+            target=cls.TCPResponder,
+            args=[
+                10657,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.RedirectDoTCallback,
+                tlsContext,
+            ],
+        )
+        RedirectionResponder.daemon = True
+        RedirectionResponder.start()
+        # and the corresponding redirected responder
+        RedirectedResponder = threading.Thread(
+            name="DoT Redirected responder",
+            target=cls.TCPResponder,
+            args=[
+                10658,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.RedirectDoTCallback,
+                tlsContext,
+            ],
+        )
+        RedirectedResponder.daemon = True
+        RedirectedResponder.start()
+
+        UpgradeToDoHRedirectResponder = threading.Thread(
+            name="upgrade to redirection Responder",
+            target=cls.TCPResponder,
+            args=[
+                cls._svcUpgradeDoHThenRedirect,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.UpgradeDoHToRedirectCallback,
+            ],
+        )
+        UpgradeToDoHRedirectResponder.daemon = True
+        UpgradeToDoHRedirectResponder.start()
+        DoHRedirectionResponder = threading.Thread(
+            name="DoH Redirection Responder",
+            target=cls.DOHResponder,
+            args=[
+                10659,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.RedirectDoHCallback,
+                tlsContext,
+            ],
+        )
+        DoHRedirectionResponder.daemon = True
+        DoHRedirectionResponder.start()
+        # and the corresponding redirected responder
+        DoHRedirectedResponder = threading.Thread(
+            name="DoH upgraded different addr 2 Responder",
+            target=cls.DOHResponder,
+            args=[
+                10660,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.RedirectDoHCallback,
+                tlsContext,
+            ],
+        )
+        DoHRedirectedResponder.daemon = True
+        DoHRedirectedResponder.start()
+
+        UpgradeToDoHRedirectIntoFailureResponder = threading.Thread(
+            name="upgrade to redirection Responder into failure",
+            target=cls.TCPResponder,
+            args=[
+                cls._svcUpgradeDoHThenRedirectIntoFailure,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.UpgradeDoHToRedirectIntoFailureCallback,
+            ],
+        )
+        UpgradeToDoHRedirectIntoFailureResponder.daemon = True
+        UpgradeToDoHRedirectIntoFailureResponder.start()
+        DoHRedirectionFailureResponder = threading.Thread(
+            name="DoH Redirection failure Responder",
+            target=cls.DOHResponder,
+            args=[
+                10661,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.RedirectDoHFailureCallback,
+                tlsContext,
+            ],
+        )
+        DoHRedirectionFailureResponder.daemon = True
+        DoHRedirectionFailureResponder.start()
+
+        UpgradeToDoTRedirectIntoLoopResponder = threading.Thread(
+            name="upgrade to redirection Responder into loop",
+            target=cls.TCPResponder,
+            args=[
+                cls._svcUpgradeDoTThenRedirectLoop,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.UpgradeDoTToRedirectLoopCallback,
+            ],
+        )
+        UpgradeToDoTRedirectIntoLoopResponder.daemon = True
+        UpgradeToDoTRedirectIntoLoopResponder.start()
+        DoTRedirectionLoop1Responder = threading.Thread(
+            name="DoT Redirection loop Responder 1",
+            target=cls.TCPResponder,
+            args=[
+                10662,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.RedirectLoop1Callback,
+                tlsContext,
+            ],
+        )
+        DoTRedirectionLoop1Responder.daemon = True
+        DoTRedirectionLoop1Responder.start()
+        DoTRedirectionLoop2Responder = threading.Thread(
+            name="DoT Redirection loop Responder 2",
+            target=cls.TCPResponder,
+            args=[
+                10663,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.RedirectLoop2Callback,
+                tlsContext,
+            ],
+        )
+        DoTRedirectionLoop2Responder.daemon = True
+        DoTRedirectionLoop2Responder.start()
+
+        UpgradeToRedirectAndKeepResponder = threading.Thread(
+            name="upgrade to DoT redirection and keep Responder",
+            target=cls.TCPResponder,
+            args=[
+                cls._svcUpgradeDoTRedirectAndKeep,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.UpgradeDoTThenKeepCallback,
+                None,
+                False,
+                "127.0.0.1",
+                True,
+            ],
+        )
+        UpgradeToRedirectAndKeepResponder.daemon = True
+        UpgradeToRedirectAndKeepResponder.start()
+        RedirectAndKeepResponder = threading.Thread(
+            name="DoT Redirection and keep Responder",
+            target=cls.TCPResponder,
+            args=[
+                10664,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.RedirectDoTThenKeepCallback,
+                tlsContext,
+            ],
+        )
+        RedirectAndKeepResponder.daemon = True
+        RedirectAndKeepResponder.start()
+        # and the corresponding redirected responder
+        RedirectedAndKeepResponder = threading.Thread(
+            name="DoT Redirected and keep responder",
+            target=cls.TCPResponder,
+            args=[
+                10665,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.RedirectDoTThenKeepCallback,
+                tlsContext,
+            ],
+        )
+        RedirectedAndKeepResponder.daemon = True
+        RedirectedAndKeepResponder.start()
+
     def checkBackendsUpgraded(self):
         output = self.sendConsoleCommand("showServers()")
         print(output)
@@ -604,7 +919,7 @@ class TestBackendDiscovery(DNSDistTest):
                 continue
             tokens = line.split()
             self.assertTrue(len(tokens) == 13 or len(tokens) == 14)
-            if tokens[1] == "127.0.0.1:10652":
+            if tokens[1] == "127.0.0.1:10652" or tokens[1] == "127.0.0.1:10665":
                 # in this particular case, the upgraded backend
                 # does not replace the existing one and thus
                 # the health-check is forced to auto (or lazy auto)
@@ -639,6 +954,12 @@ class TestBackendDiscovery(DNSDistTest):
             "127.0.0.1:10652": "upgraded",
             "127.0.0.1:10653": "another-pool",
             "127.0.0.2:10654": "",
+            "127.0.0.1:10661": "",
+            "127.0.0.1:10658": "",
+            "127.0.0.1:10660": "",
+            "127.0.0.1:10662": "",
+            "127.0.0.1:10664": "",
+            "127.0.0.1:10665": "",
         }
         print(backends)
         return backends == expected


### PR DESCRIPTION
### Short description

This implements [EDSR][EDSR] (draft) for backends. This applies both to encrypted backends and ones that were upgraded with `autoUpgrade` flag. This allows the backends to advertise preferable alternative backends, using the same mechanism as DDR (`autoUpgrade`), but only via encrypted channels.

[EDSR]: https://datatracker.ietf.org/doc/draft-ietf-add-encrypted-dns-server-redirection/00/

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)

---
>Sponsored by [Quad9](https://quad9.net/)