### PR TITLE
auth: redact more secrets

### DIFF
--- a/pdns/ws-api.cc
+++ b/pdns/ws-api.cc
@@ -100,7 +100,7 @@ void apiServerDetail(HttpRequest* /* req */, HttpResponse* resp)
   resp->setJsonBody(getServerDetail());
 }
 
-static bool shouldBeRedacted(const std::string& setting)
+bool apiShouldBeRedacted(const std::string& setting)
 {
   // auth, rec: webserver-password
   if (boost::ends_with(setting, "-password")) {
@@ -126,7 +126,7 @@ void apiServerConfig(HttpRequest* /* req */, HttpResponse* resp)
   Json::array doc;
   for (const string& item : items) {
     // Prevent sensitive configuration values from being leaked
-    if (shouldBeRedacted(item)) {
+    if (apiShouldBeRedacted(item)) {
       value = "***";
     }
     else {

--- a/pdns/ws-api.hh
+++ b/pdns/ws-api.hh
@@ -41,6 +41,7 @@ DNSName apiNameToDNSName(const string& name);
 #if defined(PDNS_AUTH)
 ZoneName apiNameToZoneName(const string& name);
 #endif
+bool apiShouldBeRedacted(const std::string& setting);
 
 // To be provided by product code.
 void productServerStatisticsFetch(std::map<string, string>& out);

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -327,9 +327,17 @@ static void printargs(ostringstream& ret)
 {
   ret << R"(<table border=1><tr><td colspan=3 bgcolor="#0000ff"><font color="#ffffff">Arguments</font></td>)" << endl;
 
-  vector<string> entries = arg().list();
+  const auto& entries = arg().list();
   for (const auto& entry : entries) {
-    ret << "<tr><td>" << entry << "</td><td>" << htmlescape(arg()[entry]) << "</td><td>" << arg().getHelp(entry) << "</td>" << endl;
+    ret << "<tr><td>" << entry << "</td><td>";
+    // Prevent sensitive configuration values from being leaked
+    if (apiShouldBeRedacted(entry)) {
+      ret << "***";
+    }
+    else {
+      ret << htmlescape(arg()[entry]);
+    }
+    ret << "</td><td>" << arg().getHelp(entry) << "</td>" << endl;
   }
 }
 


### PR DESCRIPTION
### Short description
While the API `/config` endpoint will hide passwords and the API key, if the authoritative server runs with `webserver-print-arguments` (which defaults to no), the statistics page will list all configuration parameters without hiding any of these sensitive data.

This PR makes sure these are now redacted.

Reported by Qifan Zhang.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
