### PR TITLE
rec: on quite-nicely wait for mthreads to be done 

### DIFF
--- a/pdns/recursordist/mtasker.hh
+++ b/pdns/recursordist/mtasker.hh
@@ -148,6 +148,11 @@ public:
 #endif
   }
 
+  void stopCreating()
+  {
+    d_acceptNew = false;
+  }
+
 private:
   EventKey d_eventkey; // for waitEvent, contains exact key it was awoken for
   EventVal d_waitval;
@@ -180,6 +185,7 @@ private:
   int d_tid{0};
   int d_maxtid{0};
   bool d_used{true}; // was d_eventkey consumed?
+  bool d_acceptNew{true};
   enum waitstatusenum : int8_t
   {
     Error = -1,
@@ -383,6 +389,9 @@ std::shared_ptr<pdns_ucontext_t> MTasker<Key, Val, Cmp>::getUContext()
 template <class Key, class Val, class Cmp>
 void MTasker<Key, Val, Cmp>::makeThread(tfunc_t* start, void* val)
 {
+  if (!d_acceptNew) {
+    return;
+  }
   auto ucontext = getUContext();
 
   ++d_threadsCount;

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -49,7 +49,7 @@ thread_local FDWrapper t_tracefd = -1;
 thread_local ProtobufServersInfo t_protobufServers;
 thread_local ProtobufServersInfo t_outgoingProtobufServers;
 
-thread_local std::unique_ptr<MT_t> g_multiTasker; // the big MTasker
+thread_local std::unique_ptr<MT_t> t_multiTasker; // the big MTasker
 std::unique_ptr<MemRecursorCache> g_recCache;
 std::unique_ptr<NegCache> g_negCache;
 std::unique_ptr<RecursorPacketCache> g_packetCache;
@@ -239,11 +239,11 @@ static void handleGenUDPQueryResponse(int fileDesc, FDMultiplexer::funcparam_t& 
   t_fdm->removeReadFD(fileDesc);
   if (ret >= 0) {
     resp.resize(ret);
-    g_multiTasker->sendEvent(pident, &resp);
+    t_multiTasker->sendEvent(pident, &resp);
   }
   else {
     PacketBuffer empty;
-    g_multiTasker->sendEvent(pident, &empty);
+    t_multiTasker->sendEvent(pident, &empty);
   }
 }
 
@@ -264,7 +264,7 @@ PacketBuffer GenUDPQueryResponse(const ComboAddress& dest, const string& query)
   t_fdm->addReadFD(socket.getHandle(), handleGenUDPQueryResponse, pident);
 
   PacketBuffer data;
-  int ret = g_multiTasker->waitEvent(pident, &data, authWaitTimeMSec(g_multiTasker));
+  int ret = t_multiTasker->waitEvent(pident, &data, authWaitTimeMSec(t_multiTasker));
 
   if (ret == 0 || ret == -1) { // timeout
     t_fdm->removeReadFD(socket.getHandle());
@@ -310,7 +310,7 @@ LWResult::Result asendto(const void* data, size_t len,
   // See if there is an existing outstanding request we can chain on to, using partial equivalence
   // function looking for the same query (qname, qtype and ecs if applicable) to the same host, but
   // with a different message ID.
-  auto chain = g_multiTasker->getWaiters().equal_range(pident, PacketIDBirthdayCompare());
+  auto chain = t_multiTasker->getWaiters().equal_range(pident, PacketIDBirthdayCompare());
 
   for (; chain.first != chain.second; chain.first++) {
     // Line below detected an issue with the two ways of ordering PacketIDs (birthday and non-birthday)
@@ -324,7 +324,7 @@ LWResult::Result asendto(const void* data, size_t len,
       }
       assert(uSec(chain.first->key->creationTime) != 0); // NOLINT
       auto age = now - chain.first->key->creationTime;
-      if (uSec(age) > static_cast<uint64_t>(1000) * authWaitTimeMSec(g_multiTasker) * 2 / 3) {
+      if (uSec(age) > static_cast<uint64_t>(1000) * authWaitTimeMSec(t_multiTasker) * 2 / 3) {
         return LWResult::Result::ChainLimitError;
       }
       chain.first->key->authReqChain.emplace(*fileDesc, qid); // we can chain
@@ -396,7 +396,7 @@ LWResult::Result arecvfrom(PacketBuffer& packet, const ComboAddress& fromAddr, s
     // We fill in the search key with the ecs we sent out, so both cases are covered and accepted here.
     pident->ecsSubnet = ecs->getSource();
   }
-  int ret = g_multiTasker->waitEvent(pident, &packet, authWaitTimeMSec(g_multiTasker), &now);
+  int ret = t_multiTasker->waitEvent(pident, &packet, authWaitTimeMSec(t_multiTasker), &now);
   len = 0;
 
   /* -1 means error, 0 means timeout, 1 means a result from handleUDPServerResponse() which might still be an error */
@@ -1137,7 +1137,7 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
 
     resolver.d_eventTrace = std::move(comboWriter->d_eventTrace);
     resolver.d_otTrace = std::move(comboWriter->d_otTrace);
-    resolver.setId(g_multiTasker->getTid());
+    resolver.setId(t_multiTasker->getTid());
 
     bool DNSSECOK = false;
     if (comboWriter->d_luaContext) {
@@ -1233,7 +1233,7 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
                                                   "source", Logging::Loggable(comboWriter->d_source),
                                                   "proto", Logging::Loggable(comboWriter->d_tcp ? "tcp" : "udp"),
                                                   "ecs", Logging::Loggable(comboWriter->d_ednssubnet.getSource().empty() ? "" : comboWriter->d_ednssubnet.getSource().toString()),
-                                                  "mtid", Logging::Loggable(g_multiTasker->getTid()));
+                                                  "mtid", Logging::Loggable(t_multiTasker->getTid()));
     RunningResolveGuard tcpGuard(comboWriter);
 
     if (ednsExtRCode != 0 || comboWriter->d_mdp.d_header.opcode == static_cast<unsigned>(Opcode::Notify)) {
@@ -2032,9 +2032,9 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
   runTaskOnce(g_logCommonErrors);
 
   static const size_t stackSizeThreshold = 9 * ::arg().asNum("stack-size") / 10;
-  if (g_multiTasker->getMaxStackUsage() >= stackSizeThreshold) {
+  if (t_multiTasker->getMaxStackUsage() >= stackSizeThreshold) {
     resolver.d_slog->info(Logr::Error, "Reached mthread stack usage of 90%",
-                          "stackUsage", Logging::Loggable(g_multiTasker->getMaxStackUsage()),
+                          "stackUsage", Logging::Loggable(t_multiTasker->getMaxStackUsage()),
                           "outqueries", Logging::Loggable(resolver.d_outqueries),
                           "netms", Logging::Loggable(resolver.d_totUsec / 1000.0),
                           "throttled", Logging::Loggable(resolver.d_throttledqueries),
@@ -2043,7 +2043,7 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
                           "dotout", Logging::Loggable(resolver.d_dotoutqueries),
                           "validationState", Logging::Loggable(resolver.getValidationState()));
   }
-  t_Counters.at(rec::Counter::maxMThreadStackUsage) = max(g_multiTasker->getMaxStackUsage(), t_Counters.at(rec::Counter::maxMThreadStackUsage));
+  t_Counters.at(rec::Counter::maxMThreadStackUsage) = max(t_multiTasker->getMaxStackUsage(), t_Counters.at(rec::Counter::maxMThreadStackUsage));
   t_Counters.updateSnap(g_regressionTestMode);
 }
 
@@ -2499,7 +2499,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
     variable = true;
   }
 
-  if (g_multiTasker->numProcesses() >= g_maxMThreads) {
+  if (t_multiTasker->numProcesses() >= g_maxMThreads) {
     if (!g_quiet) {
       g_slogudpin->info(Logr::Notice, "Dropped question, over capacity", "source", Logging::Loggable(source), "remote", Logging::Loggable(fromaddr));
     }
@@ -2544,7 +2544,7 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
   comboWriter->d_eventTrace = std::move(eventTrace);
   comboWriter->d_otTrace = std::move(otTrace);
 
-  g_multiTasker->makeThread(startDoResolve, (void*)comboWriter.release()); // deletes dc
+  t_multiTasker->makeThread(startDoResolve, (void*)comboWriter.release()); // deletes dc
   return nullptr;
 }
 
@@ -2998,7 +2998,7 @@ static void doResends(MT_t::waiters_t::iterator& iter, const std::shared_ptr<Pac
     auto packetID = std::make_shared<PacketID>(*resend);
     packetID->fd = fileDesc;
     packetID->id = qid;
-    g_multiTasker->sendEvent(packetID, &content);
+    t_multiTasker->sendEvent(packetID, &content);
     t_Counters.at(rec::Counter::chainResends)++;
   }
 }
@@ -3011,7 +3011,7 @@ void mthreadSleep(unsigned int jitterMsec)
   neverHappens->remote = ComboAddress("100::"); // discard-only
   neverHappens->remote.setPort(dns_random_uint16());
   neverHappens->fd = -1;
-  assert(g_multiTasker->waitEvent(neverHappens, nullptr, jitterMsec) != -1); // NOLINT
+  assert(t_multiTasker->waitEvent(neverHappens, nullptr, jitterMsec) != -1); // NOLINT
 }
 
 static bool checkIncomingECSSource(const PacketBuffer& packet, const Netmask& subnet)
@@ -3057,11 +3057,11 @@ static void handleUDPServerResponse(int fileDesc, FDMultiplexer::funcparam_t& va
     t_udpclientsocks->returnSocket(fileDesc);
 
     PacketBuffer empty;
-    auto iter = g_multiTasker->getWaiters().find(pid);
-    if (iter != g_multiTasker->getWaiters().end()) {
+    auto iter = t_multiTasker->getWaiters().find(pid);
+    if (iter != t_multiTasker->getWaiters().end()) {
       doResends(iter, pid, empty);
     }
-    g_multiTasker->sendEvent(pid, &empty); // this denotes error (does retry lookup using other NS)
+    t_multiTasker->sendEvent(pid, &empty); // this denotes error (does retry lookup using other NS)
     return;
   }
 
@@ -3119,19 +3119,19 @@ static void handleUDPServerResponse(int fileDesc, FDMultiplexer::funcparam_t& va
   }
 
   if (!pident->domain.empty()) {
-    auto iter = g_multiTasker->getWaiters().find(pident);
-    if (iter != g_multiTasker->getWaiters().end()) {
+    auto iter = t_multiTasker->getWaiters().find(pident);
+    if (iter != t_multiTasker->getWaiters().end()) {
       doResends(iter, pident, packet);
     }
   }
 
 retryWithName:
 
-  if (pident->domain.empty() || g_multiTasker->sendEvent(pident, &packet) == 0) {
+  if (pident->domain.empty() || t_multiTasker->sendEvent(pident, &packet) == 0) {
     /* we did not find a match for this response, something is wrong */
 
     // we do a full scan for outstanding queries on unexpected answers. not too bad since we only accept them on the right port number, which is hard enough to guess
-    for (const auto& d_waiter : g_multiTasker->getWaiters()) {
+    for (const auto& d_waiter : t_multiTasker->getWaiters()) {
       if (pident->fd == d_waiter.key->fd && d_waiter.key->remote == pident->remote && d_waiter.key->type == pident->type && pident->domain == d_waiter.key->domain) {
         /* we are expecting an answer from that exact source, on that exact port (since we are using connected sockets), for that qname/qtype,
            but with a different message ID. That smells like a spoofing attempt. For now we will just increase the counter and will deal with
@@ -3151,7 +3151,7 @@ retryWithName:
       g_slogudpin->info(Logr::Warning, "Discarding unexpected packet", "from", Logging::Loggable(fromaddr),
                         "qname", Logging::Loggable(pident->domain),
                         "qtype", Logging::Loggable(QType(pident->type)),
-                        "waiters", Logging::Loggable(g_multiTasker->getWaiters().size()));
+                        "waiters", Logging::Loggable(t_multiTasker->getWaiters().size()));
     }
   }
   else if (fileDesc >= 0) {

--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -2545,7 +2545,6 @@ static string* doProcessUDPQuestion(const std::string& question, const ComboAddr
   comboWriter->d_otTrace = std::move(otTrace);
 
   g_multiTasker->makeThread(startDoResolve, (void*)comboWriter.release()); // deletes dc
-
   return nullptr;
 }
 

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2882,12 +2882,12 @@ static void recLoop()
 
   while (true) {
     try {
-      while (g_multiTasker->schedule(g_now)) {
+      while (t_multiTasker->schedule(g_now)) {
         ; // MTasker letting the mthreads do their thing
       }
       if (RecursorControlChannel::stop) {
-        g_multiTasker->stopCreating();
-        if (g_multiTasker->noProcesses()) {
+        t_multiTasker->stopCreating();
+        if (t_multiTasker->noProcesses()) {
           break;
         }
       }
@@ -2896,7 +2896,7 @@ static void recLoop()
       if (((threadInfo.isHandler() || threadInfo.isTaskThread()) && s_counter % handlerAndTaskInterval == 0) || s_counter % otherInterval == 0) {
         timeval start{};
         Utility::gettimeofday(&start);
-        g_multiTasker->makeThread(houseKeeping, nullptr);
+        t_multiTasker->makeThread(houseKeeping, nullptr);
         if (!threadInfo.isTaskThread()) {
           timeval stop{};
           Utility::gettimeofday(&stop);
@@ -2928,13 +2928,13 @@ static void recLoop()
         Utility::gettimeofday(&g_now, nullptr);
 
         if ((g_now.tv_sec - last_carbon) >= carbonInterval) {
-          g_multiTasker->makeThread(doCarbonDump, nullptr);
+          t_multiTasker->makeThread(doCarbonDump, nullptr);
           last_carbon = g_now.tv_sec;
         }
       }
       runLuaMaintenance(threadInfo, last_lua_maintenance, luaMaintenanceInterval);
 
-      auto timeoutUsec = g_multiTasker->nextWaiterDelayUsec(1000000U / handlerAndTaskInterval / 2);
+      auto timeoutUsec = t_multiTasker->nextWaiterDelayUsec(1000000U / handlerAndTaskInterval / 2);
       t_fdm->run(&g_now, static_cast<int>(timeoutUsec / 1000));
       // 'run' updates g_now for us
     }
@@ -3027,8 +3027,8 @@ static void recursorThread()
       t_bogusqueryring = std::make_unique<boost::circular_buffer<pair<DNSName, uint16_t>>>();
       t_bogusqueryring->set_capacity(ringsize);
     }
-    g_multiTasker = std::make_unique<MT_t>(::arg().asNum("stack-size"), ::arg().asNum("stack-cache-size"));
-    threadInfo.setMT(g_multiTasker.get());
+    t_multiTasker = std::make_unique<MT_t>(::arg().asNum("stack-size"), ::arg().asNum("stack-cache-size"));
+    threadInfo.setMT(t_multiTasker.get());
 
     {
       /* start protobuf export threads if needed, don't keep a ref to lua config around */

--- a/pdns/recursordist/rec-main.cc
+++ b/pdns/recursordist/rec-main.cc
@@ -2880,12 +2880,17 @@ static void recLoop()
   constexpr uint32_t handlerAndTaskInterval = 11;
   constexpr uint32_t otherInterval = 499;
 
-  while (!RecursorControlChannel::stop) {
+  while (true) {
     try {
       while (g_multiTasker->schedule(g_now)) {
         ; // MTasker letting the mthreads do their thing
       }
-
+      if (RecursorControlChannel::stop) {
+        g_multiTasker->stopCreating();
+        if (g_multiTasker->noProcesses()) {
+          break;
+        }
+      }
       // Use primes, it avoid not being scheduled in cases where the counter has a regular pattern.
       // We want to call handler thread often, it gets scheduled about 2 times per second
       if (((threadInfo.isHandler() || threadInfo.isTaskThread()) && s_counter % handlerAndTaskInterval == 0) || s_counter % otherInterval == 0) {

--- a/pdns/recursordist/rec-main.hh
+++ b/pdns/recursordist/rec-main.hh
@@ -171,7 +171,7 @@ enum class PaddingMode : uint8_t
 };
 
 using MT_t = MTasker<std::shared_ptr<PacketID>, PacketBuffer, PacketIDCompare>;
-extern thread_local std::unique_ptr<MT_t> g_multiTasker; // the big MTasker
+extern thread_local std::unique_ptr<MT_t> t_multiTasker; // the big MTasker
 extern std::unique_ptr<RecursorPacketCache> g_packetCache;
 
 using RemoteLoggerStats_t = std::unordered_map<std::string, RemoteLoggerInterface::Stats>;
@@ -273,7 +273,7 @@ using deferredAdd_t = vector<pair<int, std::function<void(int, boost::any&)>>>;
 
 inline MT_t* getMT()
 {
-  return g_multiTasker ? g_multiTasker.get() : nullptr;
+  return t_multiTasker ? t_multiTasker.get() : nullptr;
 }
 
 /* this function is called with both a string and a vector<uint8_t> representing a packet */

--- a/pdns/recursordist/rec-tcp.cc
+++ b/pdns/recursordist/rec-tcp.cc
@@ -518,7 +518,7 @@ static void doProcessTCPQuestion(std::unique_ptr<DNSComboWriter>& comboWriter, s
     }
     tcpGuard.keep();
     traceScope.close(0);
-    g_multiTasker->makeThread(startDoResolve, comboWriter.release()); // deletes dc
+    t_multiTasker->makeThread(startDoResolve, comboWriter.release()); // deletes dc
   } // good query
 }
 
@@ -715,7 +715,7 @@ void handleNewTCPQuestion(int fileDesc, [[maybe_unused]] FDMultiplexer::funcpara
     closeSock(rec::Counter::tcpOverflow, "Error closing TCP socket after an overflow drop");
     return;
   }
-  if (g_multiTasker->numProcesses() >= g_maxMThreads) {
+  if (t_multiTasker->numProcesses() >= g_maxMThreads) {
     closeSock(rec::Counter::overCapacityDrops, "Error closing TCP socket after an over capacity drop");
     return;
   }
@@ -870,7 +870,7 @@ static void TCPIOHandlerIO(int fileDesc, FDMultiplexer::funcparam_t& var)
           pid->inMSG.resize(pid->inPos); // old content (if there) + new bytes read, only relevant for the inIncompleteOkay case
           newstate = IOState::Done;
           TCPIOHandlerStateChange(pid->lowState, newstate, pid);
-          g_multiTasker->sendEvent(pid, &pid->inMSG);
+          t_multiTasker->sendEvent(pid, &pid->inMSG);
           return;
         }
         break;
@@ -886,7 +886,7 @@ static void TCPIOHandlerIO(int fileDesc, FDMultiplexer::funcparam_t& var)
       TCPLOG(pid->tcpsock, "read exception..." << e.what() << endl);
       PacketBuffer empty;
       TCPIOHandlerStateChange(pid->lowState, newstate, pid);
-      g_multiTasker->sendEvent(pid, &empty); // this conveys error status
+      t_multiTasker->sendEvent(pid, &empty); // this conveys error status
       return;
     }
     break;
@@ -901,7 +901,7 @@ static void TCPIOHandlerIO(int fileDesc, FDMultiplexer::funcparam_t& var)
       case IOState::Done: {
         TCPLOG(pid->tcpsock, "tryWrite: Done" << endl);
         TCPIOHandlerStateChange(pid->lowState, newstate, pid);
-        g_multiTasker->sendEvent(pid, &pid->outMSG); // send back what we sent to convey everything is ok
+        t_multiTasker->sendEvent(pid, &pid->outMSG); // send back what we sent to convey everything is ok
         return;
       }
       case IOState::NeedRead: // NOLINT(bugprone-branch-clone) (if !TCPLOGGing)
@@ -920,7 +920,7 @@ static void TCPIOHandlerIO(int fileDesc, FDMultiplexer::funcparam_t& var)
       TCPLOG(pid->tcpsock, "write exception..." << e.what() << endl);
       PacketBuffer sent;
       TCPIOHandlerStateChange(pid->lowState, newstate, pid);
-      g_multiTasker->sendEvent(pid, &sent); // we convey error status by sending empty string
+      t_multiTasker->sendEvent(pid, &sent); // we convey error status by sending empty string
       return;
     }
     break;
@@ -993,7 +993,7 @@ LWResult::Result asendtcp(const PacketBuffer& data, shared_ptr<TCPIOHandler>& ha
   TCPIOHandlerStateChange(IOState::Done, state, pident);
 
   PacketBuffer packet;
-  int ret = g_multiTasker->waitEvent(pident, &packet, g_networkTimeoutMsec);
+  int ret = t_multiTasker->waitEvent(pident, &packet, g_networkTimeoutMsec);
   TCPLOG(pident->tcpsock, "asendtcp waitEvent returned " << ret << ' ' << packet.size() << '/' << data.size() << ' ');
   if (ret == 0) {
     TCPLOG(pident->tcpsock, "timeout" << endl);
@@ -1063,7 +1063,7 @@ LWResult::Result arecvtcp(PacketBuffer& data, const size_t len, shared_ptr<TCPIO
   // Will set pident->lowState
   TCPIOHandlerStateChange(IOState::Done, state, pident);
 
-  int ret = g_multiTasker->waitEvent(pident, &data, authWaitTimeMSec(g_multiTasker));
+  int ret = t_multiTasker->waitEvent(pident, &data, authWaitTimeMSec(t_multiTasker));
   TCPLOG(pident->tcpsock, "arecvtcp " << ret << ' ' << data.size() << ' ');
   if (ret == 0) {
     TCPLOG(pident->tcpsock, "timeout" << endl);


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

This _should_ prevent to occasional memory leak reported in the regression tests, which happens if an mthread is still active on quit.

2nd commit is renaming a global var to comply with our naming conventions, the beef is in the 1st commit.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
