### PR TITLE
auth rest-api: fix signedness bug in json data normalization

### DIFF
--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -779,7 +779,7 @@ static std::string normalizeJsonString(const std::string& jsonContent)
         ret << chr;
       }
       else {
-        ret << '\\' << std::setfill('0') << std::setw(3) << static_cast<unsigned int>(chr) << std::setw(0);
+        ret << '\\' << std::setfill('0') << std::setw(3) << static_cast<int>(static_cast<unsigned char>(chr)) << std::setw(0);
       }
     }
     if (quote) {

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -538,12 +538,12 @@ class AuthZones(ZonesApiTestCase, AuthZonesHelperMixin):
                 ],
             },
             {
-                "name": name,
+                "name": "band." + name,
                 "type": "TXT",
                 "ttl": 3600,
                 "records": [
                     {
-                        "content": '"test TXT"',
+                        "content": '"Blue \\195\\150yster Cult"',
                         "disabled": False,
                     }
                 ],
@@ -567,7 +567,7 @@ class AuthZones(ZonesApiTestCase, AuthZonesHelperMixin):
         # check our comment has appeared
         self.assertEqual(get_rrset(data, name, "SOA")["comments"], rrsets[0]["comments"])
         self.assertEqual(get_rrset(data, name, "A")["comments"], [])
-        self.assertEqual(get_rrset(data, name, "TXT")["comments"], [])
+        self.assertEqual(get_rrset(data, "band." + name, "TXT")["comments"], [])
         self.assertEqual(get_rrset(data, name, "AAAA")["comments"], rrsets[1]["comments"])
 
     def test_create_zone_uncanonical_nameservers(self):


### PR DESCRIPTION
### Short description
As reported a few minutes ago, escaped characters (`\nnn`) in Json input were not normalized correctly.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
