### PR TITLE
rec: add unit test and a bit more logging for apex hash label parent impersonation

### DIFF
--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -1217,30 +1217,55 @@ BOOST_AUTO_TEST_CASE(test_nsec3_apex_hash_label_parent_impersonation)
   const unsigned int nbIterations = 10;
 
   DNSName tld("com.");
+  DNSName unrelatedDomain("unrelated-domain.com.");
   DNSName victim("victim.com.");
   // compute the hash of the TLD domain
   std::string hashedTLD = hashQNameWithSalt(salt, nbIterations, tld);
   DNSName attackDomain(DNSName(hashedTLD) + tld);
 
   testkeysset_t keys;
+  generateKeyMaterial(tld, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
   generateKeyMaterial(attackDomain, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
 
+  cspmap_t denialMap;
   vector<DNSRecord> records;
 
-  sortedRecords_t recordContents;
-  vector<shared_ptr<const RRSIGRecordContent>> signatureContents;
-  addNSEC3RecordToLW(attackDomain, hashedTLD, salt, nbIterations, {QType::NS, QType::SOA, QType::RRSIG}, 600, records);
+  {
+    sortedRecords_t recordContents;
+    vector<shared_ptr<const RRSIGRecordContent>> signatureContents;
+    addNSEC3RecordToLW(attackDomain, hashedTLD, salt, nbIterations, {QType::NS, QType::SOA, QType::RRSIG}, 600, records);
 
-  recordContents.insert(records.at(0).getContent());
-  addRRSIG(keys, records, attackDomain, 300);
-  signatureContents.push_back(getRR<RRSIGRecordContent>(records.at(1)));
+    recordContents.insert(records.at(0).getContent());
+    addRRSIG(keys, records, attackDomain, 300);
+    signatureContents.push_back(getRR<RRSIGRecordContent>(records.at(1)));
 
-  ContentSigPair pair;
-  pair.records = recordContents;
-  pair.signatures = signatureContents;
-  cspmap_t denialMap;
-  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
-  records.clear();
+    ContentSigPair pair;
+    pair.records = recordContents;
+    pair.signatures = signatureContents;
+    denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+    records.clear();
+  }
+
+  /* also include one legit NSEC3 from the tld zone, that does not prove
+     that the victim domain does not exist but gets us past the !nsec3Seen
+     gate of our validation code, reaching the closest encloser chase
+  */
+
+  {
+    sortedRecords_t recordContents;
+    vector<shared_ptr<const RRSIGRecordContent>> signatureContents;
+    addNSEC3NarrowRecordToLW(unrelatedDomain, tld, {QType::RRSIG, QType::NSEC3}, 600, records, nbIterations);
+
+    recordContents.insert(records.at(0).getContent());
+    addRRSIG(keys, records, tld, 300);
+    signatureContents.push_back(getRR<RRSIGRecordContent>(records.at(1)));
+
+    ContentSigPair pair;
+    pair.records = recordContents;
+    pair.signatures = signatureContents;
+    denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+    records.clear();
+  }
 
   OptLog log;
   log = {std::string(__PRETTY_FUNCTION__), timeval{}, getLogger()};

--- a/pdns/recursordist/test-syncres_cc8.cc
+++ b/pdns/recursordist/test-syncres_cc8.cc
@@ -1209,6 +1209,48 @@ BOOST_AUTO_TEST_CASE(test_nsec3_ent_opt_out)
   BOOST_CHECK_EQUAL(denialState, dState::OPTOUT);
 }
 
+BOOST_AUTO_TEST_CASE(test_nsec3_apex_hash_label_parent_impersonation)
+{
+  initSR();
+
+  const std::string salt = "deadbeef";
+  const unsigned int nbIterations = 10;
+
+  DNSName tld("com.");
+  DNSName victim("victim.com.");
+  // compute the hash of the TLD domain
+  std::string hashedTLD = hashQNameWithSalt(salt, nbIterations, tld);
+  DNSName attackDomain(DNSName(hashedTLD) + tld);
+
+  testkeysset_t keys;
+  generateKeyMaterial(attackDomain, DNSSEC::ECDSA256, DNSSEC::DIGEST_SHA256, keys);
+
+  vector<DNSRecord> records;
+
+  sortedRecords_t recordContents;
+  vector<shared_ptr<const RRSIGRecordContent>> signatureContents;
+  addNSEC3RecordToLW(attackDomain, hashedTLD, salt, nbIterations, {QType::NS, QType::SOA, QType::RRSIG}, 600, records);
+
+  recordContents.insert(records.at(0).getContent());
+  addRRSIG(keys, records, attackDomain, 300);
+  signatureContents.push_back(getRR<RRSIGRecordContent>(records.at(1)));
+
+  ContentSigPair pair;
+  pair.records = recordContents;
+  pair.signatures = signatureContents;
+  cspmap_t denialMap;
+  denialMap[std::pair(records.at(0).d_name, records.at(0).d_type)] = pair;
+  records.clear();
+
+  OptLog log;
+  log = {std::string(__PRETTY_FUNCTION__), timeval{}, getLogger()};
+
+  pdns::validation::ValidationContext validationContext;
+  validationContext.d_nsec3IterationsRemainingQuota = 100U;
+  /* this NSEC3 is not valid to deny the existence of a sibling domain since it is from the child zone */
+  BOOST_CHECK_EQUAL(getDenial(denialMap, victim, QType::A, false, true, validationContext, log), dState::NODENIAL);
+}
+
 BOOST_AUTO_TEST_CASE(test_dnssec_rrsig_negcache_validity)
 {
   std::unique_ptr<SyncRes> sr;

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -748,7 +748,7 @@ dState getDenial(const cspmap_t& validrrsets, const DNSName& qname, const uint16
         numberOfLabelsOfParentZone = std::min(numberOfLabelsOfParentZone, static_cast<uint8_t>(signer.countLabels()));
 
         if (!qname.isPartOf(signer)) {
-          VLOG(log, qname << ": is not part of the signer (" << signer << ")!" << endl);
+          VLOG(log, qname << ": Qname " << qname << " is not part of the signer " << signer << ", ignoring" << endl);
           continue;
         }
 
@@ -860,6 +860,7 @@ dState getDenial(const cspmap_t& validrrsets, const DNSName& qname, const uint16
             }
 
             if (!closestEncloser.isPartOf(signer)) {
+              VLOG(log, qname << ": Closest encloser " << closestEncloser << " is not part of the signer " << signer << ", ignoring" << endl);
               continue;
             }
 
@@ -970,6 +971,7 @@ dState getDenial(const cspmap_t& validrrsets, const DNSName& qname, const uint16
             }
 
             if (!nextCloser.isPartOf(signer)) {
+              VLOG(log, qname << ": Next closer " << nextCloser << " is not part of the signer " << signer << ", ignoring" << endl);
               continue;
             }
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This was reported by Palo Alto to other vendors and fixed by them in the meantime. We already handled this correctly, so we add a little bit of logging and a unit test just to make sure we keep handling this correctly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [X] added or modified unit test(s)
