### PR TITLE
auth 5.1: backport "iputils: do not index past the address for byte-aligned prefixes"

### DIFF
--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -385,6 +385,11 @@ void ComboAddress::truncate(unsigned int bits) noexcept
   memset(start + len - tozero / 8, 0, tozero / 8); // blot out the whole bytes on the right NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 
   auto bitsleft = tozero % 8; // 2 bits left to clear
+  if (bitsleft == 0) {
+    // the memset() above cleared whole bytes only, and for 0 bits the byte we
+    // would look at is the one before the address
+    return;
+  }
 
   // a b c d, to truncate to 22 bits, we just zeroed 'd' and need to zero 2 bits from c
   // so and by '11111100', which is ~((1<<2)-1)  = ~3

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -808,6 +808,11 @@ public:
       }
       // still here, now match remaining bits
       uint8_t bits = d_bits % 8;
+      if (bits == 0) {
+        // no partial byte left to match, and lhs[index] would be one past the
+        // address for a /128
+        return true;
+      }
       auto mask = static_cast<uint8_t>(~(0xFF >> bits));
 
       return ((lhs[index]) == (rhs[index] & mask));

--- a/pdns/test-iputils_hh.cc
+++ b/pdns/test-iputils_hh.cc
@@ -183,6 +183,19 @@ BOOST_AUTO_TEST_CASE(test_ComboAddressTruncate) {
   ca6.truncate(8);
   BOOST_CHECK_EQUAL(ca6.toString(), "2000::");
 
+  /* truncating to 0 bits leaves no partial byte, so nothing before the address
+     may be touched */
+  ca4 = ComboAddress("130.161.252.29", 53);
+  ca4.truncate(0);
+  BOOST_CHECK_EQUAL(ca4.toString(), "0.0.0.0");
+  BOOST_CHECK_EQUAL(ca4.sin4.sin_port, htons(53));
+
+  ca6 = ComboAddress("2001:888:2000:1d::2", 53);
+  ca6.sin6.sin6_flowinfo = htonl(0x0badcafe);
+  ca6.truncate(0);
+  BOOST_CHECK_EQUAL(ca6.toString(), "::");
+  BOOST_CHECK_EQUAL(ca6.sin6.sin6_flowinfo, htonl(0x0badcafe));
+
 
   orig=ca6=ComboAddress("2001:888:2000:1d::2");
   for(int n=128; n; --n) {
@@ -256,6 +269,16 @@ BOOST_AUTO_TEST_CASE(test_Netmask) {
   Netmask nmp6("fe80::92fb:a6ff:fe4a:51da/128");
   BOOST_CHECK(nmp6.match("fe80::92fb:a6ff:fe4a:51da"));
   BOOST_CHECK(!nmp6.match("fe81::92fb:a6ff:fe4a:51db"));
+
+  /* a /128 leaves no partial byte to compare, so the scope id sitting right
+     after the address must not be taken into account */
+  ComboAddress scoped("fe80::92fb:a6ff:fe4a:51da");
+  scoped.sin6.sin6_scope_id = 1;
+  Netmask nmscoped(scoped);
+  BOOST_CHECK_EQUAL(nmscoped.getBits(), 128);
+  BOOST_CHECK(nmscoped.match(scoped));
+  BOOST_CHECK(nmscoped.match("fe80::92fb:a6ff:fe4a:51da"));
+  BOOST_CHECK(!nmscoped.match("fe80::92fb:a6ff:fe4a:51db"));
 
   Netmask all("0.0.0.0/0");
   BOOST_CHECK(all.match(local) && all.match(remote));


### PR DESCRIPTION
### Short description
Backport of #17835.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
