### PR TITLE
auth: reject *XFR requests with EDNS and EDNS version != 0

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -379,17 +379,25 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
       if (packet->hasEDNSCookie())
         S.inc("tcp-cookie-queries");
 
-      if(packet->qtype.getCode()==QType::AXFR) {
+      if(packet->qtype.getCode()==QType::AXFR || packet->qtype.getCode()==QType::IXFR) {
+        // Since we will bypass PacketHandler here, we need to perform some
+        // sanity checks.
+        if (packet->hasEDNS()) {
+          if (packet->getEDNSVersion() > 0) {
+            auto resp = packet->replyPacket();
+            resp->setEDNSRcode(ERCode::BADVERS);
+            sendPacket(resp, fd);
+            continue;
+          }
+        }
         packet->d_xfr=true;
         g_zoneCache.setZoneVariant(*packet);
-        doAXFR(packet->qdomainzone, packet, fd, slog);
-        continue;
-      }
-
-      if(packet->qtype.getCode()==QType::IXFR) {
-        packet->d_xfr=true;
-        g_zoneCache.setZoneVariant(*packet);
-        doIXFR(packet, fd, slog);
+        if(packet->qtype.getCode()==QType::AXFR) {
+          doAXFR(packet->qdomainzone, packet, fd, slog);
+        }
+        else {
+          doIXFR(packet, fd, slog);
+        }
         continue;
       }
 
@@ -399,8 +407,8 @@ void TCPNameserver::doConnection(int fd, Logr::log_t slog)
       if(g_logDNSQueries)  {
         if (g_slogStructured) {
           slogger = slog->withValues("remote", Logging::Loggable(packet->getRemoteString()), "query", Logging::Loggable(packet->qdomain), "type", Logging::Loggable(packet->qtype), "dnssecok", Logging::Loggable(packet->d_dnssecOk), "bufsize", Logging::Loggable(packet->getMaxReplyLen()));
-	}
-	else {
+        }
+        else {
           g_log << Logger::Notice<<"TCP Remote "<< packet->getRemoteString() <<" wants '" << packet->qdomain<<"|"<<packet->qtype.toString() <<
                "', do = " <<packet->d_dnssecOk <<", bufsize = "<< packet->getMaxReplyLen();
         }


### PR DESCRIPTION
### Short description
Handling of *XFR requests is performed outside of `PacketHandler`; because of this, it lacks the logic rejecting packets with EDNS but an EDNS version different from zero.

This PR adds the missing version check in case of *XFR. This duplicates a bit of code, but it's a small enough chunk to be acceptable IMO.

Reported by Qifan Zhang.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
