### PR TITLE
auth: better numerical parameter parsing #2

### DIFF
--- a/docs/appendices/backend-writers-guide.rst
+++ b/docs/appendices/backend-writers-guide.rst
@@ -503,9 +503,10 @@ available. The exact definitions:
 
   Returns the exact value of a parameter.
 
-.. cpp:function:: int DNSBackend::getArgAsNum(const string &key)
+.. cpp:function:: T DNSBackend::getArgAsNum<T>(const string &key)
 
-  Returns the numerical value of a parameter. Uses ``strtol()`` internally.
+  Returns the numerical value of a parameter. Uses the appropriate variant
+  of ``strtol()`` internally, depending on the type of the return value.
 
   Sample usage from the BIND backend: getting the 'check-interval' setting:
 
@@ -513,7 +514,7 @@ available. The exact definitions:
 
       if(!safeGetBBDomainInfo(i->name, &bbd)) {
         bbd.d_id=domain_id++;
-        bbd.setCheckInterval(getArgAsNum("check-interval"));
+        bbd.setCheckInterval(getArgAsNum<time_t>("check-interval"));
         bbd.d_lastnotified=0;
         bbd.d_loaded=false;
       }

--- a/modules/bindbackend/bindbackend2.cc
+++ b/modules/bindbackend/bindbackend2.cc
@@ -1048,7 +1048,7 @@ void Bind2Backend::loadConfig(string* status) // NOLINT(readability-function-cog
       if (!safeGetBBDomainInfo(domain.name, &bbd)) {
         isNew = true;
         bbd.d_id = domain_id++;
-        bbd.setCheckInterval(getArgAsNum("check-interval"));
+        bbd.setCheckInterval(getArgAsNum<time_t>("check-interval"));
         bbd.d_lastnotified = 0;
         bbd.d_loaded = false;
       }
@@ -1559,7 +1559,7 @@ BB2DomainInfo Bind2Backend::createDomainEntry(const ZoneName& domain)
   bbd.d_id = newid;
   bbd.d_records = std::make_shared<recordstorage_t>();
   bbd.d_name = domain;
-  bbd.setCheckInterval(getArgAsNum("check-interval"));
+  bbd.setCheckInterval(getArgAsNum<time_t>("check-interval"));
 
   return bbd;
 }

--- a/modules/gmysqlbackend/gmysqlbackend.cc
+++ b/modules/gmysqlbackend/gmysqlbackend.cc
@@ -62,13 +62,13 @@ void gMySQLBackend::reconnect()
   setDB(std::unique_ptr<SSql>(new SMySQL(d_slog,
                                          getArg("dbname"),
                                          getArg("host"),
-                                         getArgAsNum("port"),
+                                         getArgAsNum<uint16_t>("port"),
                                          getArg("socket"),
                                          getArg("user"),
                                          getArg("password"),
                                          getArg("group"),
                                          mustDo("innodb-read-committed"),
-                                         getArgAsNum("timeout"),
+                                         getArgAsNum<unsigned int>("timeout"),
                                          mustDo("thread-cleanup"))));
   allocateStatements();
 }

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -780,7 +780,7 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
       uint32_t currentSchemaVersion = currentSchemaVersionAndShards.first;
       // std::cerr<<"current schema version: "<<currentSchemaVersion<<", shards="<<currentSchemaVersionAndShards.second<<std::endl;
 
