### PR TITLE
upload-to-pulp action: enable uploading packages to more than one rpm repository

### DIFF
--- a/upload-to-pulp/action.yml
+++ b/upload-to-pulp/action.yml
@@ -62,9 +62,9 @@ runs:
         . .venv/bin/activate && python3 upload-packages-to-pulp.py \
           --command upload-packages \
           --repo_type deb \
-          --repo_name ${REPOSITORY_NAME} \
-          --distribution_name ${DISTRIBUTION_NAME} \
-          --source ${PACKAGES_DIR}
+          --repo_name "${REPOSITORY_NAME}" \
+          --distribution_name "${DISTRIBUTION_NAME}" \
+          --source "${PACKAGES_DIR}"
       working-directory: ${{ github.action_path }}
     - name: Publish latest DEB repository version
       if: ${{ inputs.repository-type == 'deb' && inputs.publish == 'true' }}
@@ -79,7 +79,7 @@ runs:
         . .venv/bin/activate && python3 upload-packages-to-pulp.py \
           --command create-publication \
           --repo_type deb \
-          --repo_name ${REPOSITORY_NAME}
+          --repo_name "${REPOSITORY_NAME}"
       working-directory: ${{ github.action_path }}
     - name: Upload RPM packages to a repository
       if: ${{ inputs.repository-type == 'rpm' && inputs.upload == 'true' }}
@@ -95,8 +95,8 @@ runs:
         . .venv/bin/activate && python3 upload-packages-to-pulp.py \
           --command upload-packages \
           --repo_type rpm \
-          --repo_name ${REPOSITORY_NAME} \
-          --source ${PACKAGES_DIR}
+          --repo_name "${REPOSITORY_NAME}" \
+          --source "${PACKAGES_DIR}"
       working-directory: ${{ github.action_path }}
     - name: Publish latest RPM repository version
       if: ${{ inputs.repository-type == 'rpm' && inputs.publish == 'true' }}
@@ -111,7 +111,7 @@ runs:
         . .venv/bin/activate && python3 upload-packages-to-pulp.py \
           --command create-publication \
           --repo_type rpm \
-          --repo_name ${REPOSITORY_NAME}
+          --repo_name "${REPOSITORY_NAME}"
       working-directory: ${{ github.action_path }}
     - name: Upload File artifacs to a repository
       if: ${{ inputs.repository-type == 'file' }}
@@ -128,7 +128,7 @@ runs:
         . .venv/bin/activate && python3 upload-packages-to-pulp.py \
           --command upload-packages \
           --repo_type file \
-          --repo_name ${REPOSITORY_NAME} \
-          --destination_path ${DESTINATION_PATH} \
-          --source ${PACKAGES_DIR}
+          --repo_name "${REPOSITORY_NAME}" \
+          --destination_path "${DESTINATION_PATH}" \
+          --source "${PACKAGES_DIR}"
       working-directory: ${{ github.action_path }}

--- a/upload-to-pulp/upload-packages-to-pulp.py
+++ b/upload-to-pulp/upload-packages-to-pulp.py
@@ -137,14 +137,68 @@ def pulp_create_publication(repo_name, repo_type):
     run_pulp_cmd(cmd)
 
 
-def pulp_upload_rpm_packages_by_folder(repo_name, source):
+def pulp_repository_modify(repository_href, add_content_units):
+    """
+    This function updates a repository in Pulp by calling the modify API and
+    passing as arguments the list of content units to be added
+    """
+
+    modify_repository_url = PULP_API_URL + repository_href + "modify/"
+
+    try:
+        res = requests.post(
+            modify_repository_url,
+            auth=PULP_API_AUTH,
+            headers=PULP_API_HEADERS,
+            json={"add_content_units": add_content_units},
+        )
+        res.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(f"::error::Error adding content to repository {repository_href}: {e.response.text}")
+        sys.exit(1)
+
+    task_href = res.json().get("task")
+    if not is_pulp_task_completed(task_href):
+        print(
+            f"::error::Error adding content to repository {repository_href}. Task {task_href} timeout"
+        )
+        sys.exit(1)
+
+def pulp_upload_rpm_packages_by_folder(repo_names, source):
+
+    repo_names = list(dict.fromkeys(repo_names))
+    # repository where the packages will be uploaded to
+    repo_name = repo_names[0]
+    # additional repositories that will also have the same packages associated
+    additional_repos = repo_names[1:]
+    content_hrefs = []
+
     for root, dirs, files in os.walk(source):
         for file in files:
             if file.endswith(".rpm"):
                 full_path = os.path.join(root, file)
                 # Set chunk size to 500MB to avoid creating an "upload" instead of a file. Required for signing RPMs.
                 cmd = f"rpm content -t package upload --file {full_path} --repository {repo_name} --no-publish --chunk-size 500MB"
-                run_pulp_cmd(cmd)
+                content = run_pulp_cmd(cmd)
+
+                # Check that chunk size was not exceeded so a package object is returned instead of a content object
+                content_href = get_pulp_output_attribute(content, "pulp_href")
+                if not content_href or "/content/rpm/packages/" not in content_href:
+                    print(
+                        f"::error::Error retrieving rpm package_href from: {content}"
+                    )
+                    sys.exit(1)
+
+                if content_href not in content_hrefs:
+                    content_hrefs.append(content_href)
+
+    if not content_hrefs:
+        print(f"::error::No rpm packages found in {source}")
+        sys.exit(1)
+
+    for repo in additional_repos:
+        repository_href = get_pulp_repository_href(repo, "rpm")
+        pulp_repository_modify(repository_href, content_hrefs)
 
 
 def is_pulp_task_completed(task_href):
