### PR TITLE
auth: allow EDNS Client Subnet prefix to be narrowed

### DIFF
--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -241,6 +241,8 @@ static void declareArguments()
   ::arg().setSwitch("prevent-self-notification", "Don't send notifications to what we think is ourself") = "yes";
   ::arg().setSwitch("any-to-tcp", "Answer ANY queries with tc=1, shunting to TCP") = "yes";
   ::arg().setSwitch("edns-subnet-processing", "If we should act on EDNS Subnet options") = "no";
+  ::arg().setSwitch("edns-scope-mask-ipv4", "EDNS scope mask to use for IPv4 addresses") = "0";
+  ::arg().setSwitch("edns-scope-mask-ipv6", "EDNS scope mask to use for IPv6 addresses") = "0";
   ::arg().set("delay-notifications", "Configure a delay to send out notifications, no delay by default") = "0";
 
   ::arg().set("edns-cookie-secret", "When set, set a server cookie when responding to a query with a Client cookie (in hex)") = "";
@@ -837,6 +839,8 @@ static void mainthread()
 
     DNSPacket::s_udpTruncationThreshold = std::max(static_cast<uint16_t>(512), ::arg().asNum<uint16_t>("udp-truncation-threshold"));
     DNSPacket::s_doEDNSSubnetProcessing = ::arg().mustDo("edns-subnet-processing");
+    DNSPacket::s_ECSscopeMaskIPv4 = ::arg().asBoundedNum<uint8_t>("edns-scope-mask-ipv4", 0, 32);
+    DNSPacket::s_ECSscopeMaskIPv6 = ::arg().asBoundedNum<uint8_t>("edns-scope-mask-ipv6", 0, 128);
     PacketHandler::s_SVCAutohints = ::arg().mustDo("svc-autohints");
     PacketHandler::s_NAPTRprocessing = ::arg().mustDo("naptr-additional-processing");
 

--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -56,6 +56,8 @@
 
 bool DNSPacket::s_doEDNSSubnetProcessing;
 bool DNSPacket::s_doEDNSCookieProcessing;
+uint8_t DNSPacket::s_ECSscopeMaskIPv4;
+uint8_t DNSPacket::s_ECSscopeMaskIPv6;
 string DNSPacket::s_EDNSCookieKey;
 uint16_t DNSPacket::s_udpTruncationThreshold;
 
@@ -343,13 +345,20 @@ void DNSPacket::wrapup(bool throwsOnTruncation)
           maxScopeMask = d_span.getBits();
         }
         else {
+          // tighten the scopeMask if configured to do so
+          if (d_eso.getFamily() == AF_INET) {
+            maxScopeMask = max(maxScopeMask, s_ECSscopeMaskIPv4);
+          }
+          else {
+            maxScopeMask = max(maxScopeMask, s_ECSscopeMaskIPv6);
+          }
           // use the scopeMask from the resolver, if it is greater - issue #5469
           maxScopeMask = max(maxScopeMask, eso.getScopePrefixLength());
         }
         eso.setScopePrefixLength(maxScopeMask);
 
         string opt = eso.makeOptString();
-        opts.emplace_back(8, opt); // 'EDNS SUBNET'
+        opts.emplace_back(EDNSOptionCode::ECS, opt);
       }
 
       if (d_haveednscookie && d_eco.isWellFormed()) {
@@ -624,7 +633,7 @@ try
       }
       else if(s_doEDNSSubnetProcessing && (option.first == EDNSOptionCode::ECS)) { // 'EDNS SUBNET'
         if (EDNSSubnetOpts::getFromString(option.second, &d_eso)) {
-          //cerr<<"Parsed, source: "<<d_eso.source.toString()<<", scope: "<<d_eso.scope.toString()<<", family = "<<d_eso.scope.getNetwork().sin4.sin_family<<endl;
+          //cerr<<"Parsed, source: "<<d_eso.source.toString()<<", scope: "<<d_eso.getScope().toString()<<", family = "<<d_eso.getFamily()<<endl;
           d_haveednssubnet=true;
         }
       }

--- a/pdns/dnspacket.hh
+++ b/pdns/dnspacket.hh
@@ -170,6 +170,8 @@ public:
   static uint16_t s_udpTruncationThreshold;
   static bool s_doEDNSSubnetProcessing;
   static bool s_doEDNSCookieProcessing;
+  static uint8_t s_ECSscopeMaskIPv4;
+  static uint8_t s_ECSscopeMaskIPv6;
   static string s_EDNSCookieKey;
   EDNSSubnetOpts d_eso;
 


### PR DESCRIPTION
### Short description
This PR adds two new settings, `edns-scope-mask-ipv4` and `edns-scope-mask-ipv6`, which will be used to narrow the scope mask in EDNS responses, except for packets which have hit a view, in which case the view netmask is still used.

Note that this PR is built ontop the first commit of #17878. No need to review more than once.

This could help people mitigate #16803.

Todo:
- [ ] tests
- [ ] documentation 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