-      if (getArgAsNum("schema-version") != SCHEMAVERSION) {
+      if (getArgAsNum<uint32_t>("schema-version") != SCHEMAVERSION) {
         throw std::runtime_error("This version of the lmdbbackend only supports schema version 6. Configuration demands a lower version. Not starting up.");
       }
 

--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -735,16 +735,16 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
 
   d_mapsize_main = d_mapsize_shards = 0;
   try {
-    d_mapsize_main = std::stoll(getArg("map-size"));
+    d_mapsize_main = getArgAsNum<uint64_t>("map-size");
   }
-  catch (const std::exception& e) {
-    throw std::runtime_error(std::string("Unable to parse the 'map-size' LMDB value: ") + e.what());
+  catch (const ArgException& e) {
+    throw std::runtime_error(std::string("Unable to parse the 'map-size' LMDB value: ") + e.reason);
   }
   try {
-    d_mapsize_shards = std::stoll(getArg("shards-map-size"));
+    d_mapsize_shards = getArgAsNum<uint64_t>("shards-map-size");
   }
-  catch (const std::exception& e) {
-    throw std::runtime_error(std::string("Unable to parse the 'shards-map-size' LMDB value: ") + e.what());
+  catch (const ArgException& e) {
+    throw std::runtime_error(std::string("Unable to parse the 'shards-map-size' LMDB value: ") + e.reason);
   }
   if (d_mapsize_shards == 0) {
     // Old configuration with only one settings for main and shards.
@@ -759,7 +759,7 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
     d_handle_dups = true;
     LMDBLS::s_flag_deleted = true;
 
-    if (atoi(getArg("shards").c_str()) != 1) {
+    if (getArgAsNum<uint32_t>("shards") != 1) {
       throw std::runtime_error(std::string("running with Lightning Stream support requires shards=1"));
     }
   }
@@ -817,14 +817,10 @@ LMDBBackend::LMDBBackend(const std::string& suffix)
 
       auto txn = d_tdomains->getEnv()->getRWTransaction();
 
-      const auto configShardsTemp = atoi(getArg("shards").c_str());
-      if (configShardsTemp < 0) {
-        throw std::runtime_error("a negative shards value is not supported");
-      }
-      if (configShardsTemp == 0) {
+      const auto configShards = getArgAsNum<uint32_t>("shards");
+      if (configShards == 0) {
         throw std::runtime_error("a shards value of 0 is not supported");
       }
-      const auto configShards = static_cast<uint32_t>(configShardsTemp);
 
       MDBOutVal shards{};
       if (txn->get(pdnsdbi, "shards", shards) == 0) {

--- a/modules/pipebackend/pipebackend.cc
+++ b/modules/pipebackend/pipebackend.cc
@@ -142,7 +142,7 @@ void PipeBackend::launch()
     }
     d_regexstr = getArg("regex");
     d_abiVersion = getArgAsNum("abi-version");
-    d_coproc = std::make_unique<CoWrapper>(d_slog, getArg("command"), getArgAsNum("timeout"), getArgAsNum("abi-version"));
+    d_coproc = std::make_unique<CoWrapper>(d_slog, getArg("command"), getArgAsNum("timeout"), d_abiVersion);
   }
 
   catch (const ArgException& A) {

--- a/modules/tinydnsbackend/tinydnsbackend.cc
+++ b/modules/tinydnsbackend/tinydnsbackend.cc
@@ -83,7 +83,7 @@ TinyDNSBackend::TinyDNSBackend(const string& suffix)
   d_suffix = suffix;
   d_locations = mustDo("locations");
   d_ignorebogus = mustDo("ignore-bogus-records");
-  d_taiepoch = 4611686018427387904ULL + getArgAsNum("tai-adjust");
+  d_taiepoch = 4611686018427387904ULL + getArgAsNum<time_t>("tai-adjust");
   d_dnspacket = NULL;
   d_cdbReader = NULL;
   d_isAxfr = false;

--- a/pdns/dnsbackend.cc
+++ b/pdns/dnsbackend.cc
@@ -25,7 +25,6 @@
 #endif
 #include "utility.hh"
 #include "dnsbackend.hh"
-#include "arguments.hh"
 #include "ueberbackend.hh"
 #include "logger.hh"
 
@@ -60,11 +59,6 @@ bool DNSBackend::mustDo(const string& key)
 const string& DNSBackend::getArg(const string& key)
 {
   return arg()[d_prefix + "-" + key];
-}
-
-int DNSBackend::getArgAsNum(const string& key)
-{
-  return arg().asNum(d_prefix + "-" + key);
 }
 
 // Default API lookup has no support for disabled records and simply wraps lookup()

--- a/pdns/dnsbackend.hh
+++ b/pdns/dnsbackend.hh
@@ -36,6 +36,7 @@ class DNSPacket;
 #include <iostream>
 #include <sys/socket.h>
 #include <dirent.h>
+#include "arguments.hh"
 #include "misc.hh"
 #include "qtype.hh"
 #include "dns.hh"
@@ -536,7 +537,12 @@ public:
 protected:
   bool mustDo(const string& key);
   const string& getArg(const string& key);
-  int getArgAsNum(const string& key);
+
+  template <typename T = int>
+  T getArgAsNum(const string& key)
+  {
+    return arg().asNum<T>(d_prefix + "-" + key);
+  }
 
   std::shared_ptr<Logr::Logger> d_slog;
 


### PR DESCRIPTION
### Short description
This is similar to #17878, for `DNSBackend`. This class has a `getArgAsNum` method wrapping `arg()::asNum`, so make it templated so it can return a different type than `int`.

Then, make use of it to replace hand-made conversions of `getArg` results to numbers.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
