### PR TITLE
auth: allow a subset of records to be returned by the API

### DIFF
--- a/docs/backends/generic-sql.rst
+++ b/docs/backends/generic-sql.rst
@@ -238,16 +238,17 @@ queries must return the following fields in order:
 Please note that the names of the fields are not relevant, but the order
 is!
 
--  ``basic-query``: This is the most used query, needed for doing 1:1
-   lookups of qtype/name values.
+-  ``basic-query``: This is the most used query, needed for doing 1:1 lookups of qtype/name values.
 -  ``id-query``: Used for doing lookups within a domain.
+-  ``api-id-query``: Used for doing lookups within a domain from the HTTP API, similar to ``id-query`` above but allowing disabled records to be returned.
 -  ``any-query``: For doing ANY queries. Also used internally.
--  ``any-id-query``: For doing ANY queries within a domain. Also used
-   internally.
--  ``list-query``: For doing AXFRs, lists all records in the zone. Also
-   used internally.
--  ``list-subzone-query``: For doing RFC 2136 DNS Updates, lists all
-   records below a zone.
+-  ``any-id-query``: For doing ANY queries within a domain. Also used internally.
+-  ``api-id-partial-query``: similar to ``api-id-query`` above, but returning a subset of its results.
+-  ``api-any-id-query``: For doing ANY queries within a domain from the HTTP API, similar to ``any-id-query`` above but allowing disabled records to be returned.
+-  ``api-any-id-partial-query``: similar to ``api-any-id-query`` above, but returning a subset of its results.
+-  ``list-query``: For doing AXFRs, lists all records in the zone. Also used internally.
+-  ``list-partial-query``: similar to ``list-query`` above, but returning a subset of its results.
+-  ``list-subzone-query``: For doing RFC 2136 DNS Updates, lists all records below a zone.
 -  ``search-records-query``: To search for records on name and content.
 
 DNSSEC queries

--- a/docs/http-api/openapi/authoritative-api-openapi.yaml
+++ b/docs/http-api/openapi/authoritative-api-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: "0.0.20"
+  version: "0.0.21"
   title: PowerDNS Authoritative HTTP API
   license:
     name: MIT
@@ -649,6 +649,16 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: start
+          in: query
+          description: Used with the "limit" parameter to Limit output to the subset of "limit" records starting at position "start".
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Used with the "start" parameter to Limit output to the subset of "limit" records starting at position "start".
+          schema:
+            type: integer
       responses:
         "200":
           description: A Zone

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -16,6 +16,13 @@ NAPTR additional answers
 
 Since version 5.0, the information of the `a` and `s` NAPTR records are added to the additional answers section. This behaviour can be disabled by setting :ref:`setting-naptr-additional-processing` to `no`.
 
+New SQL queries for partial zone lookups
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Three new queries have been added to the SQL backends, to return subsets of zone contents. These three queries are similar to existing queries, but add "ORDER BY", "LIMIT" and "OFFSET" clauses to the "SELECT" statement, in order to return a subset of the query results.
+
+These three queries, named ``api-id-partial-query``, ``api-any-id-partial-query`` and ``list-partial-query``, supplement the ``api-id-query``, ``api-any-id-query`` and ``list-query`` queries. If you use non-default values for these queries, you might need to add matching "partial" flavours.
+
 5.0.x to 5.1.x
 --------------
 

--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -102,10 +102,17 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=0 and name=?");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=0 and name=? and domain_id=?");
 
-    declare(suffix, "api-id-query", "API basic with ID query", record_query + " (disabled=0 or ?) and type=? and name=? and domain_id=?");
-    declare(suffix, "api-any-id-query", "API any with ID query", record_query + " (disabled=0 or ?) and name=? and domain_id=?");
+    string api_id_query = record_query + " (disabled=0 or ?) and type=? and name=? and domain_id=?";
+    declare(suffix, "api-id-query", "API basic with ID query", api_id_query);
+    string partial_query_suffix = " order by name,type,content limit ? offset ?";
+    declare(suffix, "api-id-partial-query", "API basic with ID query (partial results)", api_id_query + partial_query_suffix);
+    string api_any_id_query = record_query + " (disabled=0 or ?) and name=? and domain_id=?";
+    declare(suffix, "api-any-id-query", "API any with ID query", api_any_id_query);
+    declare(suffix, "api-any-id-partial-query", "API any with ID query (partial results)", api_any_id_query + partial_query_suffix);
 
