### PR TITLE
auth, rec: better numerical parameter parsing

### DIFF
--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -592,8 +592,8 @@ void Bind2Backend::parseZoneFile(BB2DomainInfo* bbd)
 
   auto records = std::make_shared<recordstorage_t>();
   ZoneParserTNG zpt(bbd->main_filename(), bbd->d_name, s_binddirectory, d_upgradeContent);
-  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
-  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
+  zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum<size_t>("max-include-depth"));
   DNSResourceRecord rr;
   string hashed;
   while (zpt.get(rr)) {
@@ -932,7 +932,7 @@ void Bind2Backend::doEmptyNonTerminals(std::shared_ptr<recordstorage_t>& records
   std::unordered_set<DNSName> qnames;
   std::unordered_map<DNSName, bool> nonterm;
 
-  uint32_t maxent = ::arg().asNum("max-ent-entries");
+  auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
 
   for (const auto& bdr : *records)
     qnames.insert(bdr.qname);

--- a/modules/bindbackend/binddnssec.cc
+++ b/modules/bindbackend/binddnssec.cc
@@ -237,7 +237,7 @@ bool Bind2Backend::getNSEC3PARAMuncached(const ZoneName& name, NSEC3PARAMRecordC
   else
     return false; // No NSEC3 zone
 
-  static int maxNSEC3Iterations = ::arg().asNum("max-nsec3-iterations");
+  static auto maxNSEC3Iterations = ::arg().asNum<uint16_t>("max-nsec3-iterations");
   if (ns3p) {
     auto tmp = std::dynamic_pointer_cast<NSEC3PARAMRecordContent>(DNSRecordContent::make(QType::NSEC3PARAM, 1, value));
     *ns3p = *tmp;

--- a/modules/ldapbackend/ldapbackend.cc
+++ b/modules/ldapbackend/ldapbackend.cc
@@ -45,7 +45,7 @@ LdapBackend::LdapBackend(const string& suffix)
     d_pldap = nullptr;
     d_authenticator = nullptr;
     d_qlog = arg().mustDo("query-logging");
-    d_default_ttl = arg().asNum<uint32_t>("default-ttl");
+    arg().assignNum(d_default_ttl, "default-ttl");
     d_myname = "[LdapBackend]";
     d_in_list = false;
 

--- a/modules/ldapbackend/ldapbackend.cc
+++ b/modules/ldapbackend/ldapbackend.cc
@@ -45,7 +45,7 @@ LdapBackend::LdapBackend(const string& suffix)
     d_pldap = nullptr;
     d_authenticator = nullptr;
     d_qlog = arg().mustDo("query-logging");
-    d_default_ttl = arg().asNum("default-ttl");
+    d_default_ttl = arg().asNum<uint32_t>("default-ttl");
     d_myname = "[LdapBackend]";
     d_in_list = false;
 

--- a/pdns/arguments.cc
+++ b/pdns/arguments.cc
@@ -288,27 +288,6 @@ uid_t ArgvMap::asUid(const string& arg)
   return uid;
 }
 
-int ArgvMap::asNum(const string& arg, int def)
-{
-  if (!parmIsset(arg)) {
-    throw ArgException(string("Undefined but needed argument: '") + arg + "'");
-  }
-
-  // use default for empty values
-  if (d_params[arg].empty()) {
-    return def;
-  }
-
-  const auto* cptr_orig = d_params[arg].c_str();
-  char* cptr_ret = nullptr;
-  auto retval = static_cast<int>(strtol(cptr_orig, &cptr_ret, 0));
-  if (retval == 0 && cptr_ret == cptr_orig) {
-    throw ArgException("'" + arg + "' value '" + string(cptr_orig) + string("' is not a valid number"));
-  }
-
-  return retval;
-}
-
 bool ArgvMap::isEmpty(const string& arg)
 {
   if (!parmIsset(arg)) {

--- a/pdns/arguments.hh
+++ b/pdns/arguments.hh
@@ -108,7 +108,7 @@ public:
   void setDefaults();
 
   template <typename T>
-  T asBoundedNum(const string& arg, T minval, T maxval, T def = 0)
+  T asBoundedNum(const string& arg, T minval = std::numeric_limits<T>::min(), T maxval = std::numeric_limits<T>::max(), T def = 0)
   {
     if (!parmIsset(arg)) {
       throw ArgException(string("Undefined but needed argument: '") + arg + "'");
@@ -140,6 +140,12 @@ public:
   T asNum(const string& arg, T def = 0)
   {
     return asBoundedNum<T>(arg, std::numeric_limits<T>::min(), std::numeric_limits<T>::max(), def);
+  }
+
+  template <typename T = int>
+  void assignNum(T& var, const string& arg, T def = 0)
+  {
+    var = asNum<T>(arg, def);
   }
 
   vector<string> list();

--- a/pdns/arguments.hh
+++ b/pdns/arguments.hh
@@ -92,7 +92,6 @@ public:
   bool parseFile(const string& fname, const string& arg, bool lax); //<! parse one line
   bool parmIsset(const string& var); //!< Checks if a parameter is set to *a* value
   bool mustDo(const string& var); //!< if a switch is given, if we must do something (--help)
-  int asNum(const string& arg, int def = 0); //!< return a variable value as a number or the default if the variable is empty
   mode_t asMode(const string& arg); //!< return value interpreted as octal number
   uid_t asUid(const string& arg); //!< return user id, resolves if necessary
   gid_t asGid(const string& arg); //!< return group id, resolves if necessary
@@ -107,6 +106,41 @@ public:
   bool isEmpty(const string& arg); //!< checks if variable has value
   void setDefault(const string& var, const string& value);
   void setDefaults();
+
+  template <typename T>
+  T asBoundedNum(const string& arg, T minval, T maxval, T def = 0)
+  {
+    if (!parmIsset(arg)) {
+      throw ArgException(string("Undefined but needed argument: '") + arg + "'");
+    }
+
+    // use default for empty values
+    const std::string& param = d_params[arg];
+    if (param.empty()) {
+      return def;
+    }
+
+    try {
+      size_t unused{0};
+      T retval = pdns::checked_stoi<T>(param, &unused, 0);
+      if (retval < minval || retval > maxval) {
+        throw std::out_of_range("oh no!");
+      }
+      return retval;
+    }
+    catch (std::invalid_argument&) {
+      throw ArgException("'" + arg + "' value '" + param + string("' is not a valid number"));
+    }
+    catch (std::out_of_range&) {
+      throw ArgException("'" + arg + "' value '" + param + string("' value is out of [" + std::to_string(minval) + ".." + std::to_string(maxval) + "] range"));
+    }
+  }
+
+  template <typename T = int>
+  T asNum(const string& arg, T def = 0)
+  {
+    return asBoundedNum<T>(arg, std::numeric_limits<T>::min(), std::numeric_limits<T>::max(), def);
+  }
 
   vector<string> list();
   [[nodiscard]] string getHelp(const string& item) const

--- a/pdns/auth-carbon.cc
+++ b/pdns/auth-carbon.cc
@@ -83,7 +83,7 @@ void carbonDumpThread(Logr::log_t slog)
           continue;
         }
       }
-      sleep(arg().asNum("carbon-interval"));
+      sleep(arg().asNum<unsigned int>("carbon-interval")); // NOLINT(concurrency-mt-unsafe): yes, sleep may be implemented using SIGALRM. But it's 2026 now.
     }
   }
   catch(std::exception& e) {

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -819,17 +819,17 @@ static void mainthread()
 #ifdef HAVE_LUA_RECORDS
     g_doLuaRecord = ::arg().mustDo("enable-lua-records");
     g_LuaRecordSharedState = (::arg()["enable-lua-records"] == "shared");
-    g_luaRecordExecLimit = ::arg().asNum("lua-records-exec-limit");
+    ::arg().assignNum(g_luaRecordExecLimit, "lua-records-exec-limit");
     g_luaRecordInsertWhitespace = ::arg().mustDo("lua-records-insert-whitespace");
-    g_luaHealthChecksInterval = ::arg().asNum<time_t>("lua-health-checks-interval");
-    g_luaConsistentHashesExpireDelay = ::arg().asNum<time_t>("lua-consistent-hashes-expire-delay");
-    g_luaConsistentHashesCleanupInterval = ::arg().asNum<time_t>("lua-consistent-hashes-cleanup-interval");
-    g_luaHealthChecksExpireDelay = ::arg().asNum<time_t>("lua-health-checks-expire-delay");
+    ::arg().assignNum(g_luaHealthChecksInterval, "lua-health-checks-interval");
+    ::arg().assignNum(g_luaConsistentHashesExpireDelay, "lua-consistent-hashes-expire-delay");
+    ::arg().assignNum(g_luaConsistentHashesCleanupInterval, "lua-consistent-hashes-cleanup-interval");
+    ::arg().assignNum(g_luaHealthChecksExpireDelay, "lua-health-checks-expire-delay");
 #endif
 #ifdef ENABLE_GSS_TSIG
     g_doGssTSIG = ::arg().mustDo("enable-gss-tsig");
     if (g_doGssTSIG) {
-      GssContext::s_maxGssContexts = ::arg().asNum<unsigned int>("gss-max-contexts");
+      ::arg().assignNum(GssContext::s_maxGssContexts, "gss-max-contexts");
     }
 #endif
     g_views = ::arg().mustDo("views");
@@ -841,7 +841,7 @@ static void mainthread()
     PacketHandler::s_NAPTRprocessing = ::arg().mustDo("naptr-additional-processing");
 
     g_proxyProtocolACL.toMasks(::arg()["proxy-protocol-from"]);
-    g_proxyProtocolMaximumSize = ::arg().asNum<size_t>("proxy-protocol-maximum-size");
+    ::arg().assignNum(g_proxyProtocolMaximumSize, "proxy-protocol-maximum-size");
   }
   catch (ArgException& exc) {
     SLOG(g_log << Logger::Error << "Fatal error: " << exc.reason << endl,

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -802,57 +802,52 @@ static void mainthread()
   if (!::arg()["setuid"].empty())
     newuid = strToUID(::arg()["setuid"]);
 
-  g_anyToTcp = ::arg().mustDo("any-to-tcp");
-  g_8bitDNS = ::arg().mustDo("8bit-dns");
-  g_logDNSQueries = ::arg().mustDo("log-dns-queries");
-  g_soa_edit_spread = ::arg().asNum("soa-edit-spread");
-  if (g_soa_edit_spread > 604800) {
-    SLOG(g_log << Logger::Error << "Value " << ::arg()["soa-edit-spread"] << " for soa-edit-spread too large" << endl,
-         slog->error(Logr::Error, "Out of range", "Invalid value", "soa-edit-spread", Logging::Loggable(::arg()["soa-edit-spread"])));
+  try {
+    g_anyToTcp = ::arg().mustDo("any-to-tcp");
+    g_8bitDNS = ::arg().mustDo("8bit-dns");
+    g_logDNSQueries = ::arg().mustDo("log-dns-queries");
 
-    exit(1); // NOLINT(concurrency-mt-unsafe) we're single threaded at this point
-  }
+    g_soa_edit_spread = ::arg().asBoundedNum<uint32_t>("soa-edit-spread", 0, 604800);
 
-  if (::arg()["rrsig-expiry-extend"] == "soa-edit-spread") {
-    g_rrsig_expiry_extend = g_soa_edit_spread;
-  }
-  else {
-    g_rrsig_expiry_extend = ::arg().asNum("rrsig-expiry-extend");
-
-    if (g_rrsig_expiry_extend > 31536000) {
-      SLOG(g_log << Logger::Error << "Value " << ::arg()["rrsig-expiry-extend"] << " for rrsig-expiry-extend too large" << endl,
-           slog->error(Logr::Error, "Out of range", "Invalid value", "rrsig-expiry-extend", Logging::Loggable(::arg()["rrsig-expiry-extend"])));
-
-      exit(1); // NOLINT(concurrency-mt-unsafe) we're single threaded at this point
+    if (::arg()["rrsig-expiry-extend"] == "soa-edit-spread") {
+      g_rrsig_expiry_extend = g_soa_edit_spread;
     }
-  }
+    else {
+      g_rrsig_expiry_extend = ::arg().asBoundedNum<uint32_t>("rrsig-expiry-extend", 0, 31536000);
+    }
 
 #ifdef HAVE_LUA_RECORDS
-  g_doLuaRecord = ::arg().mustDo("enable-lua-records");
-  g_LuaRecordSharedState = (::arg()["enable-lua-records"] == "shared");
-  g_luaRecordExecLimit = ::arg().asNum("lua-records-exec-limit");
-  g_luaRecordInsertWhitespace = ::arg().mustDo("lua-records-insert-whitespace");
-  g_luaHealthChecksInterval = ::arg().asNum("lua-health-checks-interval");
-  g_luaConsistentHashesExpireDelay = ::arg().asNum("lua-consistent-hashes-expire-delay");
-  g_luaConsistentHashesCleanupInterval = ::arg().asNum("lua-consistent-hashes-cleanup-interval");
-  g_luaHealthChecksExpireDelay = ::arg().asNum("lua-health-checks-expire-delay");
+    g_doLuaRecord = ::arg().mustDo("enable-lua-records");
+    g_LuaRecordSharedState = (::arg()["enable-lua-records"] == "shared");
+    g_luaRecordExecLimit = ::arg().asNum("lua-records-exec-limit");
+    g_luaRecordInsertWhitespace = ::arg().mustDo("lua-records-insert-whitespace");
+    g_luaHealthChecksInterval = ::arg().asNum<time_t>("lua-health-checks-interval");
+    g_luaConsistentHashesExpireDelay = ::arg().asNum<time_t>("lua-consistent-hashes-expire-delay");
+    g_luaConsistentHashesCleanupInterval = ::arg().asNum<time_t>("lua-consistent-hashes-cleanup-interval");
+    g_luaHealthChecksExpireDelay = ::arg().asNum<time_t>("lua-health-checks-expire-delay");
 #endif
 #ifdef ENABLE_GSS_TSIG
-  g_doGssTSIG = ::arg().mustDo("enable-gss-tsig");
-  if (g_doGssTSIG) {
-    GssContext::s_maxGssContexts = ::arg().asNum("gss-max-contexts");
-  }
+    g_doGssTSIG = ::arg().mustDo("enable-gss-tsig");
+    if (g_doGssTSIG) {
+      GssContext::s_maxGssContexts = ::arg().asNum<unsigned int>("gss-max-contexts");
+    }
 #endif
-  g_views = ::arg().mustDo("views");
-  g_memberCatalogGroup = ::arg()["member-catalog-group"];
+    g_views = ::arg().mustDo("views");
+    g_memberCatalogGroup = ::arg()["member-catalog-group"];
 
-  DNSPacket::s_udpTruncationThreshold = std::max(512, ::arg().asNum("udp-truncation-threshold"));
-  DNSPacket::s_doEDNSSubnetProcessing = ::arg().mustDo("edns-subnet-processing");
-  PacketHandler::s_SVCAutohints = ::arg().mustDo("svc-autohints");
-  PacketHandler::s_NAPTRprocessing = ::arg().mustDo("naptr-additional-processing");
+    DNSPacket::s_udpTruncationThreshold = std::max(static_cast<uint16_t>(512), ::arg().asNum<uint16_t>("udp-truncation-threshold"));
+    DNSPacket::s_doEDNSSubnetProcessing = ::arg().mustDo("edns-subnet-processing");
+    PacketHandler::s_SVCAutohints = ::arg().mustDo("svc-autohints");
+    PacketHandler::s_NAPTRprocessing = ::arg().mustDo("naptr-additional-processing");
 
-  g_proxyProtocolACL.toMasks(::arg()["proxy-protocol-from"]);
-  g_proxyProtocolMaximumSize = ::arg().asNum("proxy-protocol-maximum-size");
+    g_proxyProtocolACL.toMasks(::arg()["proxy-protocol-from"]);
+    g_proxyProtocolMaximumSize = ::arg().asNum<size_t>("proxy-protocol-maximum-size");
+  }
+  catch (ArgException& exc) {
+    SLOG(g_log << Logger::Error << "Fatal error: " << exc.reason << endl,
+         slog->error(Logr::Error, exc.reason, "Fatal error"));
+    exit(1); // NOLINT(concurrency-mt-unsafe) we're single threaded at this point
+  }
 
   if (::arg()["edns-cookie-secret"].size() != 0) {
     // User wants cookie processing
@@ -905,11 +900,11 @@ static void mainthread()
   // (no more checks yet)
 
   PC.setSLog(slog);
-  PC.setTTL(::arg().asNum("cache-ttl"));
-  PC.setMaxEntries(::arg().asNum("max-packet-cache-entries"));
+  PC.setTTL(::arg().asNum<uint32_t>("cache-ttl"));
+  PC.setMaxEntries(::arg().asNum<uint64_t>("max-packet-cache-entries"));
   QC.setSLog(slog);
-  QC.setMaxEntries(::arg().asNum("max-cache-entries"));
-  DNSSECKeeper::setMaxEntries(::arg().asNum("max-cache-entries"));
+  QC.setMaxEntries(::arg().asNum<uint64_t>("max-cache-entries"));
+  DNSSECKeeper::setMaxEntries(::arg().asNum<uint64_t>("max-cache-entries"));
 
   if (!PC.enabled() && ::arg().mustDo("log-dns-queries")) {
     SLOG(g_log << Logger::Warning << "Packet cache disabled, logging queries without HIT/MISS" << endl,
@@ -969,13 +964,12 @@ static void mainthread()
     bool hadKeyError = false;
     int kskAlgo{0}, zskAlgo{0};
     for (const string algotype : {"ksk", "zsk"}) {
-      int algo, size;
       std::string key = "default-" + algotype + "-algorithm";
       if (::arg()[key].empty())
         continue;
-      algo = DNSSECKeeper::shorthand2algorithm(::arg()[key]);
+      int algo = DNSSECKeeper::shorthand2algorithm(::arg()[key]);
       std::string sizekey = "default-" + algotype + "-size";
-      size = ::arg().asNum(sizekey);
+      auto size = ::arg().asNum<size_t>(sizekey);
       if (algo == -1) {
         SLOG(g_log << Logger::Error << "Error: " << key << " set to unknown algorithm: " << ::arg()[key] << endl,
              slog->info(Logr::Error, "Unknown algorithm specified", "setting", Logging::Loggable(key), "algorithm", Logging::Loggable(::arg()[key])));
@@ -1025,7 +1019,7 @@ static void mainthread()
 
   // Setup the zone cache
   g_zoneCache.setSLog(slog);
-  g_zoneCache.setRefreshInterval(::arg().asNum("zone-cache-refresh-interval"));
+  g_zoneCache.setRefreshInterval(::arg().asNum<uint32_t>("zone-cache-refresh-interval"));
   if (g_zoneCache.getRefreshInterval() != 0) {
     if (!updateZoneCache(slog)) {
       exit(1); // NOLINT(concurrency-mt-unsafe) we're single threaded at this point
@@ -1044,7 +1038,7 @@ static void mainthread()
 
   s_tcpNameserver->go(); // tcp nameserver launch
 
-  unsigned int max_rthreads = ::arg().asNum("receiver-threads", 1);
+  auto max_rthreads = ::arg().asNum<unsigned int>("receiver-threads", 1);
   s_distributors.resize(max_rthreads);
   for (unsigned int n = 0; n < max_rthreads; ++n) {
     std::thread t(qthread, n);
@@ -1689,7 +1683,7 @@ int main(int argc, char** argv)
       _exit(99);
     }
 
-    if (!::arg().asNum("local-port")) {
+    if (::arg().asNum<uint16_t>("local-port") == 0) {
       SLOG(g_log << Logger::Error << "Unable to launch, binding to no port or port 0 makes no sense" << endl,
            startupLog->info(Logr::Error, "Unable to launch, no proper local-port configured"));
       exit(99); // this isn't going to fix itself either
@@ -1744,7 +1738,7 @@ int main(int argc, char** argv)
     DynListener::registerFunc("XFR-QUEUE", &DLSuckRequests, "Get all requests for XFR in queue");
 
     if (!::arg()["tcp-control-address"].empty()) {
-      DynListener* dlTCP = new DynListener(g_slog, ComboAddress(::arg()["tcp-control-address"], ::arg().asNum("tcp-control-port")));
+      auto* dlTCP = new DynListener(g_slog, ComboAddress(::arg()["tcp-control-address"], ::arg().asNum<uint16_t>("tcp-control-port")));
       dlTCP->go();
     }
 
@@ -1767,7 +1761,7 @@ int main(int argc, char** argv)
     s_udpNameserver = std::make_shared<UDPNameserver>(g_slog); // this fails when we are not root, throws exception
     s_udpReceivers.push_back(s_udpNameserver);
 
-    size_t rthreads = ::arg().asNum("receiver-threads", 1);
+    auto rthreads = ::arg().asNum<size_t>("receiver-threads", 1);
     if (rthreads > 1 && s_udpNameserver->canReusePort()) {
       s_udpReceivers.resize(rthreads);
 

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -513,11 +513,11 @@ void CommunicatorClass::ixfrSuck(const TSIGTriplet& tsig, const ComboAddress& la
       return;
     }
 
-    uint16_t xfrTimeout = ::arg().asNum("axfr-fetch-timeout");
+    auto xfrTimeout = ::arg().asNum<uint16_t>("axfr-fetch-timeout");
     soatimes drsoa_soatimes = {ctx.domain.serial, 0, 0, 0, 0};
     DNSRecord drsoa;
     drsoa.setContent(std::make_shared<SOARecordContent>(g_rootdnsname, g_rootdnsname, drsoa_soatimes));
-    auto deltas = getIXFRDeltas(ctx.slog, ctx.remote, ctx.domain.zone.operator const DNSName&(), drsoa, xfrTimeout, false, tsig, laddr.sin4.sin_family != 0 ? &laddr : nullptr, ((size_t)::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024);
+    auto deltas = getIXFRDeltas(ctx.slog, ctx.remote, ctx.domain.zone.operator const DNSName&(), drsoa, xfrTimeout, false, tsig, laddr.sin4.sin_family != 0 ? &laddr : nullptr, (::arg().asNum<size_t>("xfr-max-received-mbytes")) * 1024 * 1024);
     ctx.numDeltas = deltas.size();
     //    cout<<"Got "<<deltas.size()<<" deltas from serial "<<ctx.domain.serial<<", applying.."<<endl;
 
@@ -685,9 +685,9 @@ static bool processRecordForZS(const DNSName& domain, bool& firstNSEC3, DNSResou
 
 static vector<DNSResourceRecord> doAxfr(const TSIGTriplet& tt, const ComboAddress& laddr, unique_ptr<AuthLua4>& pdl, XFRContext& ctx) // NOLINT(readability-identifier-length)
 {
-  uint16_t axfr_timeout = ::arg().asNum("axfr-fetch-timeout");
+  auto axfr_timeout = ::arg().asNum<uint16_t>("axfr-fetch-timeout");
   vector<DNSResourceRecord> rrs;
-  AXFRRetriever retriever(ctx.slog, ctx.remote, ctx.domain.zone, tt, (laddr.sin4.sin_family == 0) ? nullptr : &laddr, ((size_t)::arg().asNum("xfr-max-received-mbytes")) * 1024 * 1024, axfr_timeout);
+  AXFRRetriever retriever(ctx.slog, ctx.remote, ctx.domain.zone, tt, (laddr.sin4.sin_family == 0) ? nullptr : &laddr, (::arg().asNum<size_t>("xfr-max-received-mbytes")) * 1024 * 1024, axfr_timeout);
   Resolver::res_t recs;
   bool first = true;
   bool firstNSEC3{true};
@@ -1013,7 +1013,7 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
     }
 
     bool doent = true;
-    uint32_t maxent = ::arg().asNum("max-ent-entries");
+    auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
     DNSName shorter;
     DNSName ordername;
     set<DNSName> rrterm;
@@ -1479,7 +1479,7 @@ void CommunicatorClass::secondaryRefresh(PacketHandler* P) // NOLINT(readability
     if (ssr.d_freshness.count(di.id) == 0) { // If we don't have an answer for the domain
       auto [newCount, nextCheck] = markAsFailed(di.zone);
       if (newCount == 1) {
-        SLOG(g_log << Logger::Warning << "Unable to retrieve SOA for " << di.zone << " from " << remote.toStringWithPortExcept(53) << ", this was the first time. NOTE: For every subsequent failed SOA check the domain will be suspended from freshness checks for 'num-errors x " << d_tickinterval << " seconds', with a maximum of " << (uint64_t)::arg().asNum("default-ttl") << " seconds. Skipping SOA checks until " << humanTime(nextCheck) << endl,
+        SLOG(g_log << Logger::Warning << "Unable to retrieve SOA for " << di.zone << " from " << remote.toStringWithPortExcept(53) << ", this was the first time. NOTE: For every subsequent failed SOA check the domain will be suspended from freshness checks for 'num-errors x " << d_tickinterval << " seconds', with a maximum of " << ::arg().asNum<uint32_t>("default-ttl") << " seconds. Skipping SOA checks until " << humanTime(nextCheck) << endl,
              d_slog->info(Logr::Warning, "Unable to retrieve SOA for the first time", "zone", Logging::Loggable(di.zone), "remote", Logging::Loggable(remote.toStringWithPortExcept(53)), "SOA checks skipped until", Logging::Loggable(humanTime(nextCheck))));
       }
       else if (newCount % 10 == 0) {
@@ -1620,7 +1620,7 @@ std::pair<uint64_t, time_t> CommunicatorClass::markAsFailed(const ZoneName& doma
   if (failedEntry != data->d_failedSecondaryRefresh.end()) {
     newCount = data->d_failedSecondaryRefresh[domain].first + 1;
   }
-  time_t nextCheck = now + std::min(newCount * d_tickinterval, (uint64_t)::arg().asNum("default-ttl")); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+  time_t nextCheck = now + std::min(newCount * d_tickinterval, static_cast<uint64_t>(::arg().asNum<uint32_t>("default-ttl"))); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   data->d_failedSecondaryRefresh[domain] = {newCount, nextCheck};
   return std::make_pair(newCount, nextCheck);
 }

--- a/pdns/backends/gsql/gsqlbackend.cc
+++ b/pdns/backends/gsql/gsqlbackend.cc
@@ -2581,7 +2581,7 @@ bool GSQLBackend::searchComments(const string &pattern, size_t maxResults, vecto
 
 void GSQLBackend::extractRecord(SSqlStatement::row_t& row, DNSResourceRecord& r)
 {
-  static const int defaultTTL = ::arg().asNum( "default-ttl" );
+  static const auto defaultTTL = ::arg().asNum<uint32_t>("default-ttl");
 
   if (row[1].empty())
       r.ttl = defaultTTL;
@@ -2640,7 +2640,7 @@ void GSQLBackend::extractRecord_unsafe(SSqlStatement::row_t& row, DNSResourceRec
   invalid.clear();
 
   try {
-    static const int defaultTTL = ::arg().asNum( "default-ttl" );
+    static const auto defaultTTL = ::arg().asNum<uint32_t>("default-ttl");
 
     if (row[1].empty()) {
       rec.ttl = defaultTTL;

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -129,7 +129,7 @@ void CommunicatorClass::mainloop()
     SLOG(g_log << Logger::Warning << "Primary/secondary communicator launching" << endl,
          d_slog->info(Logr::Warning, "Primary/secondary communicator launching"));
 
-    d_tickinterval = ::arg().asNum<time_t>("xfr-cycle-interval");
+    ::arg().assignNum(d_tickinterval, "xfr-cycle-interval");
 
     int rc;
     time_t next;

--- a/pdns/communicator.cc
+++ b/pdns/communicator.cc
@@ -95,7 +95,7 @@ void CommunicatorClass::go()
   std::thread mainT([this]() { mainloop(); });
   mainT.detach();
 
-  for (int nthreads = 0; nthreads < ::arg().asNum("retrieval-threads", 1); ++nthreads) {
+  for (int nthreads = ::arg().asNum("retrieval-threads", 1); nthreads > 0; --nthreads) {
     std::thread retrieve([this]() { retrievalLoopThread(); });
     retrieve.detach();
   }
@@ -129,7 +129,7 @@ void CommunicatorClass::mainloop()
     SLOG(g_log << Logger::Warning << "Primary/secondary communicator launching" << endl,
          d_slog->info(Logr::Warning, "Primary/secondary communicator launching"));
 
-    d_tickinterval = ::arg().asNum("xfr-cycle-interval");
+    d_tickinterval = ::arg().asNum<time_t>("xfr-cycle-interval");
 
     int rc;
     time_t next;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -238,7 +238,7 @@ bool DNSSECKeeper::getFromMeta(const ZoneName& zname, const std::string& key, st
     d_metaUpdate=false;
   }
 
-  static int ttl = ::arg().asNum("zone-metadata-cache-ttl");
+  static auto ttl = ::arg().asNum<uint32_t>("zone-metadata-cache-ttl");
 
   if(!((++s_ops) % 100000)) {
     cleanup();
@@ -350,7 +350,7 @@ bool DNSSECKeeper::getNSEC3PARAM(const ZoneName& zname, NSEC3PARAMRecordContent*
     return false;
   }
 
-  static int maxNSEC3Iterations=::arg().asNum("max-nsec3-iterations");
+  static auto maxNSEC3Iterations=::arg().asNum<uint16_t>("max-nsec3-iterations");
   if(ns3p != nullptr) {
     *ns3p = NSEC3PARAMRecordContent(value);
     if (ns3p->d_iterations > maxNSEC3Iterations && !isPresigned(zname, useCache)) {
@@ -379,7 +379,7 @@ bool DNSSECKeeper::getNSEC3PARAM(const ZoneName& zname, NSEC3PARAMRecordContent*
  */
 bool DNSSECKeeper::checkNSEC3PARAM(const NSEC3PARAMRecordContent& ns3p, string& msg)
 {
-  static int maxNSEC3Iterations=::arg().asNum("max-nsec3-iterations");
+  static auto maxNSEC3Iterations=::arg().asNum<uint16_t>("max-nsec3-iterations");
   bool ret = true;
   if (ns3p.d_iterations > maxNSEC3Iterations) {
     msg += "Number of NSEC3 iterations is above 'max-nsec3-iterations'.";
@@ -554,7 +554,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getEntryPoints(const ZoneName& zname)
 
 DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const ZoneName& zone, bool useCache)
 {
-  static int ttl = ::arg().asNum("dnssec-key-cache-ttl");
+  static auto ttl = ::arg().asNum<uint32_t>("dnssec-key-cache-ttl");
   // coverity[store_truncates_time_t]
   unsigned int now = time(nullptr);
 
@@ -881,7 +881,7 @@ bool DNSSECKeeper::rectifyZone(const ZoneName& zone, string& error, string& info
 
     std::unordered_map<DNSName,bool> nonterm;
     bool doent{true};
-    uint32_t maxent = ::arg().asNum("max-ent-entries");
+    auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
 
     std::unordered_map<DNSName,RecordStatus>::const_iterator it;
     for (const auto& qname: qnames) {

--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -165,7 +165,7 @@ template<class Answer, class Question, class Backend>SingleThreadDistributor<Ans
 }
 
 template<class Answer, class Question, class Backend>MultiThreadDistributor<Answer,Question,Backend>::MultiThreadDistributor(int numberOfThreads, Logr::log_t slog) :
-  d_last_started(time(nullptr)), d_overloadQueueLength(::arg().asNum("overload-queue-length")), d_maxQueueLength(::arg().asNum("max-queue-length")), d_num_threads(numberOfThreads)
+  d_last_started(time(nullptr)), d_overloadQueueLength(::arg().asNum<unsigned int>("overload-queue-length")), d_maxQueueLength(::arg().asNum<unsigned int>("max-queue-length")), d_num_threads(numberOfThreads)
 {
   d_slog = slog;
   if (numberOfThreads < 1) {
@@ -201,7 +201,7 @@ template<class Answer, class Question, class Backend>void MultiThreadDistributor
 
   try {
     auto b = make_unique<Backend>(d_slog); // this will answer our questions
-    int queuetimeout = ::arg().asNum("queue-limit");
+    auto queuetimeout = ::arg().asBoundedNum<int>("queue-limit", 0, INT_MAX);
     auto& receiver = d_receivers.at(ournum);
 
     for (;;) {

--- a/pdns/distributor.hh
+++ b/pdns/distributor.hh
@@ -165,7 +165,7 @@ template<class Answer, class Question, class Backend>SingleThreadDistributor<Ans
 }
 
 template<class Answer, class Question, class Backend>MultiThreadDistributor<Answer,Question,Backend>::MultiThreadDistributor(int numberOfThreads, Logr::log_t slog) :
-  d_last_started(time(nullptr)), d_overloadQueueLength(::arg().asNum<unsigned int>("overload-queue-length")), d_maxQueueLength(::arg().asNum<unsigned int>("max-queue-length")), d_num_threads(numberOfThreads)
+  d_last_started(time(nullptr)), d_overloadQueueLength(::arg().asNum<decltype(d_overloadQueueLength)>("overload-queue-length")), d_maxQueueLength(::arg().asNum<decltype(d_maxQueueLength)>("max-queue-length")), d_num_threads(numberOfThreads)
 {
   d_slog = slog;
   if (numberOfThreads < 1) {

--- a/pdns/dnsproxy.cc
+++ b/pdns/dnsproxy.cc
@@ -162,7 +162,7 @@ bool DNSProxy::completePacket(std::unique_ptr<DNSPacket>& reply, const DNSName& 
     uint16_t len = htons(reply->getString().length());
     string buffer((const char*)&len, 2);
     buffer.append(reply->getString());
-    writen2WithTimeout(reply->getSocket(), buffer.c_str(), buffer.length(), timeval{::arg().asNum("tcp-idle-timeout"), 0});
+    writen2WithTimeout(reply->getSocket(), buffer.c_str(), buffer.length(), timeval{::arg().asNum<time_t>("tcp-idle-timeout"), 0});
 
     return true;
   }

--- a/pdns/dnssecsigner.cc
+++ b/pdns/dnssecsigner.cc
@@ -92,12 +92,12 @@ static void fillOutRRSIG(DNSSECPrivateKey& dpk, const DNSName& signQName, RRSIGR
   if(doCache) {
     /* we add some jitter here so not all your secondaries start pruning their caches at the very same millisecond */
     time_t weekno = (time(nullptr) - dns_random(3600)) / static_cast<time_t>(86400*7);  // we just spent milliseconds doing a signature, microsecond more won't kill us
-    const static int maxcachesize=::arg().asNum("max-signature-cache-entries", INT_MAX);
+    const static auto maxcachesize=::arg().asNum<size_t>("max-signature-cache-entries", INT_MAX);
 
     signaturecache_t oldsigs;
     {
       auto signatures = g_signatures.write_lock();
-      if (g_cacheweekno < weekno || signatures->size() >= (uint) maxcachesize) {  // blunt but effective (C) Habbie, mind04
+      if (g_cacheweekno < weekno || signatures->size() >= maxcachesize) {  // blunt but effective (C) Habbie, mind04
         SLOG(g_log<<Logger::Warning<<"Cleared signature cache."<<endl,
              g_slog->info(Logr::Warning, "Cleared signature cache."));
         std::swap(oldsigs, *signatures);

--- a/pdns/nameserver.cc
+++ b/pdns/nameserver.cc
@@ -101,7 +101,7 @@ void UDPNameserver::bindAddresses()
   int s;
   // for(vector<string>::const_iterator i=locals.begin();i!=locals.end();++i) {
   for (const auto &local : locals) {
-    ComboAddress locala(local, ::arg().asNum("local-port"));
+    ComboAddress locala(local, ::arg().asNum<uint16_t>("local-port"));
 
     s = socket(locala.sin4.sin_family, SOCK_DGRAM, 0);
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2760,7 +2760,7 @@ static int createZone(const ZoneName &zone, const DNSName& nsname) {
   DNSResourceRecord rr;
   rr.qname = zone.operator const DNSName&();
   rr.auth = true;
-  rr.ttl = ::arg().asNum<uint32_t>("default-ttl");
+  ::arg().assignNum(rr.ttl, "default-ttl");
   rr.qtype = "SOA";
 
   string soa = ::arg()["default-soa-content"];
@@ -2877,7 +2877,7 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds)
   }
 
   rr.qtype = DNSRecordContent::TypeToNumber(cmds.at(2));
-  rr.ttl = ::arg().asNum<uint32_t>("default-ttl");
+  ::arg().assignNum(rr.ttl, "default-ttl");
   rr.auth = true;
   rr.domain_id = di.id;
   rr.qname = name;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -738,8 +738,9 @@ static void loadMainConfig(const std::string& configdir)
   }
 
   BackendMakers(g_slog).launch(::arg()["launch"]); // vrooooom!
-  if(::arg().asNum("loglevel") >= 3) // so you can't kill our errors
-    g_log.toConsole((Logger::Urgency)::arg().asNum("loglevel"));
+  if(s_logUrgency >= LOG_ERR) { // so you can't kill our errors
+    g_log.toConsole(s_logUrgency);
+  }
 
   //cerr<<"Backend: "<<::arg()["launch"]<<", '" << ::arg()["gmysql-dbname"] <<"'" <<endl;
 
@@ -2236,8 +2237,8 @@ static bool parseZoneFile(const char* tmpnam, int& errorline, std::vector<DNSRec
 {
   records.clear();
   ZoneParserTNG zpt(tmpnam, g_rootzonename, "", ::arg().mustDo("upgrade-unknown-types"));
-  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
-  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
+  zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum<size_t>("max-include-depth"));
   DNSResourceRecord zrr;
   try {
     while(zpt.get(zrr)) {
@@ -2630,7 +2631,7 @@ static int xcryptIP(bool encrypt, const std::string& ip, const std::string& rkey
 
 static int zonemdVerifyFile(const ZoneName& zone, const string& fname) {
   ZoneParserTNG zpt(fname, zone, "", true);
-  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+  zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
 
   bool validationDone, validationOK;
 
@@ -2702,7 +2703,7 @@ static int loadZone(const ZoneName& zone, const string& fname) {
   DNSBackend* db = di.backend;
   ZoneParserTNG zpt(fname, zone, "", ::arg().mustDo("upgrade-unknown-types"));
   zpt.setDefaultTTL(::arg().asNum("default-ttl"));
-  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+  zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
 
   DNSResourceRecord rr;
   if(!db->startTransaction(zone, di.id)) {
@@ -2759,7 +2760,7 @@ static int createZone(const ZoneName &zone, const DNSName& nsname) {
   DNSResourceRecord rr;
   rr.qname = zone.operator const DNSName&();
   rr.auth = true;
-  rr.ttl = ::arg().asNum("default-ttl");
+  rr.ttl = ::arg().asNum<uint32_t>("default-ttl");
   rr.qtype = "SOA";
 
   string soa = ::arg()["default-soa-content"];
@@ -2808,7 +2809,7 @@ static int createZone(const ZoneName &zone, const DNSName& nsname) {
       }
     }
 
-    if (::arg().asNum("zone-cache-refresh-interval") != 0) {
+    if (::arg().asNum<uint32_t>("zone-cache-refresh-interval") != 0) {
       cout << "If the authoritative server is running, be sure to refresh its zone cache" << endl << "with 'pdns_control rediscover'" << endl;
     }
   }
@@ -2876,7 +2877,7 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds)
   }
 
   rr.qtype = DNSRecordContent::TypeToNumber(cmds.at(2));
-  rr.ttl = ::arg().asNum("default-ttl");
+  rr.ttl = ::arg().asNum<uint32_t>("default-ttl");
   rr.auth = true;
   rr.domain_id = di.id;
   rr.qname = name;
@@ -3186,7 +3187,7 @@ static void testSpeed(const ZoneName& zone, int cores)
 static void verifyCrypto(const string& zone)
 {
   ZoneParserTNG zpt(zone);
-  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+  zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
   DNSResourceRecord rr;
   DNSKEYRecordContent drc;
   RRSIGRecordContent rrc;
@@ -3428,7 +3429,7 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
     }
   }
 
-  g_soa_edit_spread = ::arg().asNum("soa-edit-spread");
+  g_soa_edit_spread = ::arg().asBoundedNum<uint32_t>("soa-edit-spread", 0, 604800);
   if (g_verbose && g_soa_edit_spread > 0) {
     auto [inception, _] = getStartOfWeek();
     auto delay = weekSpreadDelay(zone);
@@ -3614,20 +3615,12 @@ static bool secureZone(DNSSECKeeper& dsk, const ZoneName& zone)
 
   // parse attribute
   string k_algo = ::arg()["default-ksk-algorithm"];
-  int k_size = ::arg().asNum("default-ksk-size");
+  auto k_size = ::arg().asNum<size_t>("default-ksk-size");
   string z_algo = ::arg()["default-zsk-algorithm"];
-  int z_size = ::arg().asNum("default-zsk-size");
-
-  if (k_size < 0) {
-     throw runtime_error("KSK key size must be equal to or greater than 0");
-  }
+  auto z_size = ::arg().asNum<size_t>("default-zsk-size");
 
   if (k_algo.empty() && z_algo.empty()) {
      throw runtime_error("Zero algorithms given for KSK+ZSK in total");
-  }
-
-  if (z_size < 0) {
-     throw runtime_error("ZSK key size must be equal to or greater than 0");
   }
 
   if(dsk.isSecuredZone(zone)) {
@@ -4302,7 +4295,7 @@ static int addZoneKey(vector<string>& cmds, const std::string_view synopsis)
   // Try to get algorithm, bits & ksk or zsk from commandline
   bool keyOrZone=true; // default to KSK
   int tmp_algo=0;
-  int bits=0;
+  size_t bits=0;
   int algorithm=-1;
   bool active=false;
   bool published=true;
@@ -4339,16 +4332,10 @@ static int addZoneKey(vector<string>& cmds, const std::string_view synopsis)
   // Use configuration defaults for missing values
   if (bits == 0) {
     if (keyOrZone) {
-      bits = ::arg().asNum("default-ksk-size");
-      if (bits < 0) {
-         throw runtime_error("Default KSK key size must be equal to or greater than 0");
-      }
+      bits = ::arg().asNum<size_t>("default-ksk-size");
     }
     else {
-      bits = ::arg().asNum("default-zsk-size");
-      if (bits < 0) {
-         throw runtime_error("Default ZSK key size must be equal to or greater than 0");
-      }
+      bits = ::arg().asNum<size_t>("default-zsk-size");
     }
   }
   if (algorithm == -1) {

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -380,7 +380,7 @@ static bool checkIncomingECSSource(const PacketBuffer& packet, const Netmask& su
 LWResult::Result arecvfrom(PacketBuffer& packet, const ComboAddress& fromAddr, size_t& len,
                            uint16_t qid, const DNSName& domain, uint16_t qtype, int fileDesc, const std::optional<EDNSSubnetOpts>& ecs, const struct timeval& now)
 {
-  static const unsigned int nearMissLimit = ::arg().asNum("spoof-nearmiss-max");
+  static const auto nearMissLimit = ::arg().asNum<unsigned int>("spoof-nearmiss-max");
 
   auto pident = std::make_shared<PacketID>();
   pident->fd = fileDesc;
@@ -2031,7 +2031,7 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
 
   runTaskOnce(g_logCommonErrors);
 
-  static const size_t stackSizeThreshold = 9 * ::arg().asNum("stack-size") / 10;
+  static const auto stackSizeThreshold = 9 * ::arg().asNum<size_t>("stack-size") / 10;
   if (t_multiTasker->getMaxStackUsage() >= stackSizeThreshold) {
     resolver.d_slog->info(Logr::Error, "Reached mthread stack usage of 90%",
                           "stackUsage", Logging::Loggable(t_multiTasker->getMaxStackUsage()),
@@ -2779,7 +2779,7 @@ unsigned int makeUDPServerSockets(deferredAdd_t& deferredAdds, Logr::log_t log, 
     throw PDNSException("No local address specified");
   }
 
-  const uint16_t defaultLocalPort = ::arg().asNum("local-port");
+  const auto defaultLocalPort = ::arg().asNum<uint16_t>("local-port");
   const vector<string> defaultVector = {"127.0.0.1", "::1"};
   const auto configIsDefault = localAddresses == defaultVector;
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -844,8 +844,8 @@ static void setupNODThread(Logr::log_t log)
       log->info(Logr::Error, "Could not initialize domain tracking");
       _exit(1);
     }
-    if (::arg().asNum<unsigned int>("new-domain-db-snapshot-interval") > 0) {
-      g_nodDBp->setSnapshotInterval(::arg().asNum<unsigned int>("new-domain-db-snapshot-interval"));
+    if (auto snapshot_interval = ::arg().asNum<unsigned int>("new-domain-db-snapshot-interval"); snapshot_interval > 0) {
+      g_nodDBp->setSnapshotInterval(snapshot_interval);
       std::thread thread([tid = std::this_thread::get_id()]() {
         g_nodDBp->housekeepingThread(tid);
       });
@@ -866,8 +866,8 @@ static void setupNODThread(Logr::log_t log)
       log->info(Logr::Error, "Could not initialize unique response tracking");
       _exit(1);
     }
-    if (::arg().asNum<unsigned int>("new-domain-db-snapshot-interval") > 0) {
-      g_udrDBp->setSnapshotInterval(::arg().asNum<unsigned int>("new-domain-db-snapshot-interval"));
+    if (auto snapshot_interval = ::arg().asNum<unsigned int>("new-domain-db-snapshot-interval"); snapshot_interval > 0) {
+      g_udrDBp->setSnapshotInterval(snapshot_interval);
       std::thread thread([tid = std::this_thread::get_id()]() {
         g_udrDBp->housekeepingThread(tid);
       });
@@ -1707,21 +1707,13 @@ static int initDNSSEC(Logr::log_t log)
     return 1;
   }
 
-  {
-    auto value = ::arg().asNum("signature-inception-skew");
-    if (value < 0) {
-      log->info(Logr::Error, "A negative value for 'signature-inception-skew' is not allowed");
-      return 1;
-    }
-    g_signatureInceptionSkew = value;
-  }
-
+  ::arg().assignNum(g_signatureInceptionSkew, "signature-inception-skew");
   g_dnssecLogBogus = ::arg().mustDo("dnssec-log-bogus");
-  g_maxNSEC3Iterations = ::arg().asNum<uint16_t>("nsec3-max-iterations");
-  g_maxRRSIGsPerRecordToConsider = ::arg().asNum<uint16_t>("max-rrsigs-per-record");
-  g_maxNSEC3sPerRecordToConsider = ::arg().asNum<uint16_t>("max-nsec3s-per-record");
-  g_maxDNSKEYsToConsider = ::arg().asNum<uint16_t>("max-dnskeys");
-  g_maxDSsToConsider = ::arg().asNum<uint16_t>("max-ds-per-zone");
+  ::arg().assignNum(g_maxNSEC3Iterations, "nsec3-max-iterations");
+  ::arg().assignNum(g_maxRRSIGsPerRecordToConsider, "max-rrsigs-per-record");
+  ::arg().assignNum(g_maxNSEC3sPerRecordToConsider, "max-nsec3s-per-record");
+  ::arg().assignNum(g_maxDNSKEYsToConsider, "max-dnskeys");
+  ::arg().assignNum(g_maxDSsToConsider, "max-ds-per-zone");
 
   vector<string> nums;
   bool automatic = true;
@@ -1765,66 +1757,70 @@ static void initDontQuery(Logr::log_t log)
 static int initSyncRes(Logr::log_t log)
 {
   try {
-    SyncRes::s_minimumTTL = ::arg().asNum<unsigned int>("minimum-ttl-override");
-    SyncRes::s_minimumECSTTL = ::arg().asNum<unsigned int>("ecs-minimum-ttl-override");
-    SyncRes::s_maxnegttl = ::arg().asNum<unsigned int>("max-negative-ttl");
-    SyncRes::s_maxbogusttl = ::arg().asNum<unsigned int>("max-cache-bogus-ttl");
-    SyncRes::s_maxcachettl = max(::arg().asNum<unsigned int>("max-cache-ttl"), 15U);
+    ::arg().assignNum(SyncRes::s_minimumTTL, "minimum-ttl-override");
+    ::arg().assignNum(SyncRes::s_minimumECSTTL, "ecs-minimum-ttl-override");
+    ::arg().assignNum(SyncRes::s_maxnegttl, "max-negative-ttl");
+    ::arg().assignNum(SyncRes::s_maxbogusttl, "max-cache-bogus-ttl");
+    ::arg().assignNum(SyncRes::s_maxcachettl, "max-cache-ttl");
+    // Silently clamp without rejecting too large values
+    SyncRes::s_maxcachettl = max(SyncRes::s_maxcachettl, 15U);
 
-    SyncRes::s_packetcachettl = ::arg().asNum<unsigned int>("packetcache-ttl");
+    ::arg().assignNum(SyncRes::s_packetcachettl, "packetcache-ttl");
     // Cap the packetcache-servfail-ttl and packetcache-negative-ttl to packetcache-ttl
-    SyncRes::s_packetcacheservfailttl = std::min(::arg().asNum<unsigned int>("packetcache-servfail-ttl"), SyncRes::s_packetcachettl);
-    SyncRes::s_packetcachenegativettl = std::min(::arg().asNum<unsigned int>("packetcache-negative-ttl"), SyncRes::s_packetcachettl);
+    ::arg().assignNum(SyncRes::s_packetcacheservfailttl, "packetcache-servfail-ttl");
+    SyncRes::s_packetcacheservfailttl = std::min(SyncRes::s_packetcacheservfailttl, SyncRes::s_packetcachettl);
+    ::arg().assignNum(SyncRes::s_packetcachenegativettl, "packetcache-negative-ttl");
+    SyncRes::s_packetcachenegativettl = std::min(SyncRes::s_packetcachenegativettl, SyncRes::s_packetcachettl);
 
-    SyncRes::s_serverdownmaxfails = ::arg().asNum<unsigned int>("server-down-max-fails");
-    SyncRes::s_serverdownthrottletime = ::arg().asNum<unsigned int>("server-down-throttle-time");
-    SyncRes::s_unthrottle_n = ::arg().asNum<unsigned int>("bypass-server-throttling-probability");
-    SyncRes::s_nonresolvingnsmaxfails = ::arg().asNum<unsigned int>("non-resolving-ns-max-fails");
-    SyncRes::s_nonresolvingnsthrottletime = ::arg().asNum<unsigned int>("non-resolving-ns-throttle-time");
+    ::arg().assignNum(SyncRes::s_serverdownmaxfails, "server-down-max-fails");
+    ::arg().assignNum(SyncRes::s_serverdownthrottletime, "server-down-throttle-time");
+    ::arg().assignNum(SyncRes::s_unthrottle_n, "bypass-server-throttling-probability");
+    ::arg().assignNum(SyncRes::s_nonresolvingnsmaxfails, "non-resolving-ns-max-fails");
+    ::arg().assignNum(SyncRes::s_nonresolvingnsthrottletime, "non-resolving-ns-throttle-time");
     SyncRes::s_serverID = ::arg()["server-id"];
     // This bound is dynamically adjusted in SyncRes, depending on qname minimization being active
-    SyncRes::s_maxqperq = ::arg().asNum<unsigned int>("max-qperq");
-    SyncRes::s_maxbytesperq = ::arg().asNum<unsigned int>("max-bytesperq");
-    SyncRes::s_maxnsperresolve = ::arg().asNum<unsigned int>("max-ns-per-resolve");
-    SyncRes::s_maxnsaddressqperq = ::arg().asNum<unsigned int>("max-ns-address-qperq");
-    SyncRes::s_maxtotusec = 1000 * ::arg().asNum<unsigned int>("max-total-msec");
-    SyncRes::s_maxdepth = ::arg().asNum<unsigned int>("max-recursion-depth");
-    SyncRes::s_maxvalidationsperq = ::arg().asNum<unsigned int>("max-signature-validations-per-query");
-    SyncRes::s_maxnsec3iterationsperq = ::arg().asNum<unsigned int>("max-nsec3-hash-computations-per-query");
+    ::arg().assignNum(SyncRes::s_maxqperq, "max-qperq");
+    ::arg().assignNum(SyncRes::s_maxbytesperq, "max-bytesperq");
+    ::arg().assignNum(SyncRes::s_maxnsperresolve, "max-ns-per-resolve");
+    ::arg().assignNum(SyncRes::s_maxnsaddressqperq, "max-ns-address-qperq");
+    ::arg().assignNum(SyncRes::s_maxtotusec, "max-total-msec");
+    SyncRes::s_maxtotusec *= 1000;
+    ::arg().assignNum(SyncRes::s_maxdepth, "max-recursion-depth");
+    ::arg().assignNum(SyncRes::s_maxvalidationsperq, "max-signature-validations-per-query");
+    ::arg().assignNum(SyncRes::s_maxnsec3iterationsperq, "max-nsec3-hash-computations-per-query");
     SyncRes::s_rootNXTrust = ::arg().mustDo("root-nx-trust");
-    SyncRes::s_refresh_ttlperc = ::arg().asNum<unsigned int>("refresh-on-ttl-perc");
-    SyncRes::s_locked_ttlperc = ::arg().asNum<unsigned int>("record-cache-locked-ttl-perc");
+    ::arg().assignNum(SyncRes::s_refresh_ttlperc, "refresh-on-ttl-perc");
+    ::arg().assignNum(SyncRes::s_locked_ttlperc, "record-cache-locked-ttl-perc");
     RecursorPacketCache::s_refresh_ttlperc = SyncRes::s_refresh_ttlperc;
-    SyncRes::s_tcp_fast_open = ::arg().asNum("tcp-fast-open");
+    ::arg().assignNum(SyncRes::s_tcp_fast_open, "tcp-fast-open");
     SyncRes::s_tcp_fast_open_connect = ::arg().mustDo("tcp-fast-open-connect");
 
     SyncRes::s_dot_to_port_853 = ::arg().mustDo("dot-to-port-853");
-    SyncRes::s_event_trace_enabled = ::arg().asNum("event-trace-enabled");
+    ::arg().assignNum(SyncRes::s_event_trace_enabled, "event-trace-enabled");
     SyncRes::s_save_parent_ns_set = ::arg().mustDo("save-parent-ns-set");
-    SyncRes::s_max_busy_dot_probes = ::arg().asNum<unsigned int>("max-busy-dot-probes");
-    SyncRes::s_max_CNAMES_followed = ::arg().asNum<unsigned int>("max-cnames-followed");
-    auto sse = ::arg().asNum<uint16_t>("serve-stale-extensions");
-    MemRecursorCache::s_maxServedStaleExtensions = sse;
-    NegCache::s_maxServedStaleExtensions = sse;
-    MemRecursorCache::s_maxRRSetSize = ::arg().asNum<uint16_t>("max-rrset-size");
+    ::arg().assignNum(SyncRes::s_max_busy_dot_probes, "max-busy-dot-probes");
+    ::arg().assignNum(SyncRes::s_max_CNAMES_followed, "max-cnames-followed");
+    ::arg().assignNum(MemRecursorCache::s_maxServedStaleExtensions, "serve-stale-extensions");
+    NegCache::s_maxServedStaleExtensions = MemRecursorCache::s_maxServedStaleExtensions;
+    ::arg().assignNum(MemRecursorCache::s_maxRRSetSize, "max-rrset-size");
     MemRecursorCache::s_limitQTypeAny = ::arg().mustDo("limit-qtype-any");
 
     if (SyncRes::s_tcp_fast_open_connect) {
       checkFastOpenSysctl(true, log);
       checkTFOconnect(log);
     }
-    SyncRes::s_ecsipv4limit = ::arg().asNum<uint8_t>("ecs-ipv4-bits");
-    SyncRes::s_ecsipv6limit = ::arg().asNum<uint8_t>("ecs-ipv6-bits");
+    ::arg().assignNum(SyncRes::s_ecsipv4limit, "ecs-ipv4-bits");
+    ::arg().assignNum(SyncRes::s_ecsipv6limit, "ecs-ipv6-bits");
     SyncRes::clearECSStats();
-    SyncRes::s_ecsipv4cachelimit = ::arg().asNum<uint8_t>("ecs-ipv4-cache-bits");
-    SyncRes::s_ecsipv6cachelimit = ::arg().asNum<uint8_t>("ecs-ipv6-cache-bits");
+    ::arg().assignNum(SyncRes::s_ecsipv4cachelimit, "ecs-ipv4-cache-bits");
+    ::arg().assignNum(SyncRes::s_ecsipv6cachelimit, "ecs-ipv6-cache-bits");
     SyncRes::s_ecsipv4nevercache = ::arg().mustDo("ecs-ipv4-never-cache");
     SyncRes::s_ecsipv6nevercache = ::arg().mustDo("ecs-ipv6-never-cache");
-    SyncRes::s_ecscachelimitttl = ::arg().asNum<unsigned int>("ecs-cache-limit-ttl");
+    ::arg().assignNum(SyncRes::s_ecscachelimitttl, "ecs-cache-limit-ttl");
 
     SyncRes::s_qnameminimization = ::arg().mustDo("qname-minimization");
-    SyncRes::s_minimize_one_label = ::arg().asNum<unsigned int>("qname-minimize-one-label");
-    SyncRes::s_max_minimize_count = ::arg().asNum<unsigned int>("qname-max-minimize-count");
+    ::arg().assignNum(SyncRes::s_minimize_one_label, "qname-minimize-one-label");
+    ::arg().assignNum(SyncRes::s_max_minimize_count, "qname-max-minimize-count");
 
     SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;
     string value = ::arg()["nothing-below-nxdomain"];
@@ -1938,7 +1934,8 @@ static unsigned int initDistribution(Logr::log_t log)
 static int initForks(Logr::log_t log)
 {
   int forks = 0;
-  for (; forks < ::arg().asNum("processes") - 1; ++forks) {
+  int nforks = ::arg().asNum("processes");
+  for (; forks < nforks - 1; ++forks) {
     if (fork() == 0) { // we are child
       break;
     }
@@ -2171,7 +2168,7 @@ static int serviceMain(Logr::log_t log)
     log->info(Logr::Notice, "PowerDNS Recursor itself will distribute queries over threads");
   }
 
-  g_outgoingEDNSBufsize = ::arg().asNum<uint16_t>("edns-outgoing-bufsize");
+  ::arg().assignNum(g_outgoingEDNSBufsize, "edns-outgoing-bufsize");
 
   if (::arg()["trace"] == "fail") {
     SyncRes::setDefaultLogMode(SyncRes::Store);
@@ -2201,27 +2198,27 @@ static int serviceMain(Logr::log_t log)
       }
     }
   }
-  g_proxyProtocolMaximumSize = ::arg().asNum<size_t>("proxy-protocol-maximum-size");
+  ::arg().assignNum(g_proxyProtocolMaximumSize, "proxy-protocol-maximum-size");
 
   ret = initDNS64(log);
   if (ret != 0) {
     return ret;
   }
-  g_networkTimeoutMsec = ::arg().asNum<unsigned int>("network-timeout");
+  ::arg().assignNum(g_networkTimeoutMsec, "network-timeout");
 
   { // Reduce scope of locks (otherwise Coverity induces from this line the global vars below should be
     // protected by a mutex)
     std::tie(*g_initialDomainMap.lock(), *g_initialAllowNotifyFor.lock()) = parseZoneConfiguration(g_yamlSettings);
   }
 
-  g_latencyStatSize = ::arg().asNum<uint64_t>("latency-statistic-size");
+  ::arg().assignNum(g_latencyStatSize, "latency-statistic-size");
 
   g_logCommonErrors = ::arg().mustDo("log-common-errors");
   g_logRPZChanges = ::arg().mustDo("log-rpz-changes");
 
   g_anyToTcp = ::arg().mustDo("any-to-tcp");
   g_allowNoRD = ::arg().mustDo("allow-no-rd");
-  g_udpTruncationThreshold = ::arg().asNum<uint16_t>("udp-truncation-threshold");
+  ::arg().assignNum(g_udpTruncationThreshold, "udp-truncation-threshold");
 
   g_lowercaseOutgoing = ::arg().mustDo("lowercase-outgoing");
 
@@ -2236,7 +2233,7 @@ static int serviceMain(Logr::log_t log)
     log->info(Logr::Error, "Unknown edns-padding-mode", "edns-padding-mode", Logging::Loggable(::arg()["edns-padding-mode"]));
     return 1;
   }
-  g_paddingTag = ::arg().asNum<unsigned int>("edns-padding-tag");
+  ::arg().assignNum(g_paddingTag, "edns-padding-tag");
   g_paddingOutgoing = ::arg().mustDo("edns-padding-out");
   g_ECSHardening = ::arg().mustDo("edns-subnet-harden");
 
@@ -2256,7 +2253,7 @@ static int serviceMain(Logr::log_t log)
     RecThreadInfo::setNumTCPWorkerThreads(1);
   }
 
-  g_maxMThreads = ::arg().asNum<unsigned int>("max-mthreads");
+  ::arg().assignNum(g_maxMThreads, "max-mthreads");
 
   auto maxInFlight = ::arg().asBoundedNum<uint32_t>("max-concurrent-requests-per-tcp-connection", 1, USHRT_MAX);
   if (maxInFlight >= g_maxMThreads) {
@@ -2269,27 +2266,27 @@ static int serviceMain(Logr::log_t log)
 
   auto millis = ::arg().asNum<time_t>("tcp-out-max-idle-ms");
   TCPOutConnectionManager::s_maxIdleTime = timeval{millis / 1000, (static_cast<suseconds_t>(millis) % 1000) * 1000};
-  TCPOutConnectionManager::s_maxIdlePerAuth = ::arg().asNum<size_t>("tcp-out-max-idle-per-auth");
-  TCPOutConnectionManager::s_maxQueries = ::arg().asNum<size_t>("tcp-out-max-queries");
-  TCPOutConnectionManager::s_maxIdlePerThread = ::arg().asNum<size_t>("tcp-out-max-idle-per-thread");
+  ::arg().assignNum(TCPOutConnectionManager::s_maxIdlePerAuth, "tcp-out-max-idle-per-auth");
+  ::arg().assignNum(TCPOutConnectionManager::s_maxQueries, "tcp-out-max-queries");
+  ::arg().assignNum(TCPOutConnectionManager::s_maxIdlePerThread, "tcp-out-max-idle-per-thread");
 
   g_gettagNeedsEDNSOptions = ::arg().mustDo("gettag-needs-edns-options");
 
-  s_statisticsInterval = ::arg().asNum<time_t>("statistics-interval");
+  ::arg().assignNum(s_statisticsInterval, "statistics-interval");
 
   SyncRes::s_addExtendedResolutionDNSErrors = ::arg().mustDo("extended-resolution-errors");
   SyncRes::s_ntaExtendedError = ::arg().mustDo("nta-extended-error");
 
-  if (::arg().asNum<uint64_t>("aggressive-nsec-cache-size") > 0) {
+  if (auto cache_size = ::arg().asNum<uint64_t>("aggressive-nsec-cache-size"); cache_size > 0) {
     if (g_dnssecmode == DNSSECMode::ValidateAll || g_dnssecmode == DNSSECMode::ValidateForLog || g_dnssecmode == DNSSECMode::Process) {
-      g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(::arg().asNum<uint64_t>("aggressive-nsec-cache-size"));
+      g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(cache_size);
     }
     else {
       log->info(Logr::Warning, "Aggressive NSEC/NSEC3 caching is enabled but DNSSEC validation is not set to 'validate', 'log-fail' or 'process', ignoring");
     }
   }
 
-  AggressiveNSECCache::s_nsec3DenialProofMaxCost = ::arg().asNum<uint64_t>("aggressive-cache-max-nsec3-hash-cost");
+  ::arg().assignNum(AggressiveNSECCache::s_nsec3DenialProofMaxCost, "aggressive-cache-max-nsec3-hash-cost");
   AggressiveNSECCache::s_maxNSEC3CommonPrefix = static_cast<uint8_t>(std::round(std::log2(::arg().asNum("aggressive-cache-min-nsec3-hit-ratio"))));
   log->info(Logr::Debug, "NSEC3 aggressive cache tuning", "aggressive-cache-min-nsec3-hit-ratio", Logging::Loggable(::arg().asNum("aggressive-cache-min-nsec3-hit-ratio")), "maxCommonPrefixBits", Logging::Loggable(AggressiveNSECCache::s_maxNSEC3CommonPrefix));
 
@@ -2304,14 +2301,14 @@ static int serviceMain(Logr::log_t log)
 
   auto forks = initForks(log);
 
-  g_tcpTimeout = ::arg().asNum("client-tcp-timeout");
-  g_maxTCPClients = ::arg().asNum<unsigned int>("max-tcp-clients");
-  g_maxTCPPerClient = ::arg().asNum<unsigned int>("max-tcp-per-client");
-  g_tcpMaxQueriesPerConn = ::arg().asNum<size_t>("max-tcp-queries-per-connection");
-  g_maxUDPQueriesPerRound = ::arg().asNum<size_t>("max-udp-queries-per-round");
+  ::arg().assignNum(g_tcpTimeout, "client-tcp-timeout");
+  ::arg().assignNum(g_maxTCPClients, "max-tcp-clients");
+  ::arg().assignNum(g_maxTCPPerClient, "max-tcp-per-client");
+  ::arg().assignNum(g_tcpMaxQueriesPerConn, "max-tcp-queries-per-connection");
+  ::arg().assignNum(g_maxUDPQueriesPerRound, "max-udp-queries-per-round");
 
   g_useKernelTimestamp = ::arg().mustDo("protobuf-use-kernel-timestamp");
-  g_maxChainLength = ::arg().asNum<unsigned int>("max-chain-length");
+  ::arg().assignNum(g_maxChainLength, "max-chain-length");
 
   checkOrFixFDS(listeningSockets, log);
   checkOrFixLinuxMapCountLimits(log);
@@ -3403,18 +3400,18 @@ int main(int argc, char** argv)
 
     if (auto ttl = ::arg().asNum<uint32_t>("system-resolver-ttl"); ttl != 0) {
       time_t interval = ttl;
-      if (::arg().asNum<time_t>("system-resolver-interval") != 0) {
-        interval = ::arg().asNum<time_t>("system-resolver-interval");
+      if (auto value = ::arg().asNum<decltype(interval)>("system-resolver-interval"); value != 0) {
+        interval = value;
       }
       bool selfResolveCheck = ::arg().mustDo("system-resolver-self-resolve-check");
       // Cannot use SyncRes::s_serverID, it is not set yet
       pdns::RecResolve::setInstanceParameters(arg()["server-id"], ttl, interval, selfResolveCheck, []() { reloadZoneConfiguration(g_yamlSettings); });
     }
 
-    MemRecursorCache::s_maxEntrySize = ::arg().asNum<uint32_t>("max-recordcache-entry-size");
+    ::arg().assignNum(MemRecursorCache::s_maxEntrySize, "max-recordcache-entry-size");
     NegCache::s_maxEntrySize = MemRecursorCache::s_maxEntrySize;
     AggressiveNSECCache::s_maxEntrySize = MemRecursorCache::s_maxEntrySize;
-    RecursorPacketCache::s_maxEntrySize = ::arg().asNum<uint32_t>("max-packetcache-entry-size");
+    ::arg().assignNum(RecursorPacketCache::s_maxEntrySize, "max-packetcache-entry-size");
     g_recCache = std::make_unique<MemRecursorCache>(::arg().asNum<size_t>("record-cache-shards"));
     g_negCache = std::make_unique<NegCache>(::arg().asNum<size_t>("record-cache-shards") / 8);
     if (!::arg().mustDo("disable-packetcache")) {

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -333,7 +333,7 @@ int RecThreadInfo::runThreads(Logr::log_t log)
 
 void RecThreadInfo::makeThreadPipes(Logr::log_t log)
 {
-  auto pipeBufferSize = ::arg().asNum("distribution-pipe-buffer-size");
+  auto pipeBufferSize = ::arg().asNum<size_t>("distribution-pipe-buffer-size");
   if (pipeBufferSize > 0) {
     log->info(Logr::Info, "Resizing the buffer of the distribution pipe", "size", Logging::Loggable(pipeBufferSize));
   }
@@ -831,7 +831,7 @@ static void checkSocketDir(Logr::log_t log)
 static void setupNODThread(Logr::log_t log)
 {
   if (g_nodEnabled) {
-    uint32_t num_cells = ::arg().asNum("new-domain-db-size");
+    auto num_cells = ::arg().asNum<uint32_t>("new-domain-db-size");
     g_nodDBp = std::make_unique<nod::NODDB>(num_cells);
     try {
       g_nodDBp->setCacheDir(::arg()["new-domain-history-dir"]);
@@ -844,8 +844,8 @@ static void setupNODThread(Logr::log_t log)
       log->info(Logr::Error, "Could not initialize domain tracking");
       _exit(1);
     }
-    if (::arg().asNum("new-domain-db-snapshot-interval") > 0) {
-      g_nodDBp->setSnapshotInterval(::arg().asNum("new-domain-db-snapshot-interval"));
+    if (::arg().asNum<unsigned int>("new-domain-db-snapshot-interval") > 0) {
+      g_nodDBp->setSnapshotInterval(::arg().asNum<unsigned int>("new-domain-db-snapshot-interval"));
       std::thread thread([tid = std::this_thread::get_id()]() {
         g_nodDBp->housekeepingThread(tid);
       });
@@ -853,7 +853,7 @@ static void setupNODThread(Logr::log_t log)
     }
   }
   if (g_udrEnabled) {
-    uint32_t num_cells = ::arg().asNum("unique-response-db-size");
+    auto num_cells = ::arg().asNum<uint32_t>("unique-response-db-size");
     g_udrDBp = std::make_unique<nod::UniqueResponseDB>(num_cells);
     try {
       g_udrDBp->setCacheDir(::arg()["unique-response-history-dir"]);
@@ -866,8 +866,8 @@ static void setupNODThread(Logr::log_t log)
       log->info(Logr::Error, "Could not initialize unique response tracking");
       _exit(1);
     }
-    if (::arg().asNum("new-domain-db-snapshot-interval") > 0) {
-      g_udrDBp->setSnapshotInterval(::arg().asNum("new-domain-db-snapshot-interval"));
+    if (::arg().asNum<unsigned int>("new-domain-db-snapshot-interval") > 0) {
+      g_udrDBp->setSnapshotInterval(::arg().asNum<unsigned int>("new-domain-db-snapshot-interval"));
       std::thread thread([tid = std::this_thread::get_id()]() {
         g_udrDBp->housekeepingThread(tid);
       });
@@ -1456,7 +1456,7 @@ void parseACLs()
   auto allowFrom = parseACL("allow-from-file", "allow-from", log);
 
   if (allowFrom->empty()) {
-    if (::arg()["local-address"] != "127.0.0.1" && ::arg().asNum("local-port") == 53) {
+    if (::arg()["local-address"] != "127.0.0.1" && ::arg().asNum<uint16_t>("local-port") == 53) {
       log->info(Logr::Warning, "WARNING: Allowing queries from all IP addresses - this can be a security risk!");
     }
     allowFrom = nullptr;
@@ -1717,11 +1717,11 @@ static int initDNSSEC(Logr::log_t log)
   }
 
   g_dnssecLogBogus = ::arg().mustDo("dnssec-log-bogus");
-  g_maxNSEC3Iterations = ::arg().asNum("nsec3-max-iterations");
-  g_maxRRSIGsPerRecordToConsider = ::arg().asNum("max-rrsigs-per-record");
-  g_maxNSEC3sPerRecordToConsider = ::arg().asNum("max-nsec3s-per-record");
-  g_maxDNSKEYsToConsider = ::arg().asNum("max-dnskeys");
-  g_maxDSsToConsider = ::arg().asNum("max-ds-per-zone");
+  g_maxNSEC3Iterations = ::arg().asNum<uint16_t>("nsec3-max-iterations");
+  g_maxRRSIGsPerRecordToConsider = ::arg().asNum<uint16_t>("max-rrsigs-per-record");
+  g_maxNSEC3sPerRecordToConsider = ::arg().asNum<uint16_t>("max-nsec3s-per-record");
+  g_maxDNSKEYsToConsider = ::arg().asNum<uint16_t>("max-dnskeys");
+  g_maxDSsToConsider = ::arg().asNum<uint16_t>("max-ds-per-zone");
 
   vector<string> nums;
   bool automatic = true;
@@ -1764,117 +1764,117 @@ static void initDontQuery(Logr::log_t log)
 
 static int initSyncRes(Logr::log_t log)
 {
-  SyncRes::s_minimumTTL = ::arg().asNum("minimum-ttl-override");
-  SyncRes::s_minimumECSTTL = ::arg().asNum("ecs-minimum-ttl-override");
-  SyncRes::s_maxnegttl = ::arg().asNum("max-negative-ttl");
-  SyncRes::s_maxbogusttl = ::arg().asNum("max-cache-bogus-ttl");
-  SyncRes::s_maxcachettl = max(::arg().asNum("max-cache-ttl"), 15);
+  try {
+    SyncRes::s_minimumTTL = ::arg().asNum<unsigned int>("minimum-ttl-override");
+    SyncRes::s_minimumECSTTL = ::arg().asNum<unsigned int>("ecs-minimum-ttl-override");
+    SyncRes::s_maxnegttl = ::arg().asNum<unsigned int>("max-negative-ttl");
+    SyncRes::s_maxbogusttl = ::arg().asNum<unsigned int>("max-cache-bogus-ttl");
+    SyncRes::s_maxcachettl = max(::arg().asNum<unsigned int>("max-cache-ttl"), 15U);
 
-  SyncRes::s_packetcachettl = ::arg().asNum("packetcache-ttl");
-  // Cap the packetcache-servfail-ttl and packetcache-negative-ttl to packetcache-ttl
-  SyncRes::s_packetcacheservfailttl = std::min(static_cast<unsigned int>(::arg().asNum("packetcache-servfail-ttl")), SyncRes::s_packetcachettl);
-  SyncRes::s_packetcachenegativettl = std::min(static_cast<unsigned int>(::arg().asNum("packetcache-negative-ttl")), SyncRes::s_packetcachettl);
+    SyncRes::s_packetcachettl = ::arg().asNum<unsigned int>("packetcache-ttl");
+    // Cap the packetcache-servfail-ttl and packetcache-negative-ttl to packetcache-ttl
+    SyncRes::s_packetcacheservfailttl = std::min(::arg().asNum<unsigned int>("packetcache-servfail-ttl"), SyncRes::s_packetcachettl);
+    SyncRes::s_packetcachenegativettl = std::min(::arg().asNum<unsigned int>("packetcache-negative-ttl"), SyncRes::s_packetcachettl);
 
-  SyncRes::s_serverdownmaxfails = ::arg().asNum("server-down-max-fails");
-  SyncRes::s_serverdownthrottletime = ::arg().asNum("server-down-throttle-time");
-  SyncRes::s_unthrottle_n = ::arg().asNum("bypass-server-throttling-probability");
-  SyncRes::s_nonresolvingnsmaxfails = ::arg().asNum("non-resolving-ns-max-fails");
-  SyncRes::s_nonresolvingnsthrottletime = ::arg().asNum("non-resolving-ns-throttle-time");
-  SyncRes::s_serverID = ::arg()["server-id"];
-  // This bound is dynamically adjusted in SyncRes, depending on qname minimization being active
-  SyncRes::s_maxqperq = ::arg().asNum("max-qperq");
-  SyncRes::s_maxbytesperq = ::arg().asNum("max-bytesperq");
-  SyncRes::s_maxnsperresolve = ::arg().asNum("max-ns-per-resolve");
-  SyncRes::s_maxnsaddressqperq = ::arg().asNum("max-ns-address-qperq");
-  SyncRes::s_maxtotusec = 1000 * ::arg().asNum("max-total-msec");
-  SyncRes::s_maxdepth = ::arg().asNum("max-recursion-depth");
-  SyncRes::s_maxvalidationsperq = ::arg().asNum("max-signature-validations-per-query");
-  SyncRes::s_maxnsec3iterationsperq = ::arg().asNum("max-nsec3-hash-computations-per-query");
-  SyncRes::s_rootNXTrust = ::arg().mustDo("root-nx-trust");
-  SyncRes::s_refresh_ttlperc = ::arg().asNum("refresh-on-ttl-perc");
-  SyncRes::s_locked_ttlperc = ::arg().asNum("record-cache-locked-ttl-perc");
-  RecursorPacketCache::s_refresh_ttlperc = SyncRes::s_refresh_ttlperc;
-  SyncRes::s_tcp_fast_open = ::arg().asNum("tcp-fast-open");
-  SyncRes::s_tcp_fast_open_connect = ::arg().mustDo("tcp-fast-open-connect");
+    SyncRes::s_serverdownmaxfails = ::arg().asNum<unsigned int>("server-down-max-fails");
+    SyncRes::s_serverdownthrottletime = ::arg().asNum<unsigned int>("server-down-throttle-time");
+    SyncRes::s_unthrottle_n = ::arg().asNum<unsigned int>("bypass-server-throttling-probability");
+    SyncRes::s_nonresolvingnsmaxfails = ::arg().asNum<unsigned int>("non-resolving-ns-max-fails");
+    SyncRes::s_nonresolvingnsthrottletime = ::arg().asNum<unsigned int>("non-resolving-ns-throttle-time");
+    SyncRes::s_serverID = ::arg()["server-id"];
+    // This bound is dynamically adjusted in SyncRes, depending on qname minimization being active
+    SyncRes::s_maxqperq = ::arg().asNum<unsigned int>("max-qperq");
+    SyncRes::s_maxbytesperq = ::arg().asNum<unsigned int>("max-bytesperq");
+    SyncRes::s_maxnsperresolve = ::arg().asNum<unsigned int>("max-ns-per-resolve");
+    SyncRes::s_maxnsaddressqperq = ::arg().asNum<unsigned int>("max-ns-address-qperq");
+    SyncRes::s_maxtotusec = 1000 * ::arg().asNum<unsigned int>("max-total-msec");
+    SyncRes::s_maxdepth = ::arg().asNum<unsigned int>("max-recursion-depth");
+    SyncRes::s_maxvalidationsperq = ::arg().asNum<unsigned int>("max-signature-validations-per-query");
+    SyncRes::s_maxnsec3iterationsperq = ::arg().asNum<unsigned int>("max-nsec3-hash-computations-per-query");
+    SyncRes::s_rootNXTrust = ::arg().mustDo("root-nx-trust");
+    SyncRes::s_refresh_ttlperc = ::arg().asNum<unsigned int>("refresh-on-ttl-perc");
+    SyncRes::s_locked_ttlperc = ::arg().asNum<unsigned int>("record-cache-locked-ttl-perc");
+    RecursorPacketCache::s_refresh_ttlperc = SyncRes::s_refresh_ttlperc;
+    SyncRes::s_tcp_fast_open = ::arg().asNum("tcp-fast-open");
+    SyncRes::s_tcp_fast_open_connect = ::arg().mustDo("tcp-fast-open-connect");
 
-  SyncRes::s_dot_to_port_853 = ::arg().mustDo("dot-to-port-853");
-  SyncRes::s_event_trace_enabled = ::arg().asNum("event-trace-enabled");
-  SyncRes::s_save_parent_ns_set = ::arg().mustDo("save-parent-ns-set");
-  SyncRes::s_max_busy_dot_probes = ::arg().asNum("max-busy-dot-probes");
-  SyncRes::s_max_CNAMES_followed = ::arg().asNum("max-cnames-followed");
-  {
-    uint64_t sse = ::arg().asNum("serve-stale-extensions");
-    if (sse > std::numeric_limits<uint16_t>::max()) {
-      log->info(Logr::Error, "Illegal serve-stale-extensions value; range = 0..65536", "value", Logging::Loggable(sse));
-      return 1;
-    }
+    SyncRes::s_dot_to_port_853 = ::arg().mustDo("dot-to-port-853");
+    SyncRes::s_event_trace_enabled = ::arg().asNum("event-trace-enabled");
+    SyncRes::s_save_parent_ns_set = ::arg().mustDo("save-parent-ns-set");
+    SyncRes::s_max_busy_dot_probes = ::arg().asNum<unsigned int>("max-busy-dot-probes");
+    SyncRes::s_max_CNAMES_followed = ::arg().asNum<unsigned int>("max-cnames-followed");
+    auto sse = ::arg().asNum<uint16_t>("serve-stale-extensions");
     MemRecursorCache::s_maxServedStaleExtensions = sse;
     NegCache::s_maxServedStaleExtensions = sse;
-  }
-  MemRecursorCache::s_maxRRSetSize = ::arg().asNum("max-rrset-size");
-  MemRecursorCache::s_limitQTypeAny = ::arg().mustDo("limit-qtype-any");
+    MemRecursorCache::s_maxRRSetSize = ::arg().asNum<uint16_t>("max-rrset-size");
+    MemRecursorCache::s_limitQTypeAny = ::arg().mustDo("limit-qtype-any");
 
-  if (SyncRes::s_tcp_fast_open_connect) {
-    checkFastOpenSysctl(true, log);
-    checkTFOconnect(log);
-  }
-  SyncRes::s_ecsipv4limit = ::arg().asNum("ecs-ipv4-bits");
-  SyncRes::s_ecsipv6limit = ::arg().asNum("ecs-ipv6-bits");
-  SyncRes::clearECSStats();
-  SyncRes::s_ecsipv4cachelimit = ::arg().asNum("ecs-ipv4-cache-bits");
-  SyncRes::s_ecsipv6cachelimit = ::arg().asNum("ecs-ipv6-cache-bits");
-  SyncRes::s_ecsipv4nevercache = ::arg().mustDo("ecs-ipv4-never-cache");
-  SyncRes::s_ecsipv6nevercache = ::arg().mustDo("ecs-ipv6-never-cache");
-  SyncRes::s_ecscachelimitttl = ::arg().asNum("ecs-cache-limit-ttl");
-
-  SyncRes::s_qnameminimization = ::arg().mustDo("qname-minimization");
-  SyncRes::s_minimize_one_label = ::arg().asNum("qname-minimize-one-label");
-  SyncRes::s_max_minimize_count = ::arg().asNum("qname-max-minimize-count");
-
-  SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;
-  string value = ::arg()["nothing-below-nxdomain"];
-  if (value == "yes") {
-    SyncRes::s_hardenNXD = SyncRes::HardenNXD::Yes;
-  }
-  else if (value == "no") {
-    SyncRes::s_hardenNXD = SyncRes::HardenNXD::No;
-  }
-  else if (value != "dnssec") {
-    log->info(Logr::Error, "Unknown nothing-below-nxdomain mode", "mode", Logging::Loggable(value));
-    return 1;
-  }
-
-  if (!::arg().isEmpty("ecs-scope-zero-address")) {
-    ComboAddress scopeZero(::arg()["ecs-scope-zero-address"]);
-    SyncRes::setECSScopeZeroAddress(Netmask(scopeZero, scopeZero.isIPv4() ? 32 : 128));
-  }
-  else {
-    Netmask netmask;
-    bool done = false;
-
-    auto addr = pdns::getNonAnyQueryLocalAddress(AF_INET).d_address;
-    if (addr.sin4.sin_family != 0) {
-      netmask = Netmask(addr, 32);
-      done = true;
+    if (SyncRes::s_tcp_fast_open_connect) {
+      checkFastOpenSysctl(true, log);
+      checkTFOconnect(log);
     }
-    if (!done) {
-      addr = pdns::getNonAnyQueryLocalAddress(AF_INET6).d_address;
+    SyncRes::s_ecsipv4limit = ::arg().asNum<uint8_t>("ecs-ipv4-bits");
+    SyncRes::s_ecsipv6limit = ::arg().asNum<uint8_t>("ecs-ipv6-bits");
+    SyncRes::clearECSStats();
+    SyncRes::s_ecsipv4cachelimit = ::arg().asNum<uint8_t>("ecs-ipv4-cache-bits");
+    SyncRes::s_ecsipv6cachelimit = ::arg().asNum<uint8_t>("ecs-ipv6-cache-bits");
+    SyncRes::s_ecsipv4nevercache = ::arg().mustDo("ecs-ipv4-never-cache");
+    SyncRes::s_ecsipv6nevercache = ::arg().mustDo("ecs-ipv6-never-cache");
+    SyncRes::s_ecscachelimitttl = ::arg().asNum<unsigned int>("ecs-cache-limit-ttl");
+
+    SyncRes::s_qnameminimization = ::arg().mustDo("qname-minimization");
+    SyncRes::s_minimize_one_label = ::arg().asNum<unsigned int>("qname-minimize-one-label");
+    SyncRes::s_max_minimize_count = ::arg().asNum<unsigned int>("qname-max-minimize-count");
+
+    SyncRes::s_hardenNXD = SyncRes::HardenNXD::DNSSEC;
+    string value = ::arg()["nothing-below-nxdomain"];
+    if (value == "yes") {
+      SyncRes::s_hardenNXD = SyncRes::HardenNXD::Yes;
+    }
+    else if (value == "no") {
+      SyncRes::s_hardenNXD = SyncRes::HardenNXD::No;
+    }
+    else if (value != "dnssec") {
+      log->info(Logr::Error, "Unknown nothing-below-nxdomain mode", "mode", Logging::Loggable(value));
+      return 1;
+    }
+
+    if (!::arg().isEmpty("ecs-scope-zero-address")) {
+      ComboAddress scopeZero(::arg()["ecs-scope-zero-address"]);
+      SyncRes::setECSScopeZeroAddress(Netmask(scopeZero, scopeZero.isIPv4() ? 32 : 128));
+    }
+    else {
+      Netmask netmask;
+      bool done = false;
+
+      auto addr = pdns::getNonAnyQueryLocalAddress(AF_INET).d_address;
       if (addr.sin4.sin_family != 0) {
-        netmask = Netmask(addr, 128);
+        netmask = Netmask(addr, 32);
         done = true;
       }
+      if (!done) {
+        addr = pdns::getNonAnyQueryLocalAddress(AF_INET6).d_address;
+        if (addr.sin4.sin_family != 0) {
+          netmask = Netmask(addr, 128);
+          done = true;
+        }
+      }
+      if (!done) {
+        netmask = Netmask(ComboAddress("127.0.0.1"), 32);
+      }
+      SyncRes::setECSScopeZeroAddress(netmask);
     }
-    if (!done) {
-      netmask = Netmask(ComboAddress("127.0.0.1"), 32);
-    }
-    SyncRes::setECSScopeZeroAddress(netmask);
-  }
 
-  SyncRes::parseEDNSSubnetAllowlist(::arg()["edns-subnet-allow-list"]);
-  SyncRes::parseEDNSSubnetAddFor(::arg()["ecs-add-for"]);
-  g_useIncomingECS = ::arg().mustDo("use-incoming-edns-subnet");
-  SyncRes::s_outAnyToTcp = ::arg().mustDo("out-any-to-tcp");
-  return 0;
+    SyncRes::parseEDNSSubnetAllowlist(::arg()["edns-subnet-allow-list"]);
+    SyncRes::parseEDNSSubnetAddFor(::arg()["ecs-add-for"]);
+    g_useIncomingECS = ::arg().mustDo("use-incoming-edns-subnet");
+    SyncRes::s_outAnyToTcp = ::arg().mustDo("out-any-to-tcp");
+    return 0;
+  }
+  catch (ArgException& A) {
+    log->error(Logr::Error, A.reason, "Fatal error");
+    return 1;
+  }
 }
 
 static unsigned int initDistribution(Logr::log_t log)
@@ -1976,23 +1976,13 @@ static int initForks(Logr::log_t log)
 
 static int initPorts(Logr::log_t log)
 {
-  int port = ::arg().asNum("udp-source-port-min");
-  if (port < 1024 || port > 65535) {
-    log->info(Logr::Error, "Unable to launch, udp-source-port-min is not a valid port number");
-    return 99; // this isn't going to fix itself either
-  }
-  g_minUdpSourcePort = port;
-  port = ::arg().asNum("udp-source-port-max");
-  if (port < 1024 || port > 65535 || port < g_minUdpSourcePort) {
-    log->info(Logr::Error, "Unable to launch, udp-source-port-max is not a valid port number or is smaller than udp-source-port-min");
-    return 99; // this isn't going to fix itself either
-  }
-  g_maxUdpSourcePort = port;
+  g_minUdpSourcePort = ::arg().asBoundedNum<uint16_t>("udp-source-port-min", 1024, 65535);
+  g_maxUdpSourcePort = ::arg().asBoundedNum<uint16_t>("udp-source-port-max", g_minUdpSourcePort, 65535);
   g_avoidUdpSourcePorts.resize(std::numeric_limits<uint16_t>::max() + 1);
   std::vector<string> parts{};
   stringtok(parts, ::arg()["udp-source-port-avoid"], ", ");
   for (const auto& part : parts) {
-    port = std::stoi(part);
+    auto port = std::stoi(part);
     if (port < 1024 || port > 65535) {
       log->info(Logr::Error, "Unable to launch, udp-source-port-avoid contains an invalid port number", "port", Logging::Loggable(part));
       return 99; // this isn't going to fix itself either
@@ -2163,7 +2153,7 @@ static int serviceMain(Logr::log_t log)
   if (ret != 0) {
     return ret;
   }
-  g_maxCacheEntries = ::arg().asNum("max-cache-entries");
+  g_maxCacheEntries = ::arg().asNum<uint32_t>("max-cache-entries");
 
   auto luaResult = luaconfig(false);
   if (luaResult.d_ret != 0) {
@@ -2181,7 +2171,7 @@ static int serviceMain(Logr::log_t log)
     log->info(Logr::Notice, "PowerDNS Recursor itself will distribute queries over threads");
   }
 
-  g_outgoingEDNSBufsize = ::arg().asNum("edns-outgoing-bufsize");
+  g_outgoingEDNSBufsize = ::arg().asNum<uint16_t>("edns-outgoing-bufsize");
 
   if (::arg()["trace"] == "fail") {
     SyncRes::setDefaultLogMode(SyncRes::Store);
@@ -2211,27 +2201,27 @@ static int serviceMain(Logr::log_t log)
       }
     }
   }
-  g_proxyProtocolMaximumSize = ::arg().asNum("proxy-protocol-maximum-size");
+  g_proxyProtocolMaximumSize = ::arg().asNum<size_t>("proxy-protocol-maximum-size");
 
   ret = initDNS64(log);
   if (ret != 0) {
     return ret;
   }
-  g_networkTimeoutMsec = ::arg().asNum("network-timeout");
+  g_networkTimeoutMsec = ::arg().asNum<unsigned int>("network-timeout");
 
   { // Reduce scope of locks (otherwise Coverity induces from this line the global vars below should be
     // protected by a mutex)
     std::tie(*g_initialDomainMap.lock(), *g_initialAllowNotifyFor.lock()) = parseZoneConfiguration(g_yamlSettings);
   }
 
-  g_latencyStatSize = ::arg().asNum("latency-statistic-size");
+  g_latencyStatSize = ::arg().asNum<uint64_t>("latency-statistic-size");
 
   g_logCommonErrors = ::arg().mustDo("log-common-errors");
   g_logRPZChanges = ::arg().mustDo("log-rpz-changes");
 
   g_anyToTcp = ::arg().mustDo("any-to-tcp");
   g_allowNoRD = ::arg().mustDo("allow-no-rd");
-  g_udpTruncationThreshold = ::arg().asNum("udp-truncation-threshold");
+  g_udpTruncationThreshold = ::arg().asNum<uint16_t>("udp-truncation-threshold");
 
   g_lowercaseOutgoing = ::arg().mustDo("lowercase-outgoing");
 
@@ -2246,30 +2236,30 @@ static int serviceMain(Logr::log_t log)
     log->info(Logr::Error, "Unknown edns-padding-mode", "edns-padding-mode", Logging::Loggable(::arg()["edns-padding-mode"]));
     return 1;
   }
-  g_paddingTag = ::arg().asNum("edns-padding-tag");
+  g_paddingTag = ::arg().asNum<unsigned int>("edns-padding-tag");
   g_paddingOutgoing = ::arg().mustDo("edns-padding-out");
   g_ECSHardening = ::arg().mustDo("edns-subnet-harden");
 
   // Ignong errors return value, as YAML parsing already checked the format of the entries.
   enableOutgoingCookies(::arg().mustDo("outgoing-cookies"), ::arg()["outgoing-cookies-unsupported"]);
 
-  RecThreadInfo::setNumDistributorThreads(::arg().asNum("distributor-threads"));
-  RecThreadInfo::setNumUDPWorkerThreads(::arg().asNum("threads"));
-  RecThreadInfo::setNumTaskThreads(::arg().asNum("taskthreads"));
+  RecThreadInfo::setNumDistributorThreads(::arg().asNum<unsigned int>("distributor-threads"));
+  RecThreadInfo::setNumUDPWorkerThreads(::arg().asNum<unsigned int>("threads"));
+  RecThreadInfo::setNumTaskThreads(::arg().asNum<unsigned int>("taskthreads"));
   if (RecThreadInfo::numUDPWorkers() < 1) {
     log->info(Logr::Warning, "Asked to run with 0 threads, raising to 1 instead");
     RecThreadInfo::setNumUDPWorkerThreads(1);
   }
-  RecThreadInfo::setNumTCPWorkerThreads(::arg().asNum("tcp-threads"));
+  RecThreadInfo::setNumTCPWorkerThreads(::arg().asNum<unsigned int>("tcp-threads"));
   if (RecThreadInfo::numTCPWorkers() < 1) {
     log->info(Logr::Warning, "Asked to run with 0 TCP threads, raising to 1 instead");
     RecThreadInfo::setNumTCPWorkerThreads(1);
   }
 
-  g_maxMThreads = ::arg().asNum("max-mthreads");
+  g_maxMThreads = ::arg().asNum<unsigned int>("max-mthreads");
 
-  int64_t maxInFlight = ::arg().asNum("max-concurrent-requests-per-tcp-connection");
-  if (maxInFlight < 1 || maxInFlight > USHRT_MAX || maxInFlight >= g_maxMThreads) {
+  auto maxInFlight = ::arg().asBoundedNum<uint32_t>("max-concurrent-requests-per-tcp-connection", 1, USHRT_MAX);
+  if (maxInFlight >= g_maxMThreads) {
     log->info(Logr::Warning, "Asked to run with illegal max-concurrent-requests-per-tcp-connection, setting to default (10)");
     TCPConnection::s_maxInFlight = 10;
   }
@@ -2277,29 +2267,29 @@ static int serviceMain(Logr::log_t log)
     TCPConnection::s_maxInFlight = maxInFlight;
   }
 
-  int64_t millis = ::arg().asNum("tcp-out-max-idle-ms");
+  auto millis = ::arg().asNum<time_t>("tcp-out-max-idle-ms");
   TCPOutConnectionManager::s_maxIdleTime = timeval{millis / 1000, (static_cast<suseconds_t>(millis) % 1000) * 1000};
-  TCPOutConnectionManager::s_maxIdlePerAuth = ::arg().asNum("tcp-out-max-idle-per-auth");
-  TCPOutConnectionManager::s_maxQueries = ::arg().asNum("tcp-out-max-queries");
-  TCPOutConnectionManager::s_maxIdlePerThread = ::arg().asNum("tcp-out-max-idle-per-thread");
+  TCPOutConnectionManager::s_maxIdlePerAuth = ::arg().asNum<size_t>("tcp-out-max-idle-per-auth");
+  TCPOutConnectionManager::s_maxQueries = ::arg().asNum<size_t>("tcp-out-max-queries");
+  TCPOutConnectionManager::s_maxIdlePerThread = ::arg().asNum<size_t>("tcp-out-max-idle-per-thread");
 
   g_gettagNeedsEDNSOptions = ::arg().mustDo("gettag-needs-edns-options");
 
-  s_statisticsInterval = ::arg().asNum("statistics-interval");
+  s_statisticsInterval = ::arg().asNum<time_t>("statistics-interval");
 
   SyncRes::s_addExtendedResolutionDNSErrors = ::arg().mustDo("extended-resolution-errors");
   SyncRes::s_ntaExtendedError = ::arg().mustDo("nta-extended-error");
 
-  if (::arg().asNum("aggressive-nsec-cache-size") > 0) {
+  if (::arg().asNum<uint64_t>("aggressive-nsec-cache-size") > 0) {
     if (g_dnssecmode == DNSSECMode::ValidateAll || g_dnssecmode == DNSSECMode::ValidateForLog || g_dnssecmode == DNSSECMode::Process) {
-      g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(::arg().asNum("aggressive-nsec-cache-size"));
+      g_aggressiveNSECCache = make_unique<AggressiveNSECCache>(::arg().asNum<uint64_t>("aggressive-nsec-cache-size"));
     }
     else {
       log->info(Logr::Warning, "Aggressive NSEC/NSEC3 caching is enabled but DNSSEC validation is not set to 'validate', 'log-fail' or 'process', ignoring");
     }
   }
 
-  AggressiveNSECCache::s_nsec3DenialProofMaxCost = ::arg().asNum("aggressive-cache-max-nsec3-hash-cost");
+  AggressiveNSECCache::s_nsec3DenialProofMaxCost = ::arg().asNum<uint64_t>("aggressive-cache-max-nsec3-hash-cost");
   AggressiveNSECCache::s_maxNSEC3CommonPrefix = static_cast<uint8_t>(std::round(std::log2(::arg().asNum("aggressive-cache-min-nsec3-hit-ratio"))));
   log->info(Logr::Debug, "NSEC3 aggressive cache tuning", "aggressive-cache-min-nsec3-hit-ratio", Logging::Loggable(::arg().asNum("aggressive-cache-min-nsec3-hit-ratio")), "maxCommonPrefixBits", Logging::Loggable(AggressiveNSECCache::s_maxNSEC3CommonPrefix));
 
@@ -2315,13 +2305,13 @@ static int serviceMain(Logr::log_t log)
   auto forks = initForks(log);
 
   g_tcpTimeout = ::arg().asNum("client-tcp-timeout");
-  g_maxTCPClients = ::arg().asNum("max-tcp-clients");
-  g_maxTCPPerClient = ::arg().asNum("max-tcp-per-client");
-  g_tcpMaxQueriesPerConn = ::arg().asNum("max-tcp-queries-per-connection");
-  g_maxUDPQueriesPerRound = ::arg().asNum("max-udp-queries-per-round");
+  g_maxTCPClients = ::arg().asNum<unsigned int>("max-tcp-clients");
+  g_maxTCPPerClient = ::arg().asNum<unsigned int>("max-tcp-per-client");
+  g_tcpMaxQueriesPerConn = ::arg().asNum<size_t>("max-tcp-queries-per-connection");
+  g_maxUDPQueriesPerRound = ::arg().asNum<size_t>("max-udp-queries-per-round");
 
   g_useKernelTimestamp = ::arg().mustDo("protobuf-use-kernel-timestamp");
-  g_maxChainLength = ::arg().asNum("max-chain-length");
+  g_maxChainLength = ::arg().asNum<unsigned int>("max-chain-length");
 
   checkOrFixFDS(listeningSockets, log);
   checkOrFixLinuxMapCountLimits(log);
@@ -2868,8 +2858,8 @@ static void recLoop()
   time_t last_stat = 0;
   time_t last_carbon = 0;
   time_t last_lua_maintenance = 0;
-  time_t carbonInterval = ::arg().asNum("carbon-interval");
-  time_t luaMaintenanceInterval = ::arg().asNum("lua-maintenance-interval");
+  auto carbonInterval = ::arg().asNum<time_t>("carbon-interval");
+  auto luaMaintenanceInterval = ::arg().asNum<time_t>("lua-maintenance-interval");
 
   auto& threadInfo = RecThreadInfo::self();
 
@@ -3003,10 +2993,10 @@ static void recursorThread()
       }
     }
 
-    if (unsigned int ringsize = ::arg().asNum("stats-ringbuffer-entries") / RecThreadInfo::numUDPWorkers(); ringsize != 0) {
+    if (auto ringsize = ::arg().asNum<unsigned int>("stats-ringbuffer-entries") / RecThreadInfo::numUDPWorkers(); ringsize != 0) {
       t_remotes = std::make_unique<addrringbuf_t>();
       if (RecThreadInfo::weDistributeQueries()) {
-        t_remotes->set_capacity(::arg().asNum("stats-ringbuffer-entries") / RecThreadInfo::numDistributors());
+        t_remotes->set_capacity(ringsize / RecThreadInfo::numDistributors());
       }
       else {
         t_remotes->set_capacity(ringsize);
@@ -3027,7 +3017,7 @@ static void recursorThread()
       t_bogusqueryring = std::make_unique<boost::circular_buffer<pair<DNSName, uint16_t>>>();
       t_bogusqueryring->set_capacity(ringsize);
     }
-    t_multiTasker = std::make_unique<MT_t>(::arg().asNum("stack-size"), ::arg().asNum("stack-cache-size"));
+    t_multiTasker = std::make_unique<MT_t>(::arg().asNum<size_t>("stack-size"), ::arg().asNum<size_t>("stack-cache-size"));
     threadInfo.setMT(t_multiTasker.get());
 
     {
@@ -3184,7 +3174,7 @@ static void handleRuntimeDefaults(Logr::log_t log)
 {
 #ifdef HAVE_FIBER_SANITIZER
   // Asan needs more stack
-  if (::arg().asNum("stack-size") == 200000) { // the default in table.py
+  if (::arg().asNum<size_t>("stack-size") == 200000) { // the default in table.py
     ::arg().set("stack-size", "stack size per mthread") = "600000";
   }
 #endif
@@ -3411,25 +3401,25 @@ int main(int argc, char** argv)
 
     handleRuntimeDefaults(startupLog);
 
-    if (auto ttl = ::arg().asNum("system-resolver-ttl"); ttl != 0) {
+    if (auto ttl = ::arg().asNum<uint32_t>("system-resolver-ttl"); ttl != 0) {
       time_t interval = ttl;
-      if (::arg().asNum("system-resolver-interval") != 0) {
-        interval = ::arg().asNum("system-resolver-interval");
+      if (::arg().asNum<time_t>("system-resolver-interval") != 0) {
+        interval = ::arg().asNum<time_t>("system-resolver-interval");
       }
       bool selfResolveCheck = ::arg().mustDo("system-resolver-self-resolve-check");
       // Cannot use SyncRes::s_serverID, it is not set yet
       pdns::RecResolve::setInstanceParameters(arg()["server-id"], ttl, interval, selfResolveCheck, []() { reloadZoneConfiguration(g_yamlSettings); });
     }
 
-    MemRecursorCache::s_maxEntrySize = ::arg().asNum("max-recordcache-entry-size");
+    MemRecursorCache::s_maxEntrySize = ::arg().asNum<uint32_t>("max-recordcache-entry-size");
     NegCache::s_maxEntrySize = MemRecursorCache::s_maxEntrySize;
     AggressiveNSECCache::s_maxEntrySize = MemRecursorCache::s_maxEntrySize;
-    RecursorPacketCache::s_maxEntrySize = ::arg().asNum("max-packetcache-entry-size");
-    g_recCache = std::make_unique<MemRecursorCache>(::arg().asNum("record-cache-shards"));
-    g_negCache = std::make_unique<NegCache>(::arg().asNum("record-cache-shards") / 8);
+    RecursorPacketCache::s_maxEntrySize = ::arg().asNum<uint32_t>("max-packetcache-entry-size");
+    g_recCache = std::make_unique<MemRecursorCache>(::arg().asNum<size_t>("record-cache-shards"));
+    g_negCache = std::make_unique<NegCache>(::arg().asNum<size_t>("record-cache-shards") / 8);
     if (!::arg().mustDo("disable-packetcache")) {
-      g_maxPacketCacheEntries = ::arg().asNum("max-packetcache-entries");
-      g_packetCache = std::make_unique<RecursorPacketCache>(g_maxPacketCacheEntries, ::arg().asNum("packetcache-shards"));
+      g_maxPacketCacheEntries = ::arg().asNum<uint32_t>("max-packetcache-entries");
+      g_packetCache = std::make_unique<RecursorPacketCache>(g_maxPacketCacheEntries, ::arg().asNum<size_t>("packetcache-shards"));
     }
 
     ret = serviceMain(startupLog);

--- a/pdns/recursordist/rec-rust-lib/generate.py
+++ b/pdns/recursordist/rec-rust-lib/generate.py
@@ -344,7 +344,7 @@ def gen_cxx_oldstylesettingstobridgestruct(file, entries):
         if rust_type == "bool":
             file.write(f'arg().mustDo("{oldname}")')
         elif rust_type == "u64":
-            file.write(f'static_cast<uint64_t>(arg().asNum("{oldname}"))')
+            file.write(f'arg().asNum<uint64_t>("{oldname}")')
         elif rust_type == "f64":
             file.write(f'arg().asDouble("{oldname}")')
         elif rust_type == "String":

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -1099,7 +1099,7 @@ unsigned int makeTCPServerSockets(deferredAdd_t& deferredAdds, std::set<int>& tc
 #ifdef TCP_DEFER_ACCEPT
   auto first = true;
 #endif
-  const uint16_t defaultLocalPort = ::arg().asNum("local-port");
+  const auto defaultLocalPort = ::arg().asNum<uint16_t>("local-port");
   const vector<string> defaultVector = {"127.0.0.1", "::1"};
   const auto configIsDefault = localAddresses == defaultVector;
 

--- a/pdns/recursordist/rec_control.cc
+++ b/pdns/recursordist/rec_control.cc
@@ -430,7 +430,7 @@ int main(int argc, char** argv)
       ++iteration;
     }
 
-    auto timeout = arg().asNum("timeout");
+    auto timeout = arg().asNum<time_t>("timeout");
     RecursorControlChannel rccS;
     rccS.connect(arg()["socket-dir"], sockname);
     RecursorControlChannel::send(rccS.getDescriptor(), {0, std::move(command)}, timeout, fileDesc);

--- a/pdns/recursordist/reczones-helpers.cc
+++ b/pdns/recursordist/reczones-helpers.cc
@@ -48,8 +48,8 @@ static void putIntoCache(time_t now, QType qtype, vState state, const ComboAddre
 static void parseHintFile(time_t now, const std::string& hintfile, set<DNSName>& seenA, set<DNSName>& seenAAAA, set<DNSName>& seenNS, std::multimap<DNSName, DNSRecord>& aRecords, std::multimap<DNSName, DNSRecord>& aaaaRecords, vector<DNSRecord>& nsvec)
 {
   ZoneParserTNG zpt(hintfile);
-  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
-  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
+  zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum<size_t>("max-include-depth"));
   DNSResourceRecord rrecord;
 
   while (zpt.get(rrecord)) {

--- a/pdns/recursordist/reczones.cc
+++ b/pdns/recursordist/reczones.cc
@@ -216,8 +216,8 @@ static void readAuthZoneData(SyncRes::AuthDomain& authDomain, const pair<string,
 {
   log->info(Logr::Notice, "Parsing authoritative data from file", "zone", Logging::Loggable(headers.first), "file", Logging::Loggable(headers.second));
   ZoneParserTNG zpt(headers.second, DNSName(headers.first));
-  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
-  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
+  zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum<size_t>("max-include-depth"));
   DNSResourceRecord resourceRecord;
   DNSRecord dnsrecord;
   while (zpt.get(resourceRecord)) {

--- a/pdns/recursordist/rpzloader.cc
+++ b/pdns/recursordist/rpzloader.cc
@@ -348,8 +348,8 @@ std::shared_ptr<const SOARecordContent> loadRPZFromFile(const std::string& fname
 {
   shared_ptr<const SOARecordContent> soaRecordContent = nullptr;
   ZoneParserTNG zpt(fname);
-  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
-  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
+  zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum<size_t>("max-include-depth"));
   DNSResourceRecord drr;
   DNSRecord soaRecord;
   DNSName domain;

--- a/pdns/recursordist/ws-recursor.cc
+++ b/pdns/recursordist/ws-recursor.cc
@@ -856,7 +856,7 @@ RecursorWebServer::RecursorWebServer(FDMultiplexer* fdm)
     validatePrometheusMetrics();
   }
 
-  d_ws = make_unique<AsyncWebServer>(fdm, arg()["webserver-address"], arg().asNum("webserver-port"));
+  d_ws = make_unique<AsyncWebServer>(fdm, arg()["webserver-address"], arg().asNum<uint16_t>("webserver-port"));
   d_ws->setSLog(g_slog->withName("webserver"));
 
   d_ws->setApiKey(arg()["api-key"], arg().mustDo("webserver-hash-plaintext-credentials"));
@@ -1168,7 +1168,7 @@ void serveRustWeb()
     }
   }
   if (config.empty()) {
-    auto address = ComboAddress(arg()["webserver-address"], arg().asNum("webserver-port"));
+    auto address = ComboAddress(arg()["webserver-address"], arg().asNum<uint16_t>("webserver-port"));
     pdns::rust::web::rec::IncomingWSConfig tmp{{::rust::String{address.toStringWithPort()}}, {}};
     config.emplace_back(tmp);
   }
@@ -1203,7 +1203,7 @@ void serveRustWeb()
   // This function returns after having created the web server object that handles the requests.
   // That object and its runtime are associated with a Posix thread that waits until all tasks are
   // done, which normally never happens. See rec-rust-lib/rust/src/web.rs for details
-  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel, arg().asNum("webserver-max-request-size") * 1024ULL * 1024ULL, arg()["cross-origin-request-header"]);
+  pdns::rust::web::rec::serveweb(config, std::move(password), std::move(apikey), std::move(aclPtr), std::move(logPtr), loglevel, arg().asNum<size_t>("webserver-max-request-size") * 1024ULL * 1024ULL, arg()["cross-origin-request-header"]);
 }
 
 static void fromCxxToRust(const HttpResponse& cxxresp, pdns::rust::web::rec::Response& rustResponse)

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1030,7 +1030,7 @@ int TCPNameserver::doAXFR(const ZoneName &targetZone, std::unique_ptr<DNSPacket>
 
     if(NSEC3Zone) {
       // ents are only required for NSEC3 zones
-      uint32_t maxent = ::arg().asNum("max-ent-entries");
+      auto maxent = ::arg().asNum<uint32_t>("max-ent-entries");
       set<DNSName> nsec3set, nonterm;
       for (auto &loopZRR: zrrs) {
         bool skip=false;
@@ -1409,14 +1409,14 @@ TCPNameserver::~TCPNameserver() = default;
 TCPNameserver::TCPNameserver(Logr::log_t slog)
 {
   d_slog = slog;
-  d_maxTransactionsPerConn = ::arg().asNum("max-tcp-transactions-per-conn");
-  d_idleTimeout = ::arg().asNum("tcp-idle-timeout");
-  d_maxConnectionDuration = ::arg().asNum("max-tcp-connection-duration");
-  d_maxConnectionsPerClient = ::arg().asNum("max-tcp-connections-per-client");
+  d_maxTransactionsPerConn = ::arg().asNum<size_t>("max-tcp-transactions-per-conn");
+  d_idleTimeout = ::arg().asNum<unsigned int>("tcp-idle-timeout");
+  d_maxConnectionDuration = ::arg().asNum<unsigned int>("max-tcp-connection-duration");
+  d_maxConnectionsPerClient = ::arg().asNum<size_t>("max-tcp-connections-per-client");
 
-//  sem_init(&d_connectionroom_sem,0,::arg().asNum("max-tcp-connections"));
-  d_connectionroom_sem = make_unique<Semaphore>( ::arg().asNum( "max-tcp-connections" ));
-  d_maxTCPConnections = ::arg().asNum( "max-tcp-connections" );
+  d_maxTCPConnections = ::arg().asNum<unsigned int>( "max-tcp-connections" );
+//  sem_init(&d_connectionroom_sem,0,d_maxTCPConnections);
+  d_connectionroom_sem = make_unique<Semaphore>(d_maxTCPConnections);
 
   vector<string>locals;
   stringtok(locals,::arg()["local-address"]," ,");
@@ -1428,7 +1428,7 @@ TCPNameserver::TCPNameserver(Logr::log_t slog)
   signal(SIGPIPE,SIG_IGN);
 
   for(auto const &laddr : locals) {
-    ComboAddress local(laddr, ::arg().asNum("local-port"));
+    ComboAddress local(laddr, ::arg().asNum<uint16_t>("local-port"));
 
     int s=socket(local.sin4.sin_family, SOCK_STREAM, 0);
     if(s<0)

--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -1409,12 +1409,12 @@ TCPNameserver::~TCPNameserver() = default;
 TCPNameserver::TCPNameserver(Logr::log_t slog)
 {
   d_slog = slog;
-  d_maxTransactionsPerConn = ::arg().asNum<size_t>("max-tcp-transactions-per-conn");
-  d_idleTimeout = ::arg().asNum<unsigned int>("tcp-idle-timeout");
-  d_maxConnectionDuration = ::arg().asNum<unsigned int>("max-tcp-connection-duration");
-  d_maxConnectionsPerClient = ::arg().asNum<size_t>("max-tcp-connections-per-client");
+  ::arg().assignNum(d_maxTransactionsPerConn, "max-tcp-transactions-per-conn");
+  ::arg().assignNum(d_idleTimeout, "tcp-idle-timeout");
+  ::arg().assignNum(d_maxConnectionDuration, "max-tcp-connection-duration");
+  ::arg().assignNum(d_maxConnectionsPerClient, "max-tcp-connections-per-client");
 
-  d_maxTCPConnections = ::arg().asNum<unsigned int>( "max-tcp-connections" );
+  ::arg().assignNum(d_maxTCPConnections, "max-tcp-connections" );
 //  sem_init(&d_connectionroom_sem,0,d_maxTCPConnections);
   d_connectionroom_sem = make_unique<Semaphore>(d_maxTCPConnections);
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -743,8 +743,8 @@ UeberBackend::UeberBackend(const string& pname)
   }
   d_handle.setSLog(d_slog);
 
-  d_cache_ttl = ::arg().asNum("query-cache-ttl");
-  d_negcache_ttl = ::arg().asNum("negquery-cache-ttl");
+  d_cache_ttl = ::arg().asNum<unsigned int>("query-cache-ttl");
+  d_negcache_ttl = ::arg().asNum<unsigned int>("negquery-cache-ttl");
 
   backends = BackendMakers().all(pname == "key-only");
 

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -743,8 +743,8 @@ UeberBackend::UeberBackend(const string& pname)
   }
   d_handle.setSLog(d_slog);
 
-  d_cache_ttl = ::arg().asNum<unsigned int>("query-cache-ttl");
-  d_negcache_ttl = ::arg().asNum<unsigned int>("negquery-cache-ttl");
+  ::arg().assignNum(d_cache_ttl, "query-cache-ttl");
+  ::arg().assignNum(d_negcache_ttl, "negquery-cache-ttl");
 
   backends = BackendMakers().all(pname == "key-only");
 

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2200,7 +2200,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   DNSResourceRecord autorr;
   autorr.qname = zonename.operator const DNSName&();
   autorr.auth = true;
-  autorr.ttl = ::arg().asNum<uint32_t>("default-ttl");
+  ::arg().assignNum(autorr.ttl, "default-ttl");
 
   if (!have_soa && zonekind != DomainInfo::Secondary && zonekind != DomainInfo::Consumer) {
     // synthesize a SOA record so the zone "really" exists

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -171,7 +171,7 @@ AuthWebServer::AuthWebServer(StatBag& stats) :
   }
 
   if (arg().mustDo("webserver") || d_doApi) {
-    d_ws = std::make_unique<ApiWebServer>(std::make_shared<ConcurrentConnectionManager>(arg().asNum("webserver-max-concurrent-connections")), arg()["webserver-address"], arg().asNum("webserver-port"), d_stats);
+    d_ws = std::make_unique<ApiWebServer>(std::make_shared<ConcurrentConnectionManager>(arg().asNum<size_t>("webserver-max-concurrent-connections")), arg()["webserver-address"], arg().asNum<uint16_t>("webserver-port"), d_stats);
     if (g_slogStructured) {
       d_ws->setSLog(g_slog->withName("webserver"));
     }
@@ -184,7 +184,7 @@ AuthWebServer::AuthWebServer(StatBag& stats) :
     acl.toMasks(::arg()["webserver-allow-from"]);
     d_ws->setACL(acl);
 
-    d_ws->setMaxBodySize(::arg().asNum("webserver-max-bodysize"));
+    d_ws->setMaxBodySize(::arg().asBoundedNum<ssize_t>("webserver-max-bodysize", 0, std::numeric_limits<ssize_t>::max() / 1024 / 1024));
     d_ws->setConnectionTimeout(::arg().asNum("webserver-connection-timeout"));
 
     d_ws->setCrossOriginRequestHeader(arg()["webserver-cross-origin-request-header"]);
@@ -871,8 +871,8 @@ static void checkDefaultDNSSECAlgos()
 {
   int k_algo = DNSSECKeeper::shorthand2algorithm(::arg()["default-ksk-algorithm"]);
   int z_algo = DNSSECKeeper::shorthand2algorithm(::arg()["default-zsk-algorithm"]);
-  int k_size = arg().asNum("default-ksk-size");
-  int z_size = arg().asNum("default-zsk-size");
+  auto k_size = arg().asNum<size_t>("default-ksk-size");
+  auto z_size = arg().asNum<size_t>("default-zsk-size");
 
   // Sanity check DNSSEC parameters
   if (!::arg()["default-zsk-algorithm"].empty()) {
@@ -908,8 +908,8 @@ static void addDefaultDNSSECKeys(DNSSECKeeper& dnssecKeeper, const ZoneName& zon
   checkDefaultDNSSECAlgos();
   int k_algo = DNSSECKeeper::shorthand2algorithm(::arg()["default-ksk-algorithm"]);
   int z_algo = DNSSECKeeper::shorthand2algorithm(::arg()["default-zsk-algorithm"]);
-  int k_size = arg().asNum("default-ksk-size");
-  int z_size = arg().asNum("default-zsk-size");
+  auto k_size = arg().asNum<size_t>("default-ksk-size");
+  auto z_size = arg().asNum<size_t>("default-zsk-size");
 
   if (k_algo != -1) {
     int64_t keyID{-1};
@@ -1695,7 +1695,7 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
   if (privatekey.is_null()) {
     // Use defaults for bits and algorithm if they have not been specified
     if (bits < 0) {
-      bits = keyOrZone ? ::arg().asNum("default-ksk-size") : ::arg().asNum("default-zsk-size");
+      bits = ::arg().asBoundedNum<int>(keyOrZone ? "default-ksk-size" : "default-zsk-size", 0, std::numeric_limits<int>::max());
     }
     if (algorithm < 0) {
       algorithm = DNSSECKeeper::shorthand2algorithm(keyOrZone ? ::arg()["default-ksk-algorithm"] : ::arg()["default-zsk-algorithm"]);
@@ -1823,8 +1823,8 @@ static void gatherRecordsFromZone(const std::string& zonestring, vector<DNSResou
   stringtok(zonedata, zonestring, "\r\n");
 
   ZoneParserTNG zpt(zonedata, zonename);
-  zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
-  zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
+  zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
+  zpt.setMaxIncludes(::arg().asNum<size_t>("max-include-depth"));
 
   bool seenSOA = false;
 
@@ -2200,7 +2200,7 @@ static void apiServerZonesPOST(HttpRequest* req, HttpResponse* resp)
   DNSResourceRecord autorr;
   autorr.qname = zonename.operator const DNSName&();
   autorr.auth = true;
-  autorr.ttl = ::arg().asNum("default-ttl");
+  autorr.ttl = ::arg().asNum<uint32_t>("default-ttl");
 
   if (!have_soa && zonekind != DomainInfo::Secondary && zonekind != DomainInfo::Consumer) {
     // synthesize a SOA record so the zone "really" exists

--- a/pdns/zone2json.cc
+++ b/pdns/zone2json.cc
@@ -173,8 +173,8 @@ try
             Json::object obj;
             Json::array recs;
             ZoneParserTNG zpt(i->filename, i->name, BP.getDirectory());
-            zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
-            zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
+            zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
+            zpt.setMaxIncludes(::arg().asNum<size_t>("max-include-depth"));
             DNSResourceRecord rr;
             obj["name"] = i->name.toString();
 
@@ -206,7 +206,7 @@ try
     }
     else {
       ZoneParserTNG zpt(zonefile, ZoneName(::arg()["zone-name"]));
-      zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+      zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
       DNSResourceRecord rr;
       string zname;
       Json::object obj;

--- a/pdns/zone2ldap.cc
+++ b/pdns/zone2ldap.cc
@@ -319,8 +319,8 @@ int main( int argc, char* argv[] )
                                                 cerr << "Parsing file: " << i.filename << ", domain: " << i.name << endl;
                                                 g_zonename = i.name;
                                                 ZoneParserTNG zpt(i.filename, i.name, BP.getDirectory());
-                                                zpt.setMaxGenerateSteps(args.asNum("max-generate-steps"));
-                                                zpt.setMaxIncludes(args.asNum("max-include-depth"));
+                                                zpt.setMaxGenerateSteps(args.asNum<size_t>("max-generate-steps"));
+                                                zpt.setMaxIncludes(args.asNum<size_t>("max-include-depth"));
                                                 DNSResourceRecord rr;
                                                 while(zpt.get(rr)) {
                                                         callback(g_domainid, rr.qname, rr.qtype.toString(), encode_non_ascii(rr.content), rr.ttl);
@@ -349,7 +349,7 @@ int main( int argc, char* argv[] )
 
                         g_zonename = ZoneName(args["zone-name"]);
                         ZoneParserTNG zpt(args["zone-file"], g_zonename);
-                        zpt.setMaxGenerateSteps(args.asNum("max-generate-steps"));
+                        zpt.setMaxGenerateSteps(args.asNum<size_t>("max-generate-steps"));
                         DNSResourceRecord rr;
                         while(zpt.get(rr)) {
                                 callback(g_domainid, rr.qname, rr.qtype.toString(), encode_non_ascii(rr.content), rr.ttl);

--- a/pdns/zone2sql.cc
+++ b/pdns/zone2sql.cc
@@ -300,8 +300,8 @@ try
             emitDomain(domain.name, &(domain.primaries));
 
             ZoneParserTNG zpt(domain.filename, domain.name, BP.getDirectory());
-            zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
-            zpt.setMaxIncludes(::arg().asNum("max-include-depth"));
+            zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
+            zpt.setMaxIncludes(::arg().asNum<size_t>("max-include-depth"));
             DNSResourceRecord rr;
             bool seenSOA=false;
             string comment;
@@ -340,7 +340,7 @@ try
         zonename = ZoneName(::arg()["zone-name"]);
 
       ZoneParserTNG zpt(zonefile, zonename);
-      zpt.setMaxGenerateSteps(::arg().asNum("max-generate-steps"));
+      zpt.setMaxGenerateSteps(::arg().asNum<size_t>("max-generate-steps"));
       DNSResourceRecord rr;
       startNewTransaction();
       string comment;


### PR DESCRIPTION
### Short description
This PR extends the `::arg().asNum()` method to:
- be able to return a value in any particular cardinal type, rather than `int`.
- check that the value fits within the type boundaries.
A new interface, `asBoundedNum`, also allows finer range checks to be performed.

The second commit passes over all the `asNum` calls to fix the returned types and add bounds checking when applicable.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
