### PR TITLE
auth 5.1: backport "geoipbackend: create DNSSEC key files with mode 0600"

### DIFF
--- a/modules/geoipbackend/geoipbackend.cc
+++ b/modules/geoipbackend/geoipbackend.cc
@@ -1135,9 +1135,22 @@ bool GeoIPBackend::addDomainKey(const ZoneName& name, const KeyData& key, int64_
       globfree(&glob_result);
       pathname.str("");
       pathname << getArg("dnssec-keydir") << "/" << dom.domain.toStringNoDot() << "." << key.flags << "." << nextid << "." << (key.active ? "1" : "0") << ".key";
-      ofstream ofs(pathname.str().c_str());
-      ofs.write(key.content.c_str(), key.content.size());
-      ofs.close();
+      auto keyFile = pdns::openFileForWriting(pathname.str(), 0600, true, false);
+      if (!keyFile) {
+        int error = errno;
+        SLOG(g_log << Logger::Error << "Cannot create key file " << pathname.str() << ": " << stringerror(error) << endl,
+             d_slog->error(Logr::Error, stringerror(error), "Cannot create key file", "file", Logging::Loggable(pathname.str())));
+        return false;
+      }
+      if (fwrite(key.content.c_str(), 1, key.content.size(), keyFile.get()) != key.content.size()) {
+        int error = errno;
+        SLOG(g_log << Logger::Error << "Cannot write key file " << pathname.str() << ": " << stringerror(error) << endl,
+             d_slog->error(Logr::Error, stringerror(error), "Cannot write key file", "file", Logging::Loggable(pathname.str())));
+        keyFile.reset();
+        unlink(pathname.str().c_str());
+        return false;
+      }
+      keyFile.reset();
       keyId = nextid;
       return true;
     }


### PR DESCRIPTION
### Short description
Backport of #17824.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