-    declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=? order by name, type");
+    string list_query = "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR ?) and domain_id=?";
+    declare(suffix, "list-query", "AXFR query", list_query + " order by name,type");
+    declare(suffix, "list-partial-query", "AXFR query (partial results)", list_query + partial_query_suffix);
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=0 and (name=? OR name like ?) and domain_id=?");
 
     declare(suffix, "remove-empty-non-terminals-from-zone-query", "remove all empty non-terminals from zone", "delete from records where domain_id=? and type is null");

--- a/modules/godbcbackend/godbcbackend.cc
+++ b/modules/godbcbackend/godbcbackend.cc
@@ -81,10 +81,17 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=0 and name=?");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=0 and name=? and domain_id=?");
 
-    declare(suffix, "api-id-query", "API basic with ID query", record_query + " (disabled=0 or disabled=?) and type=? and name=? and domain_id=?");
-    declare(suffix, "api-any-id-query", "API any with ID query", record_query + " (disabled=0 or disabled=?) and name=? and domain_id=?");
+    string api_id_query = record_query + " (disabled=0 or disabled=?) and type=? and name=? and domain_id=?";
+    declare(suffix, "api-id-query", "API basic with ID query", api_id_query);
+    string partial_query_suffix = " order by name,type,content limit ? offset ?";
+    declare(suffix, "api-id-partial-query", "API basic with ID query (partial results)", api_id_query + partial_query_suffix);
+    string api_any_id_query = record_query + " (disabled=0 or disabled=?) and name=? and domain_id=?";
+    declare(suffix, "api-any-id-query", "API any with ID query", api_any_id_query);
+    declare(suffix, "api-any-id-partial-query", "API any with ID query (partial results)", api_any_id_query + partial_query_suffix);
 
-    declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,CONVERT(varchar(255), ordername, 0) FROM records WHERE (disabled=0 OR disabled=?) and domain_id=? order by name, type");
+    string list_query = "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,CONVERT(varchar(255), ordername, 0) FROM records WHERE (disabled=0 OR disabled=?) and domain_id=?";
+    declare(suffix, "list-query", "AXFR query", list_query + " order by name, type");
+    declare(suffix, "list-partial-query", "AXFR query (partial results)", list_query + partial_query_suffix);
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=0 and (name=? OR name like ?) and domain_id=?");
 
     declare(suffix, "remove-empty-non-terminals-from-zone-query", "remove all empty non-terminals from zone", "delete from records where domain_id=? and type is null");

--- a/modules/gpgsqlbackend/gpgsqlbackend.cc
+++ b/modules/gpgsqlbackend/gpgsqlbackend.cc
@@ -109,10 +109,19 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=false and name=$1");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=false and name=$1 and domain_id=$2");
 
-    declare(suffix, "api-id-query", "API basic with ID query", record_query + " (disabled=false or $1) and type=$2 and name=$3 and domain_id=$4");
-    declare(suffix, "api-any-id-query", "API any with ID query", record_query + " (disabled=false or $1) and name=$2 and domain_id=$3");
+    string api_id_query = record_query + " (disabled=false or $1) and type=$2 and name=$3 and domain_id=$4";
+    declare(suffix, "api-id-query", "API basic with ID query", api_id_query);
+    string partial_query_suffix4 = " order by name,type,content limit $5 offset $6";
+    declare(suffix, "api-id-partial-query", "API basic with ID query (partial results)", api_id_query + partial_query_suffix4);
+    string api_any_id_query = record_query + " (disabled=false or $1) and name=$2 and domain_id=$3";
+    declare(suffix, "api-any-id-query", "API any with ID query", api_any_id_query);
+    string partial_query_suffix3 = " order by name,type,content limit $4 offset $5";
+    declare(suffix, "api-any-id-partial-query", "API any with ID query (partial results)", api_any_id_query + partial_query_suffix3);
 
