### PR TITLE
Backport 17510 to rec-5.3.x: Allow failure for some tests if running on GH, which has bad net often (especially UDP)

### DIFF
--- a/regression-tests.recursor-dnssec/test_ExtendedErrors.py
+++ b/regression-tests.recursor-dnssec/test_ExtendedErrors.py
@@ -5,6 +5,8 @@ import pytest
 
 from recursortests import RecursorTest
 
+
+@pytest.mark.xfail(os.environ.get("GITHUB_ACTIONS") == "true", reason="GH actions have flaky net")
 class ExtendedErrorsTest(RecursorTest):
 
     _confdir = 'ExtendedErrors'
@@ -194,6 +196,7 @@ extended-resolution-errors=yes
         self.assertEqual(res.options[0].otype, 15)
         self.assertEqual(res.options[0], extendederrors.ExtendedErrorOption(10, b'Extra text from Lua!'))
 
+@pytest.mark.xfail(os.environ.get("GITHUB_ACTIONS") == "true", reason="GH actions have flaky net")
 class NoExtendedErrorsTest(RecursorTest):
 
     _confdir = 'NoExtendedErrors'

--- a/regression-tests.recursor-dnssec/test_WellKnown.py
+++ b/regression-tests.recursor-dnssec/test_WellKnown.py
@@ -1,8 +1,10 @@
 import pytest
 import dns
+import os
 from recursortests import RecursorTest
 
 @pytest.mark.external
+@pytest.mark.xfail(os.environ.get("GITHUB_ACTIONS") == "true", reason="GH actions have flaky net")
 class WellKnownTest(RecursorTest):
     _auths_zones = None
     _confdir = 'WellKnown'


### PR DESCRIPTION

(cherry picked from commit 984bb494465cc57357dbae4794381a06e645fb84)

Backport of #17510 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
