### PR TITLE
rec: fix typo in rec_control command name

### DIFF
--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -2385,7 +2385,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int socket, cons
     {"list-dnssec-algos", [](ArgIterator, ArgIterator) -> Answer {
        return {0, DNSCryptoKeyEngine::listSupportedAlgoNames(g_slog->withName("control"))};
      }},
-    {"set-aggr-nsec-cache-size", setAggrNSECCacheSize},
+    {"set-max-aggr-nsec-cache-size", setAggrNSECCacheSize},
   };
 
   if (const auto entry = commands.find(cmd); entry != commands.end()) {

--- a/pdns/recursordist/rec_channel_rec.cc
+++ b/pdns/recursordist/rec_channel_rec.cc
@@ -1027,7 +1027,7 @@ static Answer setMaxPacketCacheEntries(ArgIterator begin, ArgIterator end)
   }
 }
 
-static RecursorControlChannel::Answer setAggrNSECCacheSize(ArgIterator begin, ArgIterator end)
+static RecursorControlChannel::Answer setMaxAggrNSECCacheSize(ArgIterator begin, ArgIterator end)
 {
   if (end - begin != 1) {
     return {1, "Need to supply new aggressive NSEC cache size\n"};
@@ -2385,7 +2385,7 @@ RecursorControlChannel::Answer RecursorControlParser::getAnswer(int socket, cons
     {"list-dnssec-algos", [](ArgIterator, ArgIterator) -> Answer {
        return {0, DNSCryptoKeyEngine::listSupportedAlgoNames(g_slog->withName("control"))};
      }},
-    {"set-max-aggr-nsec-cache-size", setAggrNSECCacheSize},
+    {"set-max-aggr-nsec-cache-size", setMaxAggrNSECCacheSize},
   };
 
   if (const auto entry = commands.find(cmd); entry != commands.end()) {


### PR DESCRIPTION
It is documented (in man page and help) as set-max-aggr-nsec-cache-size. So far nobody hit this as far as I know, so don't keep the old form.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
