### PR TITLE
auth: better handling of incorrect Lua view() input

### DIFF
--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -1638,6 +1638,9 @@ static bool lua_netmask(const iplist_t& ips)
 static string lua_view(const vector<pair<int, vector<pair<int, iplist_t> > > >& pairs)
 {
   for(const auto& rule : pairs) {
+    if (rule.second.size() < 2) {
+      throw std::invalid_argument("Invalid view data");
+    }
     const auto& netmasks=rule.second[0].second;
     const auto& destinations=rule.second[1].second;
     for(const auto& nmpair : netmasks) {

--- a/regression-tests.auth-py/test_LuaRecords.py
+++ b/regression-tests.auth-py/test_LuaRecords.py
@@ -184,6 +184,9 @@ none.view        IN    LUA    A          ("view({{                              
                                           "{{ {{'192.168.0.0/16'}}, {{'192.168.1.54'}}}},"
                                           "{{ {{'1.2.0.0/16'}}, {{'1.2.3.4'}}}},         "
                                           " }})                                          " )
+bogus.view       IN    LUA    A          ("view({{                                     "
+                                          "{{ {{'192.168.0.0/16'}} }},"
+                                          " }})                                          " )
 *.magic          IN    LUA    A     "closestMagic()"
 www-balanced     IN           CNAME 1-1-1-3.17-1-2-4.1-2-3-5.magic.example.org.
 
@@ -931,6 +934,16 @@ class TestLuaRecords(BaseLuaTest):
         view() test where no netmask match
         """
         query = dns.message.make_query("none.view.example.org", "A")
+
+        res = self.sendUDPQuery(query)
+        self.assertRcodeEqual(res, dns.rcode.SERVFAIL)
+        self.assertAnswerEmpty(res)
+
+    def testViewWrongData(self):
+        """
+        view() test with invalid data
+        """
+        query = dns.message.make_query("bogus.view.example.org", "A")
 
         res = self.sendUDPQuery(query)
         self.assertRcodeEqual(res, dns.rcode.SERVFAIL)


### PR DESCRIPTION
### Short description
This adds missing container bounds check to the body of the Lua `view` function, in case of invalid (incomplete) data, in order to make the error more visible.

Reported by Qifan Zhang.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
