### PR TITLE
auth 4.9: backport "geoipbackend: create DNSSEC key files with mode 0600"

### DIFF
--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -1073,9 +1073,20 @@ bool GeoIPBackend::addDomainKey(const DNSName& name, const KeyData& key, int64_t
       globfree(&glob_result);
       pathname.str("");
       pathname << getArg("dnssec-keydir") << "/" << dom.domain.toStringNoDot() << "." << key.flags << "." << nextid << "." << (key.active ? "1" : "0") << ".key";
-      ofstream ofs(pathname.str().c_str());
-      ofs.write(key.content.c_str(), key.content.size());
-      ofs.close();
+      auto keyFile = pdns::openFileForWriting(pathname.str(), 0600, true, false);
+      if (!keyFile) {
+        int error = errno;
+        g_log << Logger::Error << "Cannot create key file " << pathname.str() << ": " << stringerror(error) << endl;
+        return false;
+      }
+      if (fwrite(key.content.c_str(), 1, key.content.size(), keyFile.get()) != key.content.size()) {
+        int error = errno;
+        g_log << Logger::Error << "Cannot write key file " << pathname.str() << ": " << stringerror(error) << endl;
+        keyFile.reset();
+        unlink(pathname.str().c_str());
+        return false;
+      }
+      keyFile.reset();
       id = nextid;
       return true;
     }

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1757,4 +1757,28 @@ std::optional<std::string> visit_directory(const std::string& directory, const s
 
   return std::nullopt;
 }
+
+UniqueFilePtr openFileForWriting(const std::string& filePath, mode_t permissions, bool mustNotExist, bool appendIfExists)
+{
+  int flags = O_WRONLY | O_CREAT;
+  if (mustNotExist) {
+    flags |= O_EXCL;
+  }
+  else if (appendIfExists) {
+    flags |= O_APPEND;
+  }
+  int fileDesc = open(filePath.c_str(), flags, permissions);
+  if (fileDesc == -1) {
+    return UniqueFilePtr(nullptr);
+  }
+  auto filePtr = pdns::UniqueFilePtr(fdopen(fileDesc, appendIfExists ? "a" : "w"));
+  if (!filePtr) {
+    auto error = errno;
+    close(fileDesc);
+    errno = error;
+    return UniqueFilePtr(nullptr);
+  }
+  return filePtr;
+}
+
 }

--- a/pdns/misc.hh
+++ b/pdns/misc.hh
@@ -836,4 +836,22 @@ private:
 namespace pdns
 {
 [[nodiscard]] std::optional<std::string> visit_directory(const std::string& directory, const std::function<bool(ino_t inodeNumber, const std::string_view& name)>& visitor);
+
+struct FilePtrDeleter
+{
+  /* using a deleter instead of decltype(&fclose) has two big advantages:
+     - the deleter is included in the type and does not have to be passed
+       when creating a new object (easier to use, less memory usage, in theory
+       better inlining)
+     - we avoid the annoying "ignoring attributes on template argument ‘int (*)(FILE*)’"
+       warning from the compiler, which is there because fclose is tagged as __nonnull((1))
+  */
+  void operator()(FILE* filePtr) const noexcept {
+    fclose(filePtr);
+  }
+};
+
+using UniqueFilePtr = std::unique_ptr<FILE, FilePtrDeleter>;
+
+UniqueFilePtr openFileForWriting(const std::string& filePath, mode_t permissions, bool mustNotExist = true, bool appendIfExists = false);
 }


### PR DESCRIPTION
### Short description
Backport of #17824. I also had to backport a subset of the commit introducing `pdns::openFileForWriting()` (b1564d45616abcd65bf606fa5816449bde41af3e)
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
