### PR TITLE
docs: note pdns_notify is in the pdns-tools package

### DIFF
--- a/docs/manpages/pdns_notify.1.rst
+++ b/docs/manpages/pdns_notify.1.rst
@@ -13,6 +13,9 @@ Description
 on port 53, for *DOMAIN* and prints the remote nameserver's response. If *HOSTNAME* resolves
 to multiple IP addresses, each one is notified.
 
+On Debian and Ubuntu packages, this tool is shipped in the ``pdns-tools`` package
+(not in ``pdns-server``).
+
 Options
 -------
 


### PR DESCRIPTION
The man page did not say which package ships the binary. On Debian/Ubuntu that is `pdns-tools`, not `pdns-server`.

Fixes #12563