### PR TITLE
Backport 17786 to rec 5.3.x: fix disabling algo 8 also disables DS digest 2

### DIFF
--- a/pdns/dnssecinfra.cc
+++ b/pdns/dnssecinfra.cc
@@ -604,7 +604,9 @@ bool DNSCryptoKeyEngine::isDigestSupported(uint8_t digest)
 {
   try {
     unsigned int algo = digestToAlgorithmNumber(digest);
-    return isAlgorithmSupported(algo);
+    const makers_t& makers = getMakers();
+    auto iter = makers.find(algo);
+    return iter != makers.cend();
   }
   catch(const std::exception& e) {
     return false;


### PR DESCRIPTION
Fixes #17772 in a quick and dirty way.

Proper fix should separate algo handling and digest handling, as more than one algo can use the same digest.


(cherry picked from commit fe26a2527e3f4efd7b3318d6d9efa088738bfb88)

Backport of #17786

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
