### PR TITLE
docs: the 1980s called, they want their WKS records back

### DIFF
--- a/docs/dnsupdate.rst
+++ b/docs/dnsupdate.rst
@@ -2,12 +2,7 @@ Dynamic DNS Update (RFC 2136)
 =============================
 
 Starting with the PowerDNS Authoritative Server 3.4.0, DNS update
-support is available. There are a number of items NOT supported:
-
--  There is no support for SIG (TSIG and GSS\*TSIG are supported);
--  WKS records are specifically mentioned in the RFC, we don't
-   specifically care about WKS records;
--  Anything we forgot....
+support is available.
 
 The implementation requires the backend to support a number of new
 operations. Currently, the following backends have been modified to


### PR DESCRIPTION
### Short description
It was still the 1980s when RFC 1123 and 1127 deprecated WKS records. Since 4.8, the Authoritative server no longer recognizes them. Don't bother mentioning them as not supported in DNS update.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