-    declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int,ordername FROM records WHERE (disabled=false OR $1) and domain_id=$2 order by name, type");
+    string list_query = "SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int,ordername FROM records WHERE (disabled=false OR $1) and domain_id=$2";
+    declare(suffix, "list-query", "AXFR query", list_query + " order by name,type");
+    string partial_query_suffix2 = " order by name,type,content limit $3 offset $4";
+    declare(suffix, "list-partial-query", "AXFR query (partial results)", list_query + partial_query_suffix2);
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=false and (name=$1 OR name like $2) and domain_id=$3");
 
     declare(suffix, "remove-empty-non-terminals-from-zone-query", "remove all empty non-terminals from zone", "delete from records where domain_id=$1 and type is null");

--- a/modules/gsqlite3backend/gsqlite3backend.cc
+++ b/modules/gsqlite3backend/gsqlite3backend.cc
@@ -94,10 +94,17 @@ public:
     declare(suffix, "any-query", "Any query", record_query + " disabled=0 and name=:qname");
     declare(suffix, "any-id-query", "Any with ID query", record_query + " disabled=0 and name=:qname and domain_id=:domain_id");
 
-    declare(suffix, "api-id-query", "API basic with ID query", record_query + " (disabled=0 or :include_disabled) and type=:qtype and name=:qname and domain_id=:domain_id");
-    declare(suffix, "api-any-id-query", "API any with ID query", record_query + " (disabled=0 or :include_disabled) and name=:qname and domain_id=:domain_id");
+    string api_id_query = record_query + " (disabled=0 or :include_disabled) and type=:qtype and name=:qname and domain_id=:domain_id";
+    declare(suffix, "api-id-query", "API basic with ID query", api_id_query);
+    string partial_query_suffix = " order by name,type,content limit :limit offset :offset";
+    declare(suffix, "api-id-partial-query", "API basic with ID query (partial results)", api_id_query + partial_query_suffix);
+    string api_any_id_query = record_query + " (disabled=0 or :include_disabled) and name=:qname and domain_id=:domain_id";
+    declare(suffix, "api-any-id-query", "API any with ID query", api_any_id_query);
+    declare(suffix, "api-any-id-partial-query", "API any with ID query (partial results)", api_any_id_query + partial_query_suffix);
 
-    declare(suffix, "list-query", "AXFR query", "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR :include_disabled) and domain_id=:domain_id order by name, type");
+    string list_query = "SELECT content,ttl,prio,type,domain_id,disabled,name,auth,ordername FROM records WHERE (disabled=0 OR :include_disabled) and domain_id=:domain_id";
+    declare(suffix, "list-query", "AXFR query", list_query + " order by name,type");
+    declare(suffix, "list-partial-query", "AXFR query (partial results)", list_query + partial_query_suffix);
     declare(suffix, "list-subzone-query", "Subzone listing", record_query + " disabled=0 and (name=:zone OR name like :wildzone) and domain_id=:domain_id");
 
     declare(suffix, "remove-empty-non-terminals-from-zone-query", "remove all empty non-terminals from zone", "delete from records where domain_id=:domain_id and type is null");

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -64,9 +64,12 @@ GSQLBackend::GSQLBackend(const string &mode, const string &suffix)
   d_ANYIdQuery=getArg("any-id-query");
 
   d_APIIdQuery=getArg("api-id-query");
+  d_APIIdPartialQuery=getArg("api-id-partial-query");
   d_APIANYIdQuery=getArg("api-any-id-query");
+  d_APIANYIdPartialQuery=getArg("api-any-id-partial-query");
 
   d_listQuery=getArg("list-query");
+  d_listPartialQuery=getArg("list-partial-query");
   d_listSubZoneQuery=getArg("list-subzone-query");
 
   d_InfoOfDomainsZoneQuery=getArg("info-zone-query");
@@ -144,8 +147,11 @@ GSQLBackend::GSQLBackend(const string &mode, const string &suffix)
   d_ANYNoIdQuery_stmt = nullptr;
   d_ANYIdQuery_stmt = nullptr;
   d_APIIdQuery_stmt = nullptr;
