### PR TITLE
auth: kill processes nicely

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -1116,13 +1116,36 @@ static void daemonize()
   }
 }
 
-static int cpid;
-static void takedown(int /* i */)
+static bool axe(pid_t pid, bool waitok)
 {
-  if (cpid) {
+  if (kill(pid, SIGTERM) != 0) {
+    // Either already gone or we can't signal it anyway, there is nothing we can do.
+    return false;
+  }
+  // If we are allowed to sleep here, give a few seconds (well, 2) to the
+  // process to disappear.
+  if (waitok) {
+    for (unsigned int cycles = 2 * 10; cycles != 0; --cycles) {
+      Utility::usleep(100UL * 1000UL);
+      int status{};
+      int ret = waitpid(pid, &status, WNOHANG);
+      if (ret > 0 && (WIFEXITED(status) || WIFSIGNALED(status))) {
+        return true; // process has died
+      }
+    }
+    // Process is taking time to exit, use a larger hammer
+    return kill(pid, SIGKILL) == 0;
+  }
+  return true;
+}
+
+static pid_t cpid;
+static void takedown(int signum)
+{
+  if (cpid != 0) {
     SLOG(g_log << Logger::Error << "Guardian is killed, taking down children with us" << endl,
          g_slog->withName("guardian")->info(Logr::Error, "Guardian is killed, taking down children with us"));
-    kill(cpid, SIGKILL);
+    axe(cpid, signum == 0);
     exit(0);
   }
 }
@@ -1161,9 +1184,7 @@ static std::mutex g_guardian_lock;
 // The next two methods are not in dynhandler.cc because they use a few items declared in this file.
 static string DLCycleHandler(const vector<string>& /* parts */, pid_t /* ppid */, Logr::log_t /* slog */)
 {
-  kill(cpid, SIGKILL); // why?
-  kill(cpid, SIGKILL); // why?
-  sleep(1);
+  axe(cpid, true);
   return "ok";
 }
 
@@ -1197,6 +1218,7 @@ static string DLRestHandler(const vector<string>& parts, pid_t /* ppid */, Logr:
   return response;
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity): can probably get removed when structured logging becomes the only alternative and SLOG macros disappear
 static int guardian(int argc, char** argv)
 {
   if (isGuarded(argv))
@@ -1333,8 +1355,9 @@ static int guardian(int argc, char** argv)
           break;
         else { // child is alive
           // execute some kind of ping here
-          if (DLQuitPlease())
-            takedown(1); // needs a parameter..
+          if (DLQuitPlease()) {
+            takedown(0); // not invoked from a signal handler
+          }
           setStatus("Child running on pid " + std::to_string(pid));
           sleep(1);
         }


### PR DESCRIPTION
### Short description
There used to be a school of thought advocating killing processes with `SIGKILL`, so that we can be sure the process gets away. Apparently whoever wrote that code in PowerDNS (in pre-subversion times, therefore before 2002) was a member of that school.

This PR replaces the use of `SIGKILL` by the use of `SIGTERM` first, waiting for up to two seconds for the process to have disappeared, and if it hasn't, reluctantly send a `SIGKILL`.

This can't be worse than the current behaviour.

Before, when issueing `pdns_control cycle`:
```
Aug 06 12:43:38 Our pdns instance (1733393) exited after signal 9
Aug 06 12:43:38 Respawning
Aug 06 12:43:39 Guardian is launching an instance
```

With this PR:
```
Aug 06 12:44:43 Our pdns instance (1733497) exited after signal 15
Aug 06 12:44:43 Respawning
Aug 06 12:44:44 Guardian is launching an instance
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
