### PR TITLE
Fix intermittent "Connection refused" in dnsdist regression tests

### DIFF
--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -114,7 +114,6 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     _extraStartupSleep = 0
     _enableStructuredLoggingOnCL = True
     _dnsDistPort = pickAvailablePort()
-    _consolePort = pickAvailablePort()
     _testServerPort = pickAvailablePort()
 
     @staticmethod
@@ -167,7 +166,6 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
     @classmethod
     def startDNSDist(cls):
         cls._dnsDistPort = pickAvailablePort()
-        cls._consolePort = pickAvailablePort()
 
         print("Launching dnsdist..")
         if cls._yaml_config_template:
@@ -274,11 +272,13 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         else:
             cls.waitForTCPSocket(cls._dnsDistListeningAddr, cls._dnsDistPort)
 
-        cls.waitForTCPSocket(cls._dnsDistListeningAddr, cls._consolePort)
+        consolePort = getattr(cls, '_consolePort', None)
+        if consolePort:
+            cls.waitForTCPSocket(cls._dnsDistListeningAddr, consolePort)
 
-        web_port = getattr(cls, '_webServerPort', None)
-        if web_port is not None:
-            cls.waitForTCPSocket(cls._dnsDistListeningAddr, web_port)
+        webPort = getattr(cls, '_webServerPort', None)
+        if webPort:
+            cls.waitForTCPSocket(cls._dnsDistListeningAddr, webPort)
 
         if cls._dnsdist.poll() is not None:
             print(f"\n*** startDNSDist log for {logFile} ***")

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -272,11 +272,11 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         else:
             cls.waitForTCPSocket(cls._dnsDistListeningAddr, cls._dnsDistPort)
 
-        consolePort = getattr(cls, '_consolePort', None)
+        consolePort = getattr(cls, "_consolePort", None)
         if consolePort:
             cls.waitForTCPSocket(cls._dnsDistListeningAddr, consolePort)
 
-        webPort = getattr(cls, '_webServerPort', None)
+        webPort = getattr(cls, "_webServerPort", None)
         if webPort:
             cls.waitForTCPSocket(cls._dnsDistListeningAddr, webPort)
 

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -274,6 +274,12 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         else:
             cls.waitForTCPSocket(cls._dnsDistListeningAddr, cls._dnsDistPort)
 
+        cls.waitForTCPSocket(cls._dnsDistListeningAddr, cls._consolePort)
+
+        web_port = getattr(cls, '_webServerPort', None)
+        if web_port is not None:
+            cls.waitForTCPSocket(cls._dnsDistListeningAddr, web_port)
+
         if cls._dnsdist.poll() is not None:
             print(f"\n*** startDNSDist log for {logFile} ***")
             with open(logFile, "r") as fdLog:

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -732,6 +732,7 @@ class TestAPICustomHeaders(APITestsBase):
     _basicOnlyPath = "/"
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",
@@ -785,6 +786,7 @@ class TestStatsWithoutAuthentication(APITestsBase):
     _noAuthenticationPaths = ["/metrics", "/jsonstat?command=dynblocklist"]
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",
@@ -854,6 +856,7 @@ class TestAPIAuth(APITestsBase):
     _basicOnlyPath = "/"
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",
@@ -931,6 +934,7 @@ class TestAPIACL(APITestsBase):
     __test__ = True
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",

--- a/regression-tests.dnsdist/test_Advanced.py
+++ b/regression-tests.dnsdist/test_Advanced.py
@@ -5,7 +5,7 @@ import socket
 import time
 import unittest
 import dns
-from dnsdisttests import DNSDistTest
+from dnsdisttests import DNSDistTest, pickAvailablePort
 
 
 class TestAdvancedFixupCase(DNSDistTest):
