### PR TITLE
dnsrecords: bound APL wire elements to the record length

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -600,11 +600,18 @@ std::shared_ptr<DNSRecordContent> APLRecordContent::make(const DNSRecord &dr, Pa
   auto ret=std::make_shared<APLRecordContent>();
 
   while (processed<dr.d_clen) {
+    if (dr.d_clen - processed < 4) {
+      throw MOADNSException("Malformed APL record, element header extends beyond record length");
+    }
     pr.xfr16BitInt(ard.d_family);
     pr.xfr8BitInt(ard.d_prefix);
     pr.xfr8BitInt(temp);
     ard.d_n = (temp & 128) >> 7;
     ard.d_afdlength = temp & 127;
+
+    if (ard.d_afdlength > dr.d_clen - processed - 4) {
+      throw MOADNSException("Malformed APL record, address data extends beyond record length");
+    }
 
     if (ard.d_family == APL_FAMILY_IPV4) {
       if (ard.d_afdlength > 4) {

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -560,6 +560,34 @@ BOOST_AUTO_TEST_CASE(test_loc_records_in) {
   BOOST_CHECK_THROW(MOADNSParser failParser(false, reinterpret_cast<const char*>(packet.data()), packet.size()-1), MOADNSException);
 }
 
+// APL wire parser reads its elements straight from the packet, so a length field
+// that runs past the record's own RDATA must be rejected instead of pulling in the
+// following bytes.
+BOOST_AUTO_TEST_CASE(test_apl_record_in) {
+  const DNSName name("powerdns.com.");
+  auto validAPL = DNSRecordContent::make(QType::APL, QClass::IN, "1:10.1.1.1/32");
+
+  vector<uint8_t> packet;
+  DNSPacketWriter writer(packet, name, QType::APL, QClass::IN, 0);
+  writer.getHeader()->qr = 1;
+  writer.startRecord(name, QType::APL, 100, QClass::IN, DNSResourceRecord::ANSWER, false);
+  validAPL->toPacket(writer);
+  writer.commit();
+
+  MOADNSParser parser(false, reinterpret_cast<const char*>(packet.data()), packet.size());
+
+  // Location of the record's 2-byte RDLENGTH field.
+  const size_t rdLengthPos = sizeof(dnsheader) + name.wirelength() + sizeof(uint16_t) + sizeof(uint16_t) + name.wirelength() + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t);
+
+  auto invalidPacket = packet;
+  // The record physically holds one 8-byte element; claim an RDLENGTH of 5 so the
+  // element's address data extends three bytes past the record boundary.
+  invalidPacket.at(rdLengthPos) = 0;
+  invalidPacket.at(rdLengthPos + 1) = 5;
+
+  BOOST_CHECK_THROW(MOADNSParser failParser(false, reinterpret_cast<const char*>(invalidPacket.data()), invalidPacket.size()), MOADNSException);
+}
+
 // special record test, because NSEC records are odd
 BOOST_AUTO_TEST_CASE(test_nsec_records_in) {
 

--- a/pdns/test-dnsrecords_cc.cc
+++ b/pdns/test-dnsrecords_cc.cc
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE(test_apl_record_in) {
   validAPL->toPacket(writer);
   writer.commit();
 
-  MOADNSParser parser(false, reinterpret_cast<const char*>(packet.data()), packet.size());
+  MOADNSParser parser(false, reinterpret_cast<const char*>(packet.data()), packet.size()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
   // Location of the record's 2-byte RDLENGTH field.
   const size_t rdLengthPos = sizeof(dnsheader) + name.wirelength() + sizeof(uint16_t) + sizeof(uint16_t) + name.wirelength() + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t);
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE(test_apl_record_in) {
   invalidPacket.at(rdLengthPos) = 0;
   invalidPacket.at(rdLengthPos + 1) = 5;
 
-  BOOST_CHECK_THROW(MOADNSParser failParser(false, reinterpret_cast<const char*>(invalidPacket.data()), invalidPacket.size()), MOADNSException);
+  BOOST_CHECK_THROW(MOADNSParser failParser(false, reinterpret_cast<const char*>(invalidPacket.data()), invalidPacket.size()), MOADNSException); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 }
 
 // special record test, because NSEC records are odd


### PR DESCRIPTION
### Short description

`APLRecordContent::make` reads each element's family, prefix, and address bytes straight from the packet through `PacketReader`, and the loop only checks `processed < d_clen` at the top. It never confirms an element fits inside the record's own RDLENGTH, so a record whose `afdlength` claims more address bytes than remain in the RDATA keeps reading into the bytes that follow the record. The boilerplate record parsers avoid this because they read blobs bounded to the record and reject trailing data via `eof()`; the hand-written APL parser has neither guard.

Check that the 4-byte element header and its address data both fit within the remaining record length before reading them, throwing `MOADNSException` on a short record. Keeping the bound inside `make()` lets the wire loop stay within its own RDATA the way every other record type already does. The added unit test shrinks a valid APL record's RDLENGTH and confirms the parser rejects it instead of walking past the record.

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
