### PR TITLE
docs: fix forward-dnsupdate default to yes

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -867,7 +867,7 @@ ALIAS is not impacted by this setting.
 ---------------------
 
 -  Boolean
--  Default: no
+-  Default: yes
 
 Forward DNS updates sent to a secondary to the primary.
 


### PR DESCRIPTION
The settings page listed `forward-dnsupdate` as defaulting to `no`, but `auth-main.cc` registers it with `"yes"`. Updated the docs to match.

Fixes #12727