### PR TITLE
Backport 17156 to rec 5.4.x: Fix DNSSEC validation of wildcard-expanded proof

### DIFF
--- a/pdns/recursordist/syncres.cc
+++ b/pdns/recursordist/syncres.cc
@@ -5015,7 +5015,7 @@ void SyncRes::checkWildcardProof(const DNSName& qname, const QType& qtype, DNSRe
 
     if (recordState == vState::Secure) {
       /* We have a positive answer synthesized from a wildcard, we need to check that we have
-         proof that the exact name doesn't exist so the wildcard can be used,
+         proof that the next closer doesn't exist so the wildcard can be used,
          as described in section 5.3.4 of RFC 4035 and 5.3 of RFC 7129.
       */
       cspmap_t csp = harvestCSPFromNE(negEntry);

--- a/pdns/recursordist/test-syncres_cc5.cc
+++ b/pdns/recursordist/test-syncres_cc5.cc
@@ -947,6 +947,117 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard)
   BOOST_CHECK_EQUAL(queriesCount, 6U);
 }
 
+BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_does_not_deny_next_closer)
+{
+  std::unique_ptr<SyncRes> sr;
+  initSR(sr, true, true);
+
+  setDNSSECValidation(sr, DNSSECMode::ValidateAll);
+
+  primeHints();
+  const DNSName target("a.b.powerdns.com.");
+  testkeysset_t keys;
+
+  auto luaconfsCopy = g_luaconfs.getCopy();
+  luaconfsCopy.dsAnchors.clear();
+  generateKeyMaterial(g_rootdnsname, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys, luaconfsCopy.dsAnchors);
+  generateKeyMaterial(DNSName("com."), DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
+  generateKeyMaterial(DNSName("powerdns.com."), DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
+
+  g_luaconfs.setState(luaconfsCopy);
+
+  size_t queriesCount = 0;
+
+  sr->setAsyncCallback([&](const ComboAddress& address, const DNSName& domain, int type, bool /* doTCP */, bool /* sendRDQuery */, int /* EDNS0Level */, struct timeval* /* now */, std::optional<Netmask>& /* srcmask */, const ResolveContext& /* context */, LWResult* res, bool* /* chained */) {
+    queriesCount++;
+
+    if (type == QType::DS || type == QType::DNSKEY) {
+      if (type == QType::DS && domain == target) {
+        setLWResult(res, RCode::NoError, true, false, true);
+        addRecordToLW(res, DNSName("powerdns.com."), QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com."), 300);
+        addNSECRecordToLW(DNSName("www.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
+        addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+        return LWResult::Result::Success;
+      }
+      return genericDSAndDNSKEYHandler(res, domain, domain, type, keys);
+    }
+    {
+      if (isRootServer(address)) {
+        setLWResult(res, 0, false, false, true);
+        addRecordToLW(res, "com.", QType::NS, "a.gtld-servers.com.", DNSResourceRecord::AUTHORITY, 3600);
+        addDS(DNSName("com."), 300, res->d_records, keys);
+        addRRSIG(keys, res->d_records, DNSName("."), 300);
+        addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+        return LWResult::Result::Success;
+      }
+      if (address == ComboAddress("192.0.2.1:53")) {
+        if (domain == DNSName("com.")) {
+          setLWResult(res, 0, true, false, true);
+          addRecordToLW(res, domain, QType::NS, "a.gtld-servers.com.");
+          addRRSIG(keys, res->d_records, domain, 300);
+          addRecordToLW(res, "a.gtld-servers.com.", QType::A, "192.0.2.1", DNSResourceRecord::ADDITIONAL, 3600);
+          addRRSIG(keys, res->d_records, domain, 300);
+        }
+        else {
+          setLWResult(res, 0, false, false, true);
+          addRecordToLW(res, "powerdns.com.", QType::NS, "ns1.powerdns.com.", DNSResourceRecord::AUTHORITY, 3600);
+          addDS(DNSName("powerdns.com."), 300, res->d_records, keys);
+          addRRSIG(keys, res->d_records, DNSName("com."), 300);
+          addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
+        }
+        return LWResult::Result::Success;
+      }
+      if (address == ComboAddress("192.0.2.2:53")) {
+        setLWResult(res, 0, true, false, true);
+        if (type == QType::NS) {
+          if (domain == DNSName("powerdns.com.")) {
+            addRecordToLW(res, domain, QType::NS, "ns1.powerdns.com.");
+            addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+            addRecordToLW(res, "ns1.powerdns.com.", QType::A, "192.0.2.2", DNSResourceRecord::ADDITIONAL, 3600);
+            addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+          }
+          else {
+            addRecordToLW(res, domain, QType::SOA, "pdns-public-ns1.powerdns.com. pieter\\.lexis.powerdns.com. 2017032301 10800 3600 604800 3600", DNSResourceRecord::AUTHORITY, 3600);
+            addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+            addNSECRecordToLW(DNSName("www.powerdns.com."), DNSName("wwz.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 600, res->d_records);
+            addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+          }
+        }
+        else {
+          addRecordToLW(res, domain, QType::A, "192.0.2.42", DNSResourceRecord::ANSWER, 600);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300, false, std::nullopt, DNSName("*.powerdns.com"));
+          /* we need to add the proof that this name does not exist, so the wildcard may apply */
+          addNSECRecordToLW(DNSName("b.powerdns.com."), DNSName("c.powerdns.com."), {QType::A, QType::NSEC, QType::RRSIG}, 60, res->d_records);
+          addRRSIG(keys, res->d_records, DNSName("powerdns.com"), 300);
+        }
+        return LWResult::Result::Success;
+      }
+    }
+
+    return LWResult::Result::Timeout;
+  });
+
+  vector<DNSRecord> ret;
+  int res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusInvalidDenial);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  BOOST_CHECK_EQUAL(queriesCount, 6U);
+
+  /* again, to test the cache */
+  ret.clear();
+  res = sr->beginResolve(target, QType(QType::A), QClass::IN, ret);
+  BOOST_CHECK_EQUAL(res, RCode::NoError);
+  BOOST_CHECK_EQUAL(sr->getValidationState(), vState::BogusInvalidDenial);
+  BOOST_REQUIRE_EQUAL(ret.size(), 4U);
+  for (const auto& rec : ret) {
+    /* check that we applied the lowest TTL, here this is from the NSEC proving that the exact name did not exist */
+    BOOST_CHECK_LE(rec.d_ttl, 60U);
+  }
+  BOOST_CHECK_EQUAL(queriesCount, 6U);
+}
+
 BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_proof_before_rrsig)
 {
   /* this tests makes sure that we correctly detect that we need to gather

--- a/pdns/recursordist/test-syncres_cc5.cc
+++ b/pdns/recursordist/test-syncres_cc5.cc
@@ -950,7 +950,7 @@ BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard)
 BOOST_AUTO_TEST_CASE(test_dnssec_validation_nsec_wildcard_does_not_deny_next_closer)
 {
   std::unique_ptr<SyncRes> sr;
-  initSR(sr, true, true);
+  initSR(sr, true);
 
   setDNSSECValidation(sr, DNSSECMode::ValidateAll);
 

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -555,10 +555,10 @@ BOOST_AUTO_TEST_CASE(test_nsec_expanded_wildcard_proof)
   sortedRecords_t recordContents;
   vector<shared_ptr<const RRSIGRecordContent>> signatureContents;
 
-  /* proves that a.example.com does exist, and has been generated from a wildcard (see the RRSIG below) */
+  /* proves that b.example.com does NOT exist, and the answer has been generated from a wildcard (see the RRSIG below) */
   addNSECRecordToLW(DNSName("a.example.org."), DNSName("d.example.org"), {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, records);
   recordContents.insert(records.at(0).getContent());
-  addRRSIG(keys, records, DNSName("example.org."), 300, false, std::nullopt, DNSName("example.org."));
+  addRRSIG(keys, records, DNSName("example.org."), 300, false);
   signatureContents.push_back(getRR<RRSIGRecordContent>(records.at(1)));
   records.clear();
 
@@ -570,8 +570,39 @@ BOOST_AUTO_TEST_CASE(test_nsec_expanded_wildcard_proof)
 
   /* This is an expanded wildcard proof, meaning that it does prove that the exact name
      does not exist so the wildcard can apply */
-  dState denialState = getDenial(denialMap, DNSName("a.example.org."), QType(0).getCode(), false, false, std::nullopt, false, /* normally retrieved from the RRSIG's d_labels */ 2);
+  dState denialState = getDenial(denialMap, DNSName("b.example.org."), QType(0).getCode(), false, false, std::nullopt, false, /* normally retrieved from the RRSIG's d_labels */ 2);
   BOOST_CHECK_EQUAL(denialState, dState::NXDOMAIN);
+}
+
+BOOST_AUTO_TEST_CASE(test_nsec_expanded_wildcard_proof_missing_next_closer)
+{
+  initSR(true);
+
+  testkeysset_t keys;
+  generateKeyMaterial(DNSName("example.org."), DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
+
+  vector<DNSRecord> records;
+
+  sortedRecords_t recordContents;
+  vector<shared_ptr<const RRSIGRecordContent>> signatureContents;
+
+  /* proves that a.b.example.com does not exist, and the answer has been generated from a wildcard (see the RRSIG below) */
+  addNSECRecordToLW(DNSName("b.example.org."), DNSName("c.example.org"), {QType::A, QType::TXT, QType::RRSIG, QType::NSEC}, 600, records);
+  recordContents.insert(records.at(0).getContent());
+  addRRSIG(keys, records, DNSName("example.org."), 300, false);
+  signatureContents.push_back(getRR<RRSIGRecordContent>(records.at(1)));
+  records.clear();
+
+  ContentSigPair pair;
+  pair.records = recordContents;
+  pair.signatures = signatureContents;
+  cspmap_t denialMap;
+  denialMap[std::pair(DNSName("b.example.org."), QType::NSEC)] = pair;
+
+  /* This is an expanded wildcard proof, meaning that it does prove that the exact name
+     does not exist so the wildcard might apply EXCEPT the next closer does exist! */
+  dState denialState = getDenial(denialMap, DNSName("a.b.example.org."), QType(0).getCode(), false, false, std::nullopt, false, /* normally retrieved from the RRSIG's d_labels */ 2);
+  BOOST_CHECK_EQUAL(denialState, dState::NXQTYPE);
 }
 
 BOOST_AUTO_TEST_CASE(test_nsec_wildcard_with_cname)

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -561,13 +561,13 @@ dState matchesNSEC(const DNSName& name, uint16_t qtype, const DNSName& nsecOwner
   - If `wantsNoDataProof` is set but a NSEC proves that the whole name does not exist, the function will return
   NXQTYPE if the name is proven to be ENT and NXDOMAIN otherwise.
   - If `needWildcardProof` is false, the proof that a wildcard covering this qname|qtype is not checked. It is
-  useful when we have a positive answer synthesized from a wildcard and we only need to prove that the exact
-  name does not exist.
+  useful when we have a positive answer synthesized from a wildcard and we only need to prove that the next closer
+  does not exist.
 */
 dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16_t qtype, bool referralToUnsigned, bool wantsNoDataProof, pdns::validation::ValidationContext& context, const OptLog& log, bool needWildcardProof, unsigned int wildcardLabelsCount) // NOLINT(readability-function-cognitive-complexity): https://github.com/PowerDNS/pdns/issues/12791
 {
   bool nsec3Seen = false;
-  if (!needWildcardProof && wildcardLabelsCount == 0) {
+  if ((!needWildcardProof && wildcardLabelsCount == 0) || wildcardLabelsCount > qname.countLabels()) {
     throw PDNSException("Invalid wildcard labels count for the validation of a positive answer synthesized from a wildcard");
   }
 
@@ -589,10 +589,25 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
           continue;
         }
 
+        DNSName nameToDeny;
+        if (!needWildcardProof) {
+          /* we are trying to prove that a wildcard can apply, so in effect we need to prove that the
+             next closer does not exist: the next closer can be different from the qname,
+             and can prevent the wildcard from applying.
+          */
+          nameToDeny = qname;
+          const auto chopCount = nameToDeny.countLabels() - wildcardLabelsCount - 1;
+          for (size_t idx = 0; idx < chopCount; ++idx) {
+            nameToDeny.chopOff();
+          }
+        }
+        else {
+          nameToDeny = qname;
+        }
         const DNSName owner = getNSECOwnerName(validset.first.first, validset.second.signatures);
         const DNSName signer = getSigner(validset.second.signatures);
-        if (!validset.first.first.isPartOf(signer) || !owner.isPartOf(signer) || !qname.isPartOf(signer)) {
-           continue;
+        if (!validset.first.first.isPartOf(signer) || !owner.isPartOf(signer) || !nameToDeny.isPartOf(signer)) {
+          continue;
         }
 
         /* The NSEC is either a delegation one, from the parent zone, and
@@ -601,7 +616,7 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
          */
         const bool notApex = signer.countLabels() < owner.countLabels();
         if (notApex && nsec->isSet(QType::NS) && nsec->isSet(QType::SOA)) {
-          VLOG(log, qname << ": However, that NSEC is not at the apex and has both the NS and the SOA bits set!"<<endl);
+          VLOG(log, nameToDeny << ": However, that NSEC is not at the apex and has both the NS and the SOA bits set!" << endl);
           continue;
         }
 
@@ -611,27 +626,27 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
            that (original) owner name other than DS RRs, and all RRs below that
            owner name regardless of type.
         */
-        if (qname.isPartOf(owner) && isNSECAncestorDelegation(signer, owner, *nsec)) {
+        if (nameToDeny.isPartOf(owner) && isNSECAncestorDelegation(signer, owner, *nsec)) {
           /* this is an "ancestor delegation" NSEC RR */
-          if (qtype != QType::DS || qname != owner) {
-            VLOG(log, qname << ": An ancestor delegation NSEC RR can only deny the existence of a DS"<<endl);
+          if (qtype != QType::DS || nameToDeny != owner) {
+            VLOG(log, nameToDeny << ": An ancestor delegation NSEC RR can only deny the existence of a DS" << endl);
             return dState::NODENIAL;
           }
         }
 
-        if (qtype == QType::DS && !qname.isRoot() && signer == qname) {
-          VLOG(log, qname << ": A NSEC RR from the child zone cannot deny the existence of a DS"<<endl);
+        if (qtype == QType::DS && !nameToDeny.isRoot() && signer == nameToDeny) {
+          VLOG(log, nameToDeny << ": A NSEC RR from the child zone cannot deny the existence of a DS" << endl);
           continue;
         }
 
         /* check if the type is denied */
-        if (qname == owner) {
+        if (nameToDeny == owner) {
           if (!isTypeDenied(*nsec, QType(qtype))) {
-            VLOG(log, qname << ": Does _not_ deny existence of type "<<QType(qtype)<<endl);
+            VLOG(log, nameToDeny << ": Does _not_ deny existence of type " << QType(qtype) << endl);
             return dState::NODENIAL;
           }
 
-          VLOG(log, qname << ": Denies existence of type "<<QType(qtype)<<endl);
+          VLOG(log, nameToDeny << ": Denies existence of type " << QType(qtype) << endl);
 
           /*
            * RFC 4035 Section 2.3:
@@ -641,7 +656,7 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
            */
           if (referralToUnsigned && qtype == QType::DS) {
             if (!nsec->isSet(QType::NS)) {
-              VLOG(log, qname << ": However, no NS record exists at this level!"<<endl);
+              VLOG(log, nameToDeny << ": However, no NS record exists at this level!" << endl);
               return dState::NODENIAL;
             }
           }
@@ -657,16 +672,16 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
             return dState::NXQTYPE;
           }
 
-          DNSName closestEncloser = getClosestEncloserFromNSEC(qname, owner, nsec->d_next);
-          if (provesNoWildCard(qname, qtype, closestEncloser, validrrsets, log)) {
+          DNSName closestEncloser = getClosestEncloserFromNSEC(nameToDeny, owner, nsec->d_next);
+          if (provesNoWildCard(nameToDeny, qtype, closestEncloser, validrrsets, log)) {
             return dState::NXQTYPE;
           }
 
-          VLOG(log, qname << ": But the existence of a wildcard is not denied for "<<qname<<"/"<<endl);
+          VLOG(log, nameToDeny << ": But the existence of a wildcard is not denied for " << nameToDeny << "/" << endl);
           return dState::NODENIAL;
         }
 
-        if (qname.isPartOf(owner) && nsec->isSet(QType::DNAME)) {
+        if (nameToDeny.isPartOf(owner) && nsec->isSet(QType::DNAME)) {
           /* rfc6672 section 5.3.2: DNAME Bit in NSEC Type Map
 
              In any negative response, the NSEC or NSEC3 [RFC5155] record type
@@ -676,23 +691,23 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
              asserted, then DNAME substitution should have been done, but the
              substitution has not been done as specified.
           */
-          VLOG(log, qname << ": The DNAME bit is set and the query name is a subdomain of that NSEC"<< endl);
+          VLOG(log, nameToDeny << ": The DNAME bit is set and the query name is a subdomain of that NSEC" << endl);
           return dState::NODENIAL;
         }
 
         /* check if the whole NAME is denied existing */
-        if (isCoveredByNSEC(qname, owner, nsec->d_next)) {
-          VLOG(log, qname<< ": Is covered by ("<<owner<<" to "<<nsec->d_next<<") ");
+        if (isCoveredByNSEC(nameToDeny, owner, nsec->d_next)) {
+          VLOG(log, nameToDeny << ": Is covered by (" << owner << " to " << nsec->d_next << ") ");
 
-          if (nsecProvesENT(qname, owner, nsec->d_next)) {
+          if (nsecProvesENT(nameToDeny, owner, nsec->d_next)) {
             if (wantsNoDataProof) {
               /* if the name is an ENT and we received a NODATA answer,
                  we are fine with a NSEC proving that the name does not exist. */
-              VLOG_NO_PREFIX(log, "Denies existence of type "<<qname<<"/"<<QType(qtype)<<" by proving that "<<qname<<" is an ENT"<<endl);
+              VLOG_NO_PREFIX(log, "Denies existence of type " << nameToDeny << "/" << QType(qtype) << " by proving that " << nameToDeny << " is an ENT" << endl);
               return dState::NXQTYPE;
             }
             /* but for a NXDOMAIN proof, this doesn't make sense! */
-            VLOG_NO_PREFIX(log, "but it tries to deny the existence of "<<qname<<" by proving that "<<qname<<" is an ENT, this does not make sense!"<<endl);
+            VLOG_NO_PREFIX(log, "but it tries to deny the existence of " << nameToDeny << " by proving that " << nameToDeny << " is an ENT, this does not make sense!" << endl);
             return dState::NODENIAL;
           }
 
@@ -702,25 +717,25 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
           }
 
           VLOG_NO_PREFIX(log, "but we do need a wildcard proof so ");
-          DNSName closestEncloser = getClosestEncloserFromNSEC(qname, owner, nsec->d_next);
+          DNSName closestEncloser = getClosestEncloserFromNSEC(nameToDeny, owner, nsec->d_next);
           if (wantsNoDataProof) {
-            VLOG_NO_PREFIX(log, "looking for NODATA proof"<<endl);
-            if (provesNoDataWildCard(qname, qtype, closestEncloser, validrrsets, log)) {
+            VLOG_NO_PREFIX(log, "looking for NODATA proof" << endl);
+            if (provesNoDataWildCard(nameToDeny, qtype, closestEncloser, validrrsets, log)) {
               return dState::NXQTYPE;
             }
           }
           else {
-            VLOG_NO_PREFIX(log, "looking for NO wildcard proof"<<endl);
-            if (provesNoWildCard(qname, qtype, closestEncloser, validrrsets, log)) {
+            VLOG_NO_PREFIX(log, "looking for NO wildcard proof" << endl);
+            if (provesNoWildCard(nameToDeny, qtype, closestEncloser, validrrsets, log)) {
               return dState::NXDOMAIN;
             }
           }
 
-          VLOG(log, qname << ": But the existence of a wildcard is not denied for "<<qname<<"/"<<endl);
+          VLOG(log, nameToDeny << ": But the existence of a wildcard is not denied for " << nameToDeny << "/" << endl);
           return dState::NODENIAL;
         }
 
-        VLOG(log, qname << ": Did not deny existence of "<<QType(qtype)<<", "<<validset.first.first<<"?="<<qname<<", "<<nsec->isSet(qtype)<<", next: "<<nsec->d_next<<endl);
+        VLOG(log, nameToDeny << ": Did not deny existence of " << QType(qtype) << ", " << validset.first.first << "?=" << nameToDeny << ", " << nsec->isSet(qtype) << ", next: " << nsec->d_next << endl);
       }
     } else if(validset.first.second==QType::NSEC3) {
       for (const auto& record : validset.second.records) {

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -596,10 +596,7 @@ dState getDenial(const cspmap_t &validrrsets, const DNSName& qname, const uint16
              and can prevent the wildcard from applying.
           */
           nameToDeny = qname;
-          const auto chopCount = nameToDeny.countLabels() - wildcardLabelsCount - 1;
-          for (size_t idx = 0; idx < chopCount; ++idx) {
-            nameToDeny.chopOff();
-          }
+          nameToDeny.trimToLabels(wildcardLabelsCount + 1);
         }
         else {
           nameToDeny = qname;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #17156

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
