### PR TITLE
Backport 17157 to rec-5.4.x: Fix DNAME interaction with aggressive use of NSEC3

### DIFF
--- a/pdns/recursordist/aggressive_nsec.cc
+++ b/pdns/recursordist/aggressive_nsec.cc
@@ -662,6 +662,20 @@ bool AggressiveNSECCache::getNSEC3Denial(time_t now, std::shared_ptr<LockGuarded
         return false;
       }
 
+      if (nsec3->isSet(QType::DNAME)) {
+        /* rfc6672 section 5.3.2: DNAME Bit in NSEC Type Map
+
+           In any negative response, the NSEC or NSEC3 [RFC5155] record type
+           bitmap SHOULD be checked to see that there was no DNAME that could
+           have been applied.  If the DNAME bit in the type bitmap is set and
+           the query name is a subdomain of the closest encloser that is
+           asserted, then DNAME substitution should have been done, but the
+           substitution has not been done as specified.
+        */
+        VLOG_NO_PREFIX(log, " but this NSEC3 has the DNAME bit set");
+        return false;
+      }
+
       found = true;
       break;
     }

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -2111,4 +2111,166 @@ BOOST_AUTO_TEST_CASE(test_aggressive_max_nsec3_hash_cost)
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec_dname)
+{
+  auto cache = make_unique<AggressiveNSECCache>(10000);
+  g_recCache = std::make_unique<MemRecursorCache>();
+
+  const DNSName zone("powerdns.com");
+  time_t now = time(nullptr);
+
+  /* first we need a SOA */
+  std::vector<DNSRecord> records;
+  time_t ttd = now + 30;
+  DNSRecord drSOA;
+  drSOA.d_name = zone;
+  drSOA.d_type = QType::SOA;
+  drSOA.d_class = QClass::IN;
+  drSOA.setContent(std::make_shared<SOARecordContent>("pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600"));
+  drSOA.d_ttl = static_cast<uint32_t>(ttd); // XXX truncation
+  drSOA.d_place = DNSResourceRecord::ANSWER;
+  records.push_back(drSOA);
+
+  g_recCache->replace(now, zone, QType(QType::SOA), records, {}, {}, true, zone, std::nullopt, MemRecursorCache::NOTAG, vState::Secure);
+  BOOST_CHECK_EQUAL(g_recCache->size(), 1U);
+
+  {
+    cache = make_unique<AggressiveNSECCache>(10000);
+    DNSName name("powerdns.com");
+    DNSRecord rec;
+    rec.d_name = name;
+    rec.d_type = QType::NSEC;
+    rec.d_ttl = now + 10;
+
+    NSECRecordContent nrc;
+    nrc.d_next = DNSName("z.powerdns.com");
+    for (const auto& type : {QType::DNAME}) {
+      nrc.set(type);
+    }
+
+    rec.setContent(std::make_shared<NSECRecordContent>(nrc));
+    auto rrsig = std::make_shared<RRSIGRecordContent>("NSEC 5 3 10 20370101000000 20370101000000 24567 sub.powerdns.com. data");
+    cache->insertNSEC(zone, rec.d_name, rec, {rrsig}, false);
+
+    BOOST_CHECK_EQUAL(cache->getEntriesCount(), 1U);
+
+    /* the cache should NOT be able to deny anything below powerdns.com */
+    BOOST_CHECK_EQUAL(getDenialWrapper(cache, now, DNSName("www.powerdns.com"), QType::A), false);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_dname)
+{
+  auto cache = make_unique<AggressiveNSECCache>(10000);
+  g_recCache = std::make_unique<MemRecursorCache>();
+
+  const DNSName zone("powerdns.com");
+  time_t now = time(nullptr);
+
+  /* first we need a SOA */
+  std::vector<DNSRecord> records;
+  time_t ttd = now + 30;
+  DNSRecord drSOA;
+  drSOA.d_name = zone;
+  drSOA.d_type = QType::SOA;
+  drSOA.d_class = QClass::IN;
+  drSOA.setContent(std::make_shared<SOARecordContent>("pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600"));
+  drSOA.d_ttl = static_cast<uint32_t>(ttd); // XXX truncation
+  drSOA.d_place = DNSResourceRecord::ANSWER;
+  records.push_back(drSOA);
+
+  g_recCache->replace(now, zone, QType(QType::SOA), records, {}, {}, true, zone, std::nullopt, MemRecursorCache::NOTAG, vState::Secure);
+  BOOST_CHECK_EQUAL(g_recCache->size(), 1U);
+
+  const std::string salt("ab");
+  const unsigned int iterationsCount = 1;
+  {
+    cache = make_unique<AggressiveNSECCache>(10000);
+    DNSName closestEncloser("powerdns.com.");
+    DNSName nextCloser("www.powerdns.com.");
+    DNSName wildcard("*.powerdns.com.");
+
+    {
+      /* closest encloser */
+      std::string hashed = hashQNameWithSalt(salt, iterationsCount, closestEncloser);
+      DNSRecord rec;
+      rec.d_name = DNSName(toBase32Hex(hashed)) + zone;
+      rec.d_type = QType::NSEC3;
+      rec.d_ttl = now + 10;
+
+      NSEC3RecordContent nrc;
+      nrc.d_algorithm = 1;
+      nrc.d_flags = 0;
+      nrc.d_iterations = iterationsCount;
+      nrc.d_salt = salt;
+      nrc.d_nexthash = hashed;
+      incrementHash(nrc.d_nexthash);
+      for (const auto& type : {QType::DNAME}) {
+        nrc.set(type);
+      }
+
+      rec.setContent(std::make_shared<NSEC3RecordContent>(nrc));
+      auto rrsig = std::make_shared<RRSIGRecordContent>("NSEC3 5 3 10 20370101000000 20370101000000 24567 powerdns.com. data");
+      cache->insertNSEC(zone, rec.d_name, rec, {rrsig}, true);
+    }
+
+    {
+      /* next closer */
+      std::string hashed = hashQNameWithSalt(salt, iterationsCount, nextCloser);
+      auto before = hashed;
+      decrementHash(before);
+      DNSRecord rec;
+      rec.d_name = DNSName(toBase32Hex(before)) + zone;
+      rec.d_type = QType::NSEC3;
+      rec.d_ttl = now + 10;
+
+      NSEC3RecordContent nrc;
+      nrc.d_algorithm = 1;
+      nrc.d_flags = 0;
+      nrc.d_iterations = iterationsCount;
+      nrc.d_salt = salt;
+      nrc.d_nexthash = hashed;
+      incrementHash(nrc.d_nexthash);
+      for (const auto& type : {QType::A}) {
+        nrc.set(type);
+      }
+
+      rec.setContent(std::make_shared<NSEC3RecordContent>(nrc));
+      auto rrsig = std::make_shared<RRSIGRecordContent>("NSEC3 5 3 10 20370101000000 20370101000000 24567 powerdns.com. data");
+      cache->insertNSEC(zone, rec.d_name, rec, {rrsig}, true);
+    }
+
+    {
+      /* wildcard */
+      std::string hashed = hashQNameWithSalt(salt, iterationsCount, wildcard);
+      auto before = hashed;
+      decrementHash(before);
+      DNSRecord rec;
+      rec.d_name = DNSName(toBase32Hex(before)) + zone;
+      rec.d_type = QType::NSEC3;
+      rec.d_ttl = now + 10;
+
+      NSEC3RecordContent nrc;
+      nrc.d_algorithm = 1;
+      nrc.d_flags = 0;
+      nrc.d_iterations = iterationsCount;
+      nrc.d_salt = salt;
+      nrc.d_nexthash = hashed;
+      incrementHash(nrc.d_nexthash);
+      for (const auto& type : {QType::A}) {
+        nrc.set(type);
+      }
+
+      rec.setContent(std::make_shared<NSEC3RecordContent>(nrc));
+      auto rrsig = std::make_shared<RRSIGRecordContent>("NSEC3 5 3 10 20370101000000 20370101000000 24567 powerdns.com. data");
+      cache->insertNSEC(zone, rec.d_name, rec, {rrsig}, true);
+    }
+
+    BOOST_CHECK_EQUAL(cache->getEntriesCount(), 3U);
+
+    /* the cache should NOT be able to deny anything below powerdns.com */
+    BOOST_CHECK_EQUAL(getDenialWrapper(cache, now, DNSName("www.powerdns.com."), QType::A), false);
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/pdns/recursordist/test-aggressive_nsec_cc.cc
+++ b/pdns/recursordist/test-aggressive_nsec_cc.cc
@@ -2163,6 +2163,7 @@ BOOST_AUTO_TEST_CASE(test_aggressive_nsec3_dname)
 {
   auto cache = make_unique<AggressiveNSECCache>(10000);
   g_recCache = std::make_unique<MemRecursorCache>();
+  AggressiveNSECCache::s_maxNSEC3CommonPrefix = 200;
 
   const DNSName zone("powerdns.com");
   time_t now = time(nullptr);


### PR DESCRIPTION
rfc6672 section 5.3.2 "DNAME Bit in NSEC Type Map":

In any negative response, the NSEC or NSEC3 [RFC5155] record type bitmap SHOULD be checked to see that there was no DNAME that could have been applied. If the DNAME bit in the type bitmap is set and the query name is a subdomain of the closest encloser that is asserted, then DNAME substitution should have been done, but the substitution has not been done as specified.


(cherry picked from commit bf64487523c19df2834c6def15585bd9abeef229)

Backport of #17157

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
