### PR TITLE
dnsdist: Use the proper ALPN on auto-upgraded DoT/DoH backends

### DIFF
--- a/pdns/dnsdistdist/dnsdist-discovery.cc
+++ b/pdns/dnsdistdist/dnsdist-discovery.cc
@@ -449,6 +449,7 @@ bool ServiceDiscovery::tryToUpgradeBackend(const Logr::Logger& logger, const Upg
     config.d_tlsSubjectName = backend.d_ds->d_config.remote.toString();
     config.d_tlsSubjectIsAddr = true;
   }
+  config.d_tlsParams.d_alpn = discoveredConfig.d_protocol == dnsdist::Protocol::DoT ? TLSFrontend::ALPN::DoT : TLSFrontend::ALPN::DoH;
 
   if (!backend.d_poolAfterUpgrade.empty()) {
     config.pools.clear();

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -517,6 +517,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         multipleConnections=False,
         listeningAddr="127.0.0.1",
         partialWrite=False,
+        expectedALPN=None,
     ):
         cls._backgroundThreads[threading.get_native_id()] = True
         # trailingDataResponse=True means "ignore trailing data".
@@ -553,6 +554,12 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                     continue
 
             conn.settimeout(5.0)
+            if tlsContext and expectedALPN:
+                alpn = conn.selected_alpn_protocol()
+                if alpn != expectedALPN:
+                    print(f"Wrong ALPN, got {alpn}, expected {expectedALPN}")
+                    continue
+
             if multipleConnections:
                 thread = threading.Thread(
                     name="TCP Connection Handler",
@@ -709,6 +716,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         useProxyProtocol=False,
         closeConnCallback=False,
         connTimeout=5.0,
+        expectedALPN=None,
     ):
         cls._backgroundThreads[threading.get_native_id()] = True
         # trailingDataResponse=True means "ignore trailing data".
@@ -747,6 +755,13 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                     continue
 
             conn.settimeout(connTimeout)
+
+            if tlsContext and expectedALPN:
+                alpn = conn.selected_alpn_protocol()
+                if alpn != expectedALPN:
+                    print(f"Wrong ALPN, got {alpn}, expected {expectedALPN}")
+                    continue
+
             thread = threading.Thread(
                 name="DoH Connection Handler",
                 target=cls.handleDoHConnection,

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -291,8 +291,12 @@ class TestBackendDiscovery(DNSDistTest):
 
     @classmethod
     def startResponders(cls):
-        tlsContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        tlsContext.load_cert_chain("server.chain", "server.key")
+        dotContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        dotContext.load_cert_chain("server.chain", "server.key")
+        dotContext.set_alpn_protocols(['dot'])
+        dohContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        dohContext.load_cert_chain("server.chain", "server.key")
+        dohContext.set_alpn_protocols(['h2'])
 
         TCPNoSVCResponder = threading.Thread(
             name="TCP no SVC Responder",
@@ -347,7 +351,7 @@ class TestBackendDiscovery(DNSDistTest):
         UpgradedDoTResponder = threading.Thread(
             name="DoT upgraded Responder",
             target=cls.TCPResponder,
-            args=[10652, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, tlsContext],
+            args=[10652, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dotContext, False, "127.0.0.1", False, "dot"],
         )
         UpgradedDoTResponder.daemon = True
         UpgradedDoTResponder.start()
@@ -370,7 +374,7 @@ class TestBackendDiscovery(DNSDistTest):
         UpgradedDOHResponder = threading.Thread(
             name="DOH Responder",
             target=cls.DOHResponder,
-            args=[10653, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, tlsContext],
+            args=[10653, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dohContext, False, False, 5.0, "h2"],
         )
         UpgradedDOHResponder.daemon = True
         UpgradedDOHResponder.start()
@@ -400,9 +404,11 @@ class TestBackendDiscovery(DNSDistTest):
                 False,
                 False,
                 None,
-                tlsContext,
+                dotContext,
                 False,
                 "127.0.0.2",
+                False,
+                "dot",
             ],
         )
         UpgradedDoTResponder.daemon = True
@@ -429,7 +435,7 @@ class TestBackendDiscovery(DNSDistTest):
         UpgradedDoTResponder = threading.Thread(
             name="DoT upgraded different addr 2 Responder",
             target=cls.TCPResponder,
-            args=[10655, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, tlsContext, False],
+            args=[10655, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dotContext, False, "127.0.0.1", False, "dot"],
         )
         UpgradedDoTResponder.daemon = True
         UpgradedDoTResponder.start()

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -293,10 +293,10 @@ class TestBackendDiscovery(DNSDistTest):
     def startResponders(cls):
         dotContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         dotContext.load_cert_chain("server.chain", "server.key")
-        dotContext.set_alpn_protocols(['dot'])
+        dotContext.set_alpn_protocols(["dot"])
         dohContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         dohContext.load_cert_chain("server.chain", "server.key")
-        dohContext.set_alpn_protocols(['h2'])
+        dohContext.set_alpn_protocols(["h2"])
 
         TCPNoSVCResponder = threading.Thread(
             name="TCP no SVC Responder",
@@ -351,7 +351,19 @@ class TestBackendDiscovery(DNSDistTest):
         UpgradedDoTResponder = threading.Thread(
             name="DoT upgraded Responder",
             target=cls.TCPResponder,
-            args=[10652, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dotContext, False, "127.0.0.1", False, "dot"],
+            args=[
+                10652,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                None,
+                dotContext,
+                False,
+                "127.0.0.1",
+                False,
+                "dot",
+            ],
         )
         UpgradedDoTResponder.daemon = True
         UpgradedDoTResponder.start()
@@ -374,7 +386,19 @@ class TestBackendDiscovery(DNSDistTest):
         UpgradedDOHResponder = threading.Thread(
             name="DOH Responder",
             target=cls.DOHResponder,
-            args=[10653, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dohContext, False, False, 5.0, "h2"],
+            args=[
+                10653,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                None,
+                dohContext,
+                False,
+                False,
+                5.0,
+                "h2",
+            ],
         )
         UpgradedDOHResponder.daemon = True
         UpgradedDOHResponder.start()
@@ -435,7 +459,19 @@ class TestBackendDiscovery(DNSDistTest):
         UpgradedDoTResponder = threading.Thread(
             name="DoT upgraded different addr 2 Responder",
             target=cls.TCPResponder,
-            args=[10655, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dotContext, False, "127.0.0.1", False, "dot"],
+            args=[
+                10655,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                None,
+                dotContext,
+                False,
+                "127.0.0.1",
+                False,
+                "dot",
+            ],
         )
         UpgradedDoTResponder.daemon = True
         UpgradedDoTResponder.start()


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported by Qifan Zhang from Palo Alto Networks (thanks!).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
