### PR TITLE
dnsdist: Fix a race when calling `getPool`/`getCache` from a Lua selector/action

### DIFF
--- a/pdns/dnsdistdist/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings.cc
@@ -115,13 +115,12 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.registerFunction<std::shared_ptr<DNSDistPacketCache> (std::shared_ptr<dnsdist::lua::LuaServerPoolObject>::*)() const>("getCache", [](const std::shared_ptr<dnsdist::lua::LuaServerPoolObject>& pool) {
     std::shared_ptr<DNSDistPacketCache> cache;
     if (pool) {
-      dnsdist::configuration::updateRuntimeConfiguration([&pool, &cache](dnsdist::configuration::RuntimeConfiguration& config) {
-        auto poolIt = config.d_pools.find(pool->poolName);
-        /* this might happen if the Server Pool has been removed in the meantime, let's gracefully ignore it */
-        if (poolIt != config.d_pools.end()) {
-          cache = poolIt->second.packetCache;
-        }
-      });
+      const auto& config = dnsdist::configuration::getCurrentRuntimeConfiguration();
+      auto poolIt = config.d_pools.find(pool->poolName);
+      /* this might happen if the Server Pool has been removed in the meantime, let's gracefully ignore it */
+      if (poolIt != config.d_pools.end()) {
+        cache = poolIt->second.packetCache;
+      }
     }
     return cache;
   });

--- a/pdns/dnsdistdist/dnsdist-lua-bindings.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-bindings.cc
@@ -139,13 +139,12 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.registerFunction<bool (std::shared_ptr<dnsdist::lua::LuaServerPoolObject>::*)() const>("getECS", [](const std::shared_ptr<dnsdist::lua::LuaServerPoolObject>& pool) {
     bool ecs = false;
     if (pool) {
-      dnsdist::configuration::updateRuntimeConfiguration([&pool, &ecs](dnsdist::configuration::RuntimeConfiguration& config) {
-        auto poolIt = config.d_pools.find(pool->poolName);
-        /* this might happen if the Server Pool has been removed in the meantime, let's gracefully ignore it */
-        if (poolIt != config.d_pools.end()) {
-          ecs = poolIt->second.getECS();
-        }
-      });
+      const auto& config = dnsdist::configuration::getCurrentRuntimeConfiguration();
+      auto poolIt = config.d_pools.find(pool->poolName);
+      /* this might happen if the Server Pool has been removed in the meantime, let's gracefully ignore it */
+      if (poolIt != config.d_pools.end()) {
+        ecs = poolIt->second.getECS();
+      }
     }
     return ecs;
   });
@@ -164,13 +163,12 @@ void setupLuaBindings(LuaContext& luaCtx, bool client, bool configCheck)
   luaCtx.registerFunction<bool (std::shared_ptr<dnsdist::lua::LuaServerPoolObject>::*)() const>("getZeroScope", [](const std::shared_ptr<dnsdist::lua::LuaServerPoolObject>& pool) {
     bool zeroScope = false;
     if (pool) {
-      dnsdist::configuration::updateRuntimeConfiguration([&pool, &zeroScope](dnsdist::configuration::RuntimeConfiguration& config) {
-        auto poolIt = config.d_pools.find(pool->poolName);
-        /* this might happen if the Server Pool has been removed in the meantime, let's gracefully ignore it */
-        if (poolIt != config.d_pools.end()) {
-          zeroScope = poolIt->second.getZeroScope();
-        }
-      });
+      const auto& config = dnsdist::configuration::getCurrentRuntimeConfiguration();
+      auto poolIt = config.d_pools.find(pool->poolName);
+      /* this might happen if the Server Pool has been removed in the meantime, let's gracefully ignore it */
+      if (poolIt != config.d_pools.end()) {
+        zeroScope = poolIt->second.getZeroScope();
+      }
     }
     return zeroScope;
   });

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -1777,6 +1777,16 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     if (client) {
       return std::make_shared<dnsdist::lua::LuaServerPoolObject>(poolName);
     }
+
+    {
+      const auto& config = dnsdist::configuration::getCurrentRuntimeConfiguration();
+      auto poolIt = config.d_pools.find(poolName);
+      if (poolIt != config.d_pools.end()) {
+        return std::make_shared<dnsdist::lua::LuaServerPoolObject>(poolName);
+      }
+    }
+
+    /* yes, we just checked, but there is room for a race where a different thread created it */
     bool created = false;
     dnsdist::configuration::updateRuntimeConfiguration([&poolName, &created](dnsdist::configuration::RuntimeConfiguration& config) {
       auto [_, inserted] = config.d_pools.emplace(poolName, ServerPool());


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This only fixes the race if the pool already exists, so we need to pass more context to our bindings to disallow creating a new pool from inside a Lua selector or action, I think.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