@@ -153,11 +207,15 @@ def is_pulp_task_completed(task_href):
     and returns True. Otherwhise returns False
     """
 
-    elapsed_time = 0
-    check_interval = 5
+    check_interval = 0.5
+    max_check_interval = 15
     max_wait_time = 1200
+    # Task states still in progress: https://github.com/pulp/pulpcore/blob/main/pulpcore/constants.py#L48
+    task_state_in_progress = ["waiting", "running", "canceling"]
 
-    while elapsed_time < max_wait_time:
+    target_time = time.monotonic() + max_wait_time
+
+    while True:
         cmd = f"task show --href {task_href}"
         task = run_pulp_cmd(cmd)
         task_state = get_pulp_output_attribute(task, "state")
@@ -165,10 +223,18 @@ def is_pulp_task_completed(task_href):
         if task_state == "completed":
             return True
 
-        time.sleep(check_interval)
-        elapsed_time += check_interval
+        # Exit if the task is not completed and is no longer in progress
+        if task_state not in task_state_in_progress:
+            task_error = get_pulp_output_attribute(task, "error")
+            print(f"::error::Task {task_href} is in state {task_state}: {task_error}")
+            return False
 
-    return False
+        remaining_time = target_time - time.monotonic()
+        if remaining_time <= 0:
+            return False
+
+        time.sleep(min(check_interval, remaining_time))
+        check_interval = min(check_interval * 2, max_check_interval)
 
 
 def get_pulp_task_result(task_href):
@@ -262,30 +328,14 @@ def pulp_upload_deb_packages_by_folder(repo_name, distribution_name, source):
 
     # Add all upload packages to the repository
     repository_href = get_pulp_repository_href(repo_name, "deb")
-    modify_repository_url = PULP_API_URL + repository_href + "modify/"
 
-    repository_modify_payload = {
-        "add_content_units": packages
+    pulp_repository_modify(
+        repository_href,
+        packages
         + release_components
         + release_architectures
-        + package_release_components
-    }
-
-    try:
-        res = requests.post(
-            modify_repository_url, auth=PULP_API_AUTH, headers=PULP_API_HEADERS, json=repository_modify_payload
-        )
-        res.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        print(f"::error::Error updating DEB repository in Pulp: {e.response.text}")
-        sys.exit(1)
-
-    task_href = res.json().get('task')
-    if not is_pulp_task_completed(task_href):
-        print(
-            f"::error::Error updating DEB repository in Pulp. Task {task_href} timeout"
-        )
-        sys.exit(1)
+        + package_release_components,
+    )
 
 
 def main():
@@ -302,7 +352,11 @@ def main():
         choices=["rpm", "deb", "file"],
         help="Type of the repository [rpm|deb|file]",
     )
-    parser.add_argument("--repo_name", required=True, help="Name of the repository.")
+    parser.add_argument(
+        "--repo_name",
+        required=True,
+        help="Name of the repository. One or more space-separated names may be given for repo_type rpm",
+    )
     parser.add_argument(
         "--distribution_name",
         required=False,
@@ -324,31 +378,38 @@ def main():
     if args.command == "upload-packages" and not args.source:
         parser.error("--source is mandatory for upload-packages")
 
+    repo_names = args.repo_name.split()
+
+    if not repo_names:
+        parser.error("--repo_name is mandatory")
+
+    if len(repo_names) > 1 and args.repo_type != "rpm":
+        parser.error("multiple repository names are allowed ONLY for repo_type rpm")
+
     match (args.command, args.repo_type):
         case ("upload-packages", "rpm"):
-            pulp_upload_rpm_packages_by_folder(args.repo_name, args.source)
+            pulp_upload_rpm_packages_by_folder(repo_names, args.source)
         case ("upload-packages", "deb"):
             if not args.distribution_name:
                 parser.error(
                     "--distribution_name is mandatory for upload-packages + repo_type deb"
                 )
             pulp_upload_deb_packages_by_folder(
-                args.repo_name, args.distribution_name, args.source
+                repo_names[0], args.distribution_name, args.source
             )
-        case ("upload-packages", "deb"):
-            pulp_upload_deb_packages_by_folder(args.repo_name, args.source )
         case ("upload-packages", "file"):
             if not args.destination_path:
                 parser.error(
                     "--destination_path is mandatory for upload-packages + repo_type file"
                 )
             pulp_upload_file_packages_by_folder(
-                args.repo_name, args.source, args.destination_path
+                repo_names[0], args.source, args.destination_path
             )
         case ("create-publication", repo_type):
-            pulp_create_publication(args.repo_name, repo_type)
+            for repo_name in repo_names:
+                pulp_create_publication(repo_name, repo_type)
         case _:
-            print(f"::error::Wrong arg values: mode={args.mode}, type={args.type}")
+            print(f"::error::Wrong arg values: command={args.command}, repo_type={args.repo_type}")
             sys.exit(1)
 
 


### PR DESCRIPTION
### Short description
This PR updates the `upload-to-pulp` action to allow uploading a package to multiple RPM repositories in a single call.

This helps avoid duplicate packages (same package but different sha256sum because of the added GPG signature). 

Usage:

```
      - uses: PowerDNS/pdns/upload-to-pulp@meta
        with:
           ...
          repository-name: |-
            <repository-name-1>
            <repository-name-2>
            ...
          repository-type: 'rpm'
          ...
```

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