@@ -133,6 +133,7 @@ class TestAdvancedIncludeDir(DNSDistTest):
 class TestStatNodeRespRingSince(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     setKey("%s")
@@ -793,6 +794,7 @@ class TestChangeName(DNSDistTest):
 class TestFlagsOnTimeout(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     setKey("%s")

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -5,7 +5,7 @@ import threading
 import time
 import ssl
 
-from dnsdisttests import DNSDistTest
+from dnsdisttests import DNSDistTest, pickAvailablePort
 
 
 class TestBackendDiscovery(DNSDistTest):
@@ -32,6 +32,7 @@ class TestBackendDiscovery(DNSDistTest):
 
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",
@@ -701,6 +702,7 @@ class TestBackendDiscovery(DNSDistTest):
 class TestBackendDiscoveryByHostname(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort"]
     _config_template = """
     setKey("%s")

--- a/regression-tests.dnsdist/test_CacheHitResponses.py
+++ b/regression-tests.dnsdist/test_CacheHitResponses.py
@@ -2,7 +2,7 @@
 import base64
 import time
 import dns
-from dnsdisttests import DNSDistTest
+from dnsdisttests import DNSDistTest, pickAvailablePort
 
 
 class TestCacheHitResponses(DNSDistTest):
@@ -88,6 +88,7 @@ class TestCacheHitResponses(DNSDistTest):
 class TestStaleCacheHitResponses(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})

--- a/regression-tests.dnsdist/test_CacheMissActions.py
+++ b/regression-tests.dnsdist/test_CacheMissActions.py
@@ -9,6 +9,7 @@ from dnsdisttests import DNSDistTest, pickAvailablePort
 class TestCacheMissSelfAnswered(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
 
     _config_template = """
@@ -76,6 +77,7 @@ class TestCacheMissSelfAnswered(DNSDistTest):
 class TestCacheMissGoToADifferentPool(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _testServer2Port = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",

--- a/regression-tests.dnsdist/test_Caching.py
+++ b/regression-tests.dnsdist/test_Caching.py
@@ -1015,6 +1015,7 @@ class TestCachingCacheFull(DNSDistTest):
 class TestCachingNoStale(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
@@ -1061,6 +1062,7 @@ class TestCachingNoStale(DNSDistTest):
 class TestCachingStale(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _staleCacheTTL = 60
     _config_params = ["_staleCacheTTL", "_consoleKeyB64", "_consolePort", "_testServerPort", "_testServerPort"]
     _config_template = """
@@ -1165,6 +1167,7 @@ class TestCachingStale(DNSDistTest):
 class TestCachingStaleExpunged(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _staleCacheTTL = 60
     _config_params = ["_staleCacheTTL", "_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
@@ -1241,6 +1244,7 @@ class TestCachingStaleExpunged(DNSDistTest):
 class TestCachingStaleExpungePrevented(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1, temporaryFailureTTL=0, staleTTL=60, dontAge=false, numberOfShards=1, deferrableInsertLock=true, maxNegativeTTL=3600, parseECS=false, keepStaleData=true})
@@ -1311,6 +1315,7 @@ class TestCachingStaleExpungePrevented(DNSDistTest):
 class TestCacheManagement(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
@@ -2423,6 +2428,7 @@ class TestCachingDontAge(DNSDistTest):
 class TestCachingECSWithoutPoolECS(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort", "_testServerPort"]
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})
@@ -2477,6 +2483,7 @@ class TestCachingECSWithoutPoolECS(DNSDistTest):
 class TestCachingECSWithPoolECS(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     pc = newPacketCache(100, {maxTTL=86400, minTTL=1})

--- a/regression-tests.dnsdist/test_CommandExecution.py
+++ b/regression-tests.dnsdist/test_CommandExecution.py
@@ -3,12 +3,13 @@ import base64
 import json
 import os
 import subprocess
-from dnsdisttests import DNSDistTest
+from dnsdisttests import DNSDistTest, pickAvailablePort
 
 
 class TestSingleCommandExecution(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """

--- a/regression-tests.dnsdist/test_Console.py
+++ b/regression-tests.dnsdist/test_Console.py
@@ -6,13 +6,13 @@ import os
 import socket
 import subprocess
 import time
-from dnsdisttests import DNSDistTest
+from dnsdisttests import DNSDistTest, pickAvailablePort
 
 
 class TestConsoleAllowed(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
-
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     setKey("%s")
@@ -31,7 +31,7 @@ class TestConsoleAllowed(DNSDistTest):
 class TestConsoleAllowedV6(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
-
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     setKey("%s")
@@ -52,7 +52,7 @@ class TestConsoleAllowedV6(DNSDistTest):
 class TestConsoleNotAllowed(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
-
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     setKey("%s")
@@ -71,7 +71,7 @@ class TestConsoleNotAllowed(DNSDistTest):
 class TestConsoleNoKey(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
-
+    _consolePort = pickAvailablePort()
     _config_params = ["_consolePort", "_testServerPort"]
     _config_template = """
     controlSocket("127.0.0.1:%d")
@@ -88,6 +88,7 @@ class TestConsoleNoKey(DNSDistTest):
 class TestConsoleConcurrentConnections(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _maxConns = 2
 
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort", "_maxConns"]
@@ -136,6 +137,7 @@ def writeCDB(fname, variant=1):
 class TestConsoleAccessObjectsFromYAML(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _cdbFileName = "/tmp/test-cdb-db"
 
@@ -185,6 +187,7 @@ key_value_stores:
 class TestConsoleRings(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
@@ -252,6 +255,7 @@ class TestConsoleRings(DNSDistTest):
 class TestConsoleViaBuiltInClient(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """

--- a/regression-tests.dnsdist/test_DNSCrypt.py
+++ b/regression-tests.dnsdist/test_DNSCrypt.py
@@ -20,6 +20,7 @@ class DNSCryptTest(DNSDistTest):
 
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _providerFingerprint = "E1D7:2108:9A59:BF8D:F101:16FA:ED5E:EA6A:9F6C:C78F:7F91:AF6B:027E:62F4:69C3:B1AA"
     _providerName = "2.provider.name"

--- a/regression-tests.dnsdist/test_DOH.py
+++ b/regression-tests.dnsdist/test_DOH.py
@@ -24,6 +24,7 @@ from dnsdisttests import DNSDistTest, pickAvailablePort
 class DOHTests(object):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server.key"
     _serverCert = "server.chain"
     _serverName = "tls.tests.dnsdist.org"

--- a/regression-tests.dnsdist/test_DOQ.py
+++ b/regression-tests.dnsdist/test_DOQ.py
@@ -214,6 +214,7 @@ class TestDOQXFR(DOQCommon, QUICXFRTests, DNSDistTest):
 class TestDOQCertificateReloading(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-doq.key"
     _serverCert = "server-doq.chain"
     _serverName = "tls.tests.dnsdist.org"

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -368,19 +368,22 @@ class TestDnstapOverRemoteLoggerPool(DNSDistTest):
         sock.listen(100)
 
         def handle_connection(conn):
-            data = None
-            while True:
-                data = conn.recv(2)
-                if not data:
-                    break
-                (datalen,) = struct.unpack("!H", data)
-                data = conn.recv(datalen)
-                if not data:
-                    break
+            try:
+                data = None
+                while True:
+                    data = conn.recv(2)
+                    if not data:
+                        break
+                    (datalen,) = struct.unpack("!H", data)
+                    data = conn.recv(datalen)
+                    if not data:
+                        break
 
-                cls._remoteLoggerQueue.put(data, True, timeout=2.0)
-
-            conn.close()
+                    cls._remoteLoggerQueue.put(data, True, timeout=2.0)
+            except Exception as e:
+                print(f"Error in handle_connection (RemoteLogger): {e}")
+            finally:
+                conn.close()
 
         threads = []
 
@@ -742,10 +745,13 @@ class TestDnstapOverRemotePoolUnixLogger(DNSDistTest):
         sock.listen(100)
 
         def handle_connection(conn):
-            fstrm_handle_bidir_connection(
-                conn, lambda data: cls._fstrmLoggerQueue.put(data, True, timeout=2.0), exit_early=True
-            )
-            conn.close()
+            try:
+                fstrm_handle_bidir_connection(conn, lambda data: \
+                    cls._fstrmLoggerQueue.put(data, True, timeout=2.0), exit_early=True)
+            except Exception as e:
+                print(f"Error in handle_connection (FrameStream): {e}")
+            finally:
+                conn.close()
 
         threads = []
 
@@ -998,10 +1004,13 @@ class TestDnstapOverRemotePoolTcpLogger(DNSDistTest):
         sock.listen(100)
 
         def handle_connection(conn):
-            fstrm_handle_bidir_connection(
-                conn, lambda data: cls._fstrmLoggerQueue.put(data, True, timeout=2.0), exit_early=True
-            )
-            conn.close()
+            try:
+                fstrm_handle_bidir_connection(conn, lambda data: \
+                    cls._fstrmLoggerQueue.put(data, True, timeout=2.0), exit_early=True)
+            except Exception as e:
+                print(f"Error in handle_connection (FrameStream): {e}")
+            finally:
+                conn.close()
 
         threads = []
 

--- a/regression-tests.dnsdist/test_Dnstap.py
+++ b/regression-tests.dnsdist/test_Dnstap.py
@@ -746,8 +746,9 @@ class TestDnstapOverRemotePoolUnixLogger(DNSDistTest):
 
         def handle_connection(conn):
             try:
-                fstrm_handle_bidir_connection(conn, lambda data: \
-                    cls._fstrmLoggerQueue.put(data, True, timeout=2.0), exit_early=True)
+                fstrm_handle_bidir_connection(
+                    conn, lambda data: cls._fstrmLoggerQueue.put(data, True, timeout=2.0), exit_early=True
+                )
             except Exception as e:
                 print(f"Error in handle_connection (FrameStream): {e}")
             finally:
@@ -1005,8 +1006,9 @@ class TestDnstapOverRemotePoolTcpLogger(DNSDistTest):
 
         def handle_connection(conn):
             try:
-                fstrm_handle_bidir_connection(conn, lambda data: \
-                    cls._fstrmLoggerQueue.put(data, True, timeout=2.0), exit_early=True)
+                fstrm_handle_bidir_connection(
+                    conn, lambda data: cls._fstrmLoggerQueue.put(data, True, timeout=2.0), exit_early=True
+                )
             except Exception as e:
                 print(f"Error in handle_connection (FrameStream): {e}")
             finally:

--- a/regression-tests.dnsdist/test_DynBlocksResponseBytes.py
+++ b/regression-tests.dnsdist/test_DynBlocksResponseBytes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import base64
-from dnsdisttests import DNSDistTest
+from dnsdisttests import DNSDistTest, pickAvailablePort
 from dnsdistDynBlockTests import DynBlocksTest
 
 
@@ -8,6 +8,7 @@ class TestDynBlockResponseBytes(DynBlocksTest):
     _dynBlockBytesPerSecond = 200
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",
@@ -37,6 +38,7 @@ class TestDynBlockGroupResponseBytes(DynBlocksTest):
     _dynBlockBytesPerSecond = 200
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",

--- a/regression-tests.dnsdist/test_EBPF.py
+++ b/regression-tests.dnsdist/test_EBPF.py
@@ -12,6 +12,7 @@ from dnsdisttests import DNSDistTest, pickAvailablePort
 class TestSimpleEBPF(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _serverKey = "server.key"
     _serverCert = "server.chain"

--- a/regression-tests.dnsdist/test_HealthChecks.py
+++ b/regression-tests.dnsdist/test_HealthChecks.py
@@ -12,6 +12,7 @@ from dnsdisttests import DNSDistTest, pickAvailablePort, ResponderDropAction
 class HealthCheckTest(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _webTimeout = 2.0
     _webServerPort = pickAvailablePort()
     _webServerAPIKey = "apisecret"
@@ -350,6 +351,7 @@ class TestLazyHealthChecks(HealthCheckTest):
 
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_do53Port", "_dotPort", "_dohPort"]
     _config_template = """
     setKey("%s")

--- a/regression-tests.dnsdist/test_Lua.py
+++ b/regression-tests.dnsdist/test_Lua.py
@@ -3,12 +3,13 @@
 import base64
 import dns
 import time
-from dnsdisttests import DNSDistTest
+from dnsdisttests import DNSDistTest, pickAvailablePort
 
 
 class TestLuaThread(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _config_params = ["_consoleKeyB64", "_consolePort"]
     _config_template = """
@@ -189,6 +190,7 @@ class TestLuaPoolBindings(DNSDistTest):
 class TestLuaError(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _config_params = ["_consoleKeyB64", "_consolePort"]
     _config_template = """
@@ -209,6 +211,7 @@ class TestLuaError(DNSDistTest):
 class TestLuaRingBuffersSamplingRates(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """

--- a/regression-tests.dnsdist/test_OCSP.py
+++ b/regression-tests.dnsdist/test_OCSP.py
@@ -62,6 +62,7 @@ class DNSDistOCSPStaplingTest(DNSDistTest):
 class TestOCSPStaplingDOH(DNSDistOCSPStaplingTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-ocsp.key"
     _serverCert = "server-ocsp.chain"
     _serverName = "tls.tests.dnsdist.org"
@@ -134,6 +135,7 @@ class TestOCSPStaplingDOH(DNSDistOCSPStaplingTest):
 class TestBrokenOCSPStaplingDoH(DNSDistOCSPStaplingTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-ocsp.key"
     _serverCert = "server-ocsp.chain"
     _serverName = "tls.tests.dnsdist.org"
@@ -171,6 +173,7 @@ class TestBrokenOCSPStaplingDoH(DNSDistOCSPStaplingTest):
 class TestOCSPStaplingTLSGnuTLS(DNSDistOCSPStaplingTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-ocsp.key"
     _serverCert = "server-ocsp.chain"
     _serverName = "tls.tests.dnsdist.org"
@@ -229,6 +232,7 @@ class TestOCSPStaplingTLSGnuTLS(DNSDistOCSPStaplingTest):
 class TestBrokenOCSPStaplingTLSGnuTLS(DNSDistOCSPStaplingTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-ocsp.key"
     _serverCert = "server-ocsp.chain"
     _serverName = "tls.tests.dnsdist.org"
@@ -265,6 +269,7 @@ class TestBrokenOCSPStaplingTLSGnuTLS(DNSDistOCSPStaplingTest):
 class TestOCSPStaplingTLSOpenSSL(DNSDistOCSPStaplingTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-ocsp.key"
     _serverCert = "server-ocsp.chain"
     _serverName = "tls.tests.dnsdist.org"
@@ -323,6 +328,7 @@ class TestOCSPStaplingTLSOpenSSL(DNSDistOCSPStaplingTest):
 class TestBrokenOCSPStaplingTLSOpenSSL(DNSDistOCSPStaplingTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-ocsp.key"
     _serverCert = "server-ocsp.chain"
     _serverName = "tls.tests.dnsdist.org"

--- a/regression-tests.dnsdist/test_OutgoingDOH.py
+++ b/regression-tests.dnsdist/test_OutgoingDOH.py
@@ -263,6 +263,7 @@ class TestOutgoingDOHOpenSSL(DNSDistTest, OutgoingDOHTests):
     _tlsProvider = "openssl"
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",
@@ -320,6 +321,7 @@ class TestOutgoingDOHGnuTLS(DNSDistTest, OutgoingDOHTests):
     _tlsProvider = "gnutls"
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",
@@ -365,6 +367,7 @@ class TestOutgoingDOHOpenSSLYaml(DNSDistTest, OutgoingDOHTests):
     _tlsProvider = "openssl"
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = []
     _config_template = ""
     _yaml_config_template = """---
@@ -513,6 +516,7 @@ class TestOutgoingDOHOpenSSLWrongCertNameButNoCheck(DNSDistTest, OutgoingDOHTest
     _tlsProvider = "openssl"
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",
@@ -557,6 +561,7 @@ class TestOutgoingDOHGnuTLSWrongCertNameButNoCheck(DNSDistTest, OutgoingDOHTests
     _tlsProvider = "gnutls"
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = [
         "_consoleKeyB64",
         "_consolePort",

--- a/regression-tests.dnsdist/test_Routing.py
+++ b/regression-tests.dnsdist/test_Routing.py
@@ -899,6 +899,7 @@ class TestRoutingHighValueWRandom(DNSDistTest):
     _testServer2Port = pickAvailablePort()
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort", "_testServer2Port"]
     _config_template = """
     setKey("%s")
@@ -1244,6 +1245,7 @@ class TestRoutingOrderedWRandUntag(DNSDistTest):
 
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _testServer1Port = pickAvailablePort()
     _testServer2Port = pickAvailablePort()
     _testServer3Port = pickAvailablePort()

--- a/regression-tests.dnsdist/test_RulesActions.py
+++ b/regression-tests.dnsdist/test_RulesActions.py
@@ -8,7 +8,7 @@ import unittest
 import dns
 import clientsubnetoption
 import cookiesoption
-from dnsdisttests import DNSDistTest
+from dnsdisttests import DNSDistTest, pickAvailablePort
 
 
 class TestAdvancedAllow(DNSDistTest):
@@ -1226,6 +1226,7 @@ class TestAdvancedEDNSVersionRule(DNSDistTest):
 class TestSetRules(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     setKey("%s")
@@ -1285,6 +1286,7 @@ class TestSetRules(DNSDistTest):
 class TestRmRules(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
     _config_template = """
     setKey("%s")

--- a/regression-tests.dnsdist/test_TLS.py
+++ b/regression-tests.dnsdist/test_TLS.py
@@ -241,6 +241,7 @@ class TestOpenSSL(DNSDistTest, TLSTests):
     _extraStartupSleep = 1
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-tls.key"
     _serverCert = "server-tls.chain"
     _serverName = "tls.tests.dnsdist.org"
@@ -284,6 +285,7 @@ class TestOpenSSL(DNSDistTest, TLSTests):
 class TestGnuTLS(DNSDistTest, TLSTests):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-tls.key"
     _serverCert = "server-tls.chain"
     _serverName = "tls.tests.dnsdist.org"
@@ -328,6 +330,7 @@ class TestOpenSSLYaml(DNSDistTest, TLSTests):
     _extraStartupSleep = 1
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverKey = "server-tls.key"
     _serverCert = "server-tls.chain"
     _serverName = "tls.tests.dnsdist.org"
@@ -554,6 +557,7 @@ class TestProtocols(DNSDistTest):
 class TestPKCSTLSCertificate(DNSDistTest, TLSTests):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _serverCert = "server-tls.p12"
     _pkcsPassphrase = "passw0rd"
     _serverName = "tls.tests.dnsdist.org"
@@ -587,6 +591,7 @@ class TestPKCSTLSCertificate(DNSDistTest, TLSTests):
 class TestOpenSSLTLSTicketsKeyCallback(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _serverKey = "server.key"
     _serverCert = "server.chain"
@@ -636,6 +641,7 @@ class TestOpenSSLTLSTicketsKeyCallback(DNSDistTest):
 class TestGnuTLSTLSTicketsKeyCallback(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     _serverKey = "server.key"
     _serverCert = "server.chain"

--- a/regression-tests.dnsdist/test_TLSSessionResumption.py
+++ b/regression-tests.dnsdist/test_TLSSessionResumption.py
@@ -20,6 +20,7 @@ except NameError:
 class DNSDistTLSSessionResumptionTest(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
 
     @classmethod
     def checkSessionResumed(

--- a/regression-tests.dnsdist/test_TeeAction.py
+++ b/regression-tests.dnsdist/test_TeeAction.py
@@ -195,6 +195,7 @@ tcp-drops\t0
 class TestTeeActionLua(TeeActionBase, DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+    _consolePort = pickAvailablePort()
     _teeServerPort = pickAvailablePort()
     _teeProxyServerPort = pickAvailablePort()
     _toTeeQueue = Queue()


### PR DESCRIPTION
### Short description
This PR addresses flakiness in the dnsdist regression test suite caused by race conditions during startup and lack of proper cleanup of sockets in the RemoteLoggerListener, FrameStreamUnixListener, and FrameStreamTcpListener during exception scenarios.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
