### PR TITLE
dnsdist: Don't log the loaded config files when executing a single command

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -2566,21 +2566,25 @@ static std::optional<std::string> lookForTentativeConfigurationFileWithExtension
   return tentativeFile;
 }
 
-static bool loadConfigurationFromFile(const std::string& configurationFile, bool isClient, bool configCheck, const std::shared_ptr<const Logr::Logger>& logger)
+static bool loadConfigurationFromFile(const std::string& configurationFile, bool isClient, bool configCheck, bool singleCommand, const std::shared_ptr<const Logr::Logger>& logger)
 {
   if (boost::ends_with(configurationFile, ".yml")) {
     // the bindings are always needed, for example for inline Lua
     dnsdist::lua::setupLuaBindingsOnly(*(g_lua.lock()), isClient, configCheck);
 
     if (auto tentativeLuaConfFile = lookForTentativeConfigurationFileWithExtension(configurationFile, "lua")) {
-      SLOG(infolog("Loading configuration from auto-discovered Lua file %s", *tentativeLuaConfFile),
-           logger->info(Logr::Info, "Loading configuration from auto-discovered Lua file", "path", Logging::Loggable(*tentativeLuaConfFile)));
+      if (!singleCommand) {
+        SLOG(infolog("Loading configuration from auto-discovered Lua file %s", *tentativeLuaConfFile),
+             logger->info(Logr::Info, "Loading configuration from auto-discovered Lua file", "path", Logging::Loggable(*tentativeLuaConfFile)));
+      }
 
       dnsdist::configuration::lua::loadLuaConfigurationFile(*(g_lua.lock()), *tentativeLuaConfFile, configCheck);
     }
 
-    SLOG(infolog("Loading configuration from YAML file %s", configurationFile),
-         logger->info(Logr::Info, "Loading configuration from YAML file", "path", Logging::Loggable(configurationFile)));
+    if (!singleCommand) {
+      SLOG(infolog("Loading configuration from YAML file %s", configurationFile),
+           logger->info(Logr::Info, "Loading configuration from YAML file", "path", Logging::Loggable(configurationFile)));
+    }
 
     if (!dnsdist::configuration::yaml::loadConfigurationFromFile(configurationFile, isClient, configCheck)) {
       return false;
@@ -2593,19 +2597,25 @@ static bool loadConfigurationFromFile(const std::string& configurationFile, bool
 
   dnsdist::lua::setupLua(*(g_lua.lock()), isClient, configCheck);
   if (boost::ends_with(configurationFile, ".lua")) {
-    SLOG(infolog("Loading configuration from Lua file %s", configurationFile),
-         logger->info(Logr::Info, "Loading configuration from Lua file", "path", Logging::Loggable(configurationFile)));
+    if (!singleCommand) {
+      SLOG(infolog("Loading configuration from Lua file %s", configurationFile),
+           logger->info(Logr::Info, "Loading configuration from Lua file", "path", Logging::Loggable(configurationFile)));
+    }
 
     dnsdist::configuration::lua::loadLuaConfigurationFile(*(g_lua.lock()), configurationFile, configCheck);
     if (auto tentativeYamlConfFile = lookForTentativeConfigurationFileWithExtension(configurationFile, "yml")) {
-      SLOG(infolog("Loading configuration from auto-discovered YAML file %s", *tentativeYamlConfFile),
-           logger->info(Logr::Info, "Loading configuration from auto-discovered YAML file", "path", Logging::Loggable(*tentativeYamlConfFile)));
+      if (!singleCommand) {
+        SLOG(infolog("Loading configuration from auto-discovered YAML file %s", *tentativeYamlConfFile),
+             logger->info(Logr::Info, "Loading configuration from auto-discovered YAML file", "path", Logging::Loggable(*tentativeYamlConfFile)));
+      }
       return dnsdist::configuration::yaml::loadConfigurationFromFile(*tentativeYamlConfFile, isClient, configCheck);
     }
   }
   else {
-    SLOG(infolog("Loading configuration from Lua file %s", configurationFile),
-         logger->info(Logr::Info, "Loading configuration from Lua file", "path", Logging::Loggable(configurationFile)));
+    if (!singleCommand) {
+      SLOG(infolog("Loading configuration from Lua file %s", configurationFile),
+           logger->info(Logr::Info, "Loading configuration from Lua file", "path", Logging::Loggable(configurationFile)));
+    }
 
     dnsdist::configuration::lua::loadLuaConfigurationFile(*(g_lua.lock()), configurationFile, configCheck);
   }
@@ -2676,7 +2686,7 @@ int main(int argc, char** argv)
     });
 
     if (cmdLine.beClient || !cmdLine.command.empty()) {
-      if (!loadConfigurationFromFile(cmdLine.config, true, false, setupLogger)) {
+      if (!loadConfigurationFromFile(cmdLine.config, true, false, !cmdLine.command.empty(), setupLogger)) {
 #ifdef COVERAGE
         exit(EXIT_FAILURE);
 #else
@@ -2712,7 +2722,7 @@ int main(int argc, char** argv)
     dnsdist::webserver::registerBuiltInWebHandlers();
 
     if (cmdLine.checkConfig) {
-      if (!loadConfigurationFromFile(cmdLine.config, false, true, setupLogger)) {
+      if (!loadConfigurationFromFile(cmdLine.config, false, true, false, setupLogger)) {
 #ifdef COVERAGE
         exit(EXIT_FAILURE);
 #else
@@ -2736,7 +2746,7 @@ int main(int argc, char** argv)
     /* create the default pool no matter what */
     createPoolIfNotExists("");
 
-    if (!loadConfigurationFromFile(cmdLine.config, false, false, setupLogger)) {
+    if (!loadConfigurationFromFile(cmdLine.config, false, false, false, setupLogger)) {
 #ifdef COVERAGE
       exit(EXIT_FAILURE);
 #else

--- a/regression-tests.dnsdist/test_CommandExecution.py
+++ b/regression-tests.dnsdist/test_CommandExecution.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 from dnsdisttests import DNSDistTest
 
+
 class TestSingleCommandExecution(DNSDistTest):
     _consoleKey = DNSDistTest.generateConsoleKey()
     _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
@@ -30,5 +31,5 @@ class TestSingleCommandExecution(DNSDistTest):
             raise AssertionError("%s failed (%d): %s / %s" % (testcmd, result.returncode, result.stdout, result.stderr))
 
         values = json.loads(result.stdout)
-        for key in ['hits', 'misses', 'entries']:
+        for key in ["hits", "misses", "entries"]:
             self.assertIn(key, values)

--- a/regression-tests.dnsdist/test_CommandExecution.py
+++ b/regression-tests.dnsdist/test_CommandExecution.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+import base64
+import json
+import os
+import subprocess
+from dnsdisttests import DNSDistTest
+
+class TestSingleCommandExecution(DNSDistTest):
+    _consoleKey = DNSDistTest.generateConsoleKey()
+    _consoleKeyB64 = base64.b64encode(_consoleKey).decode("ascii")
+
+    _config_params = ["_consoleKeyB64", "_consolePort", "_testServerPort"]
+    _config_template = """
+    setKey("%s")
+    controlSocket("127.0.0.1:%d")
+    newServer{address="127.0.0.1:%d"}
+
+    pc = newPacketCache(100)
+    getPool(""):setCache(pc)
+    """
+
+    def testSingleCommandExecution(self):
+        """
+        Single command execution
+        """
+        confFile = os.path.join("configs", "dnsdist_%s.conf" % (self.__class__.__name__))
+        testcmd = [os.environ["DNSDISTBIN"], "-C", confFile, "-e", "getPool(''):getCache():getStats()"]
+        result = subprocess.run(testcmd, capture_output=True, timeout=2, check=True)
+        if result.returncode != 0:
+            raise AssertionError("%s failed (%d): %s / %s" % (testcmd, result.returncode, result.stdout, result.stderr))
+
+        values = json.loads(result.stdout)
+        for key in ['hits', 'misses', 'entries']:
+            self.assertIn(key, values)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
It interferes with headless operation.

Fixes https://github.com/PowerDNS/pdns/issues/17806

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