+  d_APIIdPartialQuery_stmt = nullptr;
   d_APIANYIdQuery_stmt = nullptr;
+  d_APIANYIdPartialQuery_stmt = nullptr;
   d_listQuery_stmt = nullptr;
+  d_listPartialQuery_stmt = nullptr;
   d_listSubZoneQuery_stmt = nullptr;
   d_InfoOfDomainsZoneQuery_stmt = nullptr;
   d_InfoOfAllSecondaryDomainsQuery_stmt = nullptr;
@@ -216,8 +222,11 @@ void GSQLBackend::allocateStatements()
     d_ANYNoIdQuery_stmt = d_db->prepare(d_ANYNoIdQuery, 1);
     d_ANYIdQuery_stmt = d_db->prepare(d_ANYIdQuery, 2);
     d_APIIdQuery_stmt = d_db->prepare(d_APIIdQuery, 4);
+    d_APIIdPartialQuery_stmt = d_db->prepare(d_APIIdPartialQuery, 6);
     d_APIANYIdQuery_stmt = d_db->prepare(d_APIANYIdQuery, 3);
+    d_APIANYIdPartialQuery_stmt = d_db->prepare(d_APIANYIdPartialQuery, 5);
     d_listQuery_stmt = d_db->prepare(d_listQuery, 2);
+    d_listPartialQuery_stmt = d_db->prepare(d_listPartialQuery, 4);
     d_listSubZoneQuery_stmt = d_db->prepare(d_listSubZoneQuery, 3);
     d_PrimaryOfDomainsZoneQuery_stmt = d_db->prepare(d_PrimaryOfDomainsZoneQuery, 1);
     d_InfoOfDomainsZoneQuery_stmt = d_db->prepare(d_InfoOfDomainsZoneQuery, 1);
@@ -289,8 +298,11 @@ void GSQLBackend::freeStatements()
   d_ANYNoIdQuery_stmt.reset();
   d_ANYIdQuery_stmt.reset();
   d_APIIdQuery_stmt.reset();
+  d_APIIdPartialQuery_stmt.reset();
   d_APIANYIdQuery_stmt.reset();
+  d_APIANYIdPartialQuery_stmt.reset();
   d_listQuery_stmt.reset();
+  d_listPartialQuery_stmt.reset();
   d_listSubZoneQuery_stmt.reset();
   d_PrimaryOfDomainsZoneQuery_stmt.reset();
   d_InfoOfDomainsZoneQuery_stmt.reset();
@@ -1701,6 +1713,50 @@ void GSQLBackend::APILookup(const QType& qtype, const DNSName& qname, domainid_t
   d_qname=qname;
 }
 
