### PR TITLE
dnsdist-2.1: Backport 17802 - Properly set the "last IO blocked" flag from incoming DoH

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -519,6 +519,7 @@ void IncomingHTTP2Connection::writeToSocket(bool socketReady)
 
     if (newState == IOState::Done) {
       d_pendingWrite = false;
+      d_lastIOBlocked = false; // setting this does matter, because it is used in IncomingTCPConnectionState::queueResponse
       d_out.clear();
       d_outPos = 0;
       if (active() && !d_connectionClosing) {
@@ -1264,6 +1265,7 @@ IOState IncomingHTTP2Connection::readHTTPData()
 
     if (got > 0) {
       /* we got something */
+      d_lastIOBlocked = false; // setting this does matter, because it is used in IncomingTCPConnectionState::queueResponse
       auto readlen = nghttp2_session_mem_recv(d_session.get(), d_in.data(), d_in.size());
       /* as long as we don't require a pause by returning nghttp2_error.NGHTTP2_ERR_PAUSE from a CB,
          all data should be consumed before returning */


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport #17802 to dnsdist-2.1.x

It is used in at least one method inherited from `IncomingTCPConnectionState`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