+// Same as above, but for a subset of the results
+bool GSQLBackend::partialLookup(const QType& qtype, const DNSName& qname, domainid_t domain_id, size_t offset, size_t limit, bool include_disabled)
+{
+  try {
+    reconnectIfNeeded();
+
+    if(qtype.getCode()!=QType::ANY) {
+      d_query_name = "api-id-partial-query";
+      d_query_stmt = &d_APIIdPartialQuery_stmt;
+      // clang-format off
+      (*d_query_stmt)->
+        bind("include_disabled", (int)include_disabled)->
+        bind("qtype", qtype.toString())->
+        bind("qname", qname)->
+        bind("domain_id", domain_id)->
+        bind("limit", limit)->
+        bind("offset", offset);
+      // clang-format on
+    } else {
+      // qtype==ANY
+      d_query_name = "api-any-id-partial-query";
+      d_query_stmt = &d_APIANYIdPartialQuery_stmt;
+      // clang-format off
+      (*d_query_stmt)->
+        bind("include_disabled", (int)include_disabled)->
+        bind("qname", qname)->
+        bind("domain_id", domain_id)->
+        bind("limit", limit)->
+        bind("offset", offset);
+      // clang-format on
+    }
+
+    (*d_query_stmt)->
+      execute();
+  }
+  catch(SSqlException &e) {
+    throw PDNSException("GSQLBackend unable to APILookup '" + qname.toLogString() + "(" + std::to_string(domain_id) + ")|" + qtype.toString() + "':"+e.txtReason());
+  }
+
+  d_currentQueryType = OTHER;
+  d_qname=qname;
+  return true;
+}
+
 bool GSQLBackend::list(const ZoneName &target, domainid_t domain_id, bool include_disabled)
 {
   DLOG(SLOG(g_log<<"GSQLBackend constructing handle for list of domain id '"<<domain_id<<"'"<<endl,
@@ -1715,6 +1771,36 @@ bool GSQLBackend::list(const ZoneName &target, domainid_t domain_id, bool includ
     (*d_query_stmt)->
       bind("include_disabled", (int)include_disabled)->
       bind("domain_id", domain_id)->
+      execute();
+    // clang-format on
+  }
+  catch(SSqlException &e) {
+    throw PDNSException("GSQLBackend unable to list domain '" + target.toLogString() + "': "+e.txtReason());
+  }
+
+  d_currentQueryType = LIST;
+  d_qname.clear();
+
+  return true;
+}
+
+// Same as above, but for a subset of the results
+bool GSQLBackend::partialList(const ZoneName &target, domainid_t domain_id, size_t offset, size_t limit, bool include_disabled)
+{
+  DLOG(SLOG(g_log<<"GSQLBackend constructing handle for list of domain id '"<<domain_id<<"'"<<endl,
+            d_slog->info(Logr::Debug, "preparing a list query", "domain id", Logging::Loggable(domain_id))));
+
+  try {
+    reconnectIfNeeded();
+
+    d_query_name = "list-partial-query";
+    d_query_stmt = &d_listPartialQuery_stmt;
+    // clang-format off
+    (*d_query_stmt)->
+      bind("include_disabled", (int)include_disabled)->
+      bind("domain_id", domain_id)->
+      bind("limit", limit)->
+      bind("offset", offset)->
       execute();
     // clang-format on
   }

--- a/pdns/backends/gsql/gsqlbackend.hh
+++ b/pdns/backends/gsql/gsqlbackend.hh
@@ -59,7 +59,9 @@ public:
   unsigned int getCapabilities() override;
   void lookup(const QType& qtype, const DNSName& qname, domainid_t domain_id, DNSPacket *p=nullptr) override;
   void APILookup(const QType &qtype, const DNSName &qname, domainid_t domain_id, bool include_disabled = false) override;
+  bool partialLookup(const QType& qtype, const DNSName& qname, domainid_t domain_id, size_t offset, size_t limit, bool include_disabled) override;
   bool list(const ZoneName &target, domainid_t domain_id, bool include_disabled=false) override;
+  bool partialList(const ZoneName &target, domainid_t domain_id, size_t offset, size_t limit, bool include_disabled) override;
   bool get(DNSResourceRecord &r) override;
   void getAllDomains(vector<DomainInfo>* domains, bool getSerial, bool include_disabled) override;
   bool startTransaction(const ZoneName &domain, domainid_t domain_id=UnknownDomainID) override;
@@ -159,9 +161,12 @@ private:
   string d_ANYIdQuery;
 
   string d_APIIdQuery;
+  string d_APIIdPartialQuery;
   string d_APIANYIdQuery;
+  string d_APIANYIdPartialQuery;
 
   string d_listQuery;
+  string d_listPartialQuery;
   string d_listSubZoneQuery;
   string d_logprefix;
 
@@ -243,8 +248,11 @@ private:
   unique_ptr<SSqlStatement> d_ANYNoIdQuery_stmt;
   unique_ptr<SSqlStatement> d_ANYIdQuery_stmt;
   unique_ptr<SSqlStatement> d_APIIdQuery_stmt;
+  unique_ptr<SSqlStatement> d_APIIdPartialQuery_stmt;
   unique_ptr<SSqlStatement> d_APIANYIdQuery_stmt;
+  unique_ptr<SSqlStatement> d_APIANYIdPartialQuery_stmt;
   unique_ptr<SSqlStatement> d_listQuery_stmt;
+  unique_ptr<SSqlStatement> d_listPartialQuery_stmt;
   unique_ptr<SSqlStatement> d_listSubZoneQuery_stmt;
   unique_ptr<SSqlStatement> d_PrimaryOfDomainsZoneQuery_stmt;
   unique_ptr<SSqlStatement> d_InfoOfDomainsZoneQuery_stmt;

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -173,6 +173,10 @@ public:
   //! lookup() initiates a lookup. A lookup without results should not throw!
   virtual void lookup(const QType& qtype, const DNSName& qdomain, domainid_t zoneId, DNSPacket* pkt_p = nullptr) = 0;
   virtual void APILookup(const QType& qtype, const DNSName& qdomain, domainid_t zoneId, bool include_disabled = false);
+  virtual bool partialLookup(const QType& /*qtype*/, const DNSName& /*qdomain*/, domainid_t /*zoneId*/, size_t /*offset*/, size_t /*limit*/, bool /*include_disabled*/)
+  {
+    return false;
+  }
   virtual bool get(DNSResourceRecord&) = 0; //!< retrieves one DNSResource record, returns false if no more were available
   virtual bool get(DNSZoneRecord& zoneRecord);
   //! Close state created by lookup(...).
@@ -184,6 +188,10 @@ public:
       \param domain_id ID of which a list is requested
   */
   virtual bool list(const ZoneName& target, domainid_t domain_id, bool include_disabled = false) = 0;
+  virtual bool partialList(const ZoneName& /*target*/, domainid_t /*domain_id*/, size_t /*offset*/, size_t /*limit*/, bool /*include_disabled*/)
+  {
+    return false;
+  }
 
   virtual ~DNSBackend() = default;
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -568,6 +568,29 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
     vector<DNSResourceRecord> records;
     vector<Comment> comments;
     size_t recordCount{0};
+    size_t recordOffset{0};
+    size_t recordLimit{0};
+
+    // It would have made sense to use "rrset_count" and "rrset_start" as
+    // query parameters to specify the subset to return. But this would
+    // create some confusion with "record_count", so better use short
+    // names which should hopefully be clear enough.
+    if (req->getvars.count("start") != 0) {
+      try {
+        pdns::checked_stoi_into(recordOffset, req->getvars["start"]);
+      }
+      catch (std::logic_error&) {
+        throw ApiException("Invalid value for 'start'");
+      }
+    }
+    if (req->getvars.count("limit") != 0) {
+      try {
+        pdns::checked_stoi_into(recordLimit, req->getvars["limit"]);
+      }
+      catch (std::logic_error&) {
+        throw ApiException("Invalid value for 'limit'");
+      }
+    }
 
     QType qType = QType::ANY;
     DNSName qName;
@@ -576,7 +599,14 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
     {
       DNSResourceRecord resourceRecord;
       if (req->getvars.count("rrset_name") == 0) {
-        domainInfo.backend->list(zonename, static_cast<int>(domainInfo.id), true); // incl. disabled
+        if (recordLimit != 0) {
+          if (!domainInfo.backend->partialList(zonename, domainInfo.id, recordOffset, recordLimit, true /* include disabled */)) {
+            throw ApiException("Backend for '" + zonename.toLogString() + "' does not support partial listing of contents");
+          }
+        }
+        else {
+          domainInfo.backend->list(zonename, domainInfo.id, true); // incl. disabled
+        }
       }
       else {
         qName = DNSName(req->getvars["rrset_name"]);
@@ -584,7 +614,14 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
           qType = req->getvars["rrset_type"];
         }
         bool include_disabled = boolFromHttpRequest(req, "include_disabled", true);
-        domainInfo.backend->APILookup(qType, qName, static_cast<int>(domainInfo.id), include_disabled);
+        if (recordLimit != 0) {
+          if (!domainInfo.backend->partialLookup(qType, qName, domainInfo.id, recordOffset, recordLimit, include_disabled)) {
+            throw ApiException("Backend for '" + zonename.toLogString() + "' does not support partial listing of contents");
+          }
+        }
+        else {
+          domainInfo.backend->APILookup(qType, qName, domainInfo.id, include_disabled);
+        }
       }
       while (domainInfo.backend->get(resourceRecord)) {
         if (resourceRecord.qtype.getCode() == 0) {
@@ -596,6 +633,10 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
         }
       }
       if (returnRRSets) {
+        // We could consider skipping that sort operation if recordLimit != 0,
+        // as this should have caused the backend to sort the results already;
+        // but the sorting order used by the backend might be different than
+        // this one.
         sort(records.begin(), records.end(), [](const DNSResourceRecord& rrA, const DNSResourceRecord& rrB) {
           /* if you ever want to update this comparison function,
              please be aware that you will also need to update the conditions in the code merging
@@ -618,6 +659,18 @@ static void fillZone(UeberBackend& backend, const ZoneName& zonename, HttpRespon
       while (domainInfo.backend->getComment(comment)) {
         if ((qName.empty() || comment.qname == qName) && (qType == QType::ANY || comment.qtype == qType)) {
           comments.push_back(comment);
+        }
+      }
+      // If we have asked for a subset of the records, remove comments
+      // which do not apply to the subset.
+      if (recordLimit != 0) {
+        for (auto iter = comments.begin(); iter != comments.end();) {
+          if (std::find_if(records.begin(), records.end(), [iter](const DNSResourceRecord& rec) { return rec.qname == iter->qname && rec.qtype == iter->qtype; }) != records.end()) {
+            ++iter;
+          }
+          else {
+            iter = comments.erase(iter);
+          }
         }
       }
       sort(comments.begin(), comments.end(), [](const Comment& rrA, const Comment& rrB) {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -3351,6 +3351,54 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         data = self.get_zone(name, rrset_name="rec42." + name)
         self.assertEqual(data["record_count"], 1)
 
+    @unittest.skipIf(is_auth_lmdb(), "Needs to perform partial lookup")
+    def test_partial_list(self):
+        name, payload, zone = self.create_zone()
+        rrsets = []
+        # We create records with the same name lengths, for simplicity.
+        for record in range(10, 99):
+            rrset = {
+                "changetype": "replace",
+                "name": "rec" + str(record) + "." + name,
+                "type": "A",
+                "ttl": 3600,
+                "records": [{"content": "192.168.0." + str(record), "disabled": False}],
+            }
+            rrsets.append(rrset)
+        payload = {"rrsets": rrsets}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+        self.assert_success(r)
+        # Ask for records 11 to 30 in the zone, thus rec21 to rec40.
+        # This exercizes the partialList method.
+        data = self.get_zone(name, rrsets="true", start="11", limit="20")
+        rrsets = data.get("rrsets")
+        self.assertEqual(len(rrsets), 20)
+        check = [False] * 100
+        for record in range(10, 99):
+            check[record] = False
+        for record in rrsets:
+            id = int(record["name"][3:5])
+            check[id] = True
+        # Make sure that we have correctly seen each of the 21-40 and no
+        # other record.
+        for record in range(100):
+            if record >= 21 and record <= 40:
+                self.assertEqual(check[record], True)
+            else:
+                self.assertEqual(check[record], False)
+        # Query again for a single record using name with and without type,
+        # to exercize the partialLookup method.
+        data = self.get_zone(name, rrsets="true", rrset_name="rec42." + name, start="0", limit="10")
+        rrsets = data.get("rrsets")
+        self.assertEqual(len(rrsets), 1)
+        data = self.get_zone(name, rrsets="true", rrset_name="rec42." + name, rrset_type="MX", start="0", limit="10")
+        rrsets = data.get("rrsets")
+        self.assertEqual(len(rrsets), 0)
+
 
 @unittest.skipIf(not is_auth(), "Not applicable")
 class AuthRootZone(ZonesApiTestCase, AuthZonesHelperMixin):


### PR DESCRIPTION
### Short description
This PR adds, for the SQL backends, the ability to return a subset of the zone records in a query, taking a `start` and `limit` extra arguments. These values will be passed in the SQL queries as `OFFSET` and `LIMIT` values, respectively.

This allows large zones to be listed in chunks, without eating too much memory.

Backends which do not have the ability to return subsets will fail hard these requests (422 + error message).

In its current state, this PR only implements this in the SQL backends. It should be almost trivial to add to the Bind backend; for LMDB this can also be done without too much headache (although caching recently-used cursors might speed up things for large zones, and this will need to be done carefully), but work on these backends will occur in a follow-up PR.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
