### PR TITLE
dnsdist-2.1: Backport 17906 - Fix a regression when dots are used in the carbon host name

### DIFF
--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -374,13 +374,13 @@ void Carbon::run(const std::vector<Carbon::Endpoint>& endpoints)
   }
 }
 
-const std::string Carbon::Endpoint::getOurName() const
+std::string Carbon::Endpoint::getOurName() const
 {
   std::string ret = ourname.value_or("");
   if (!ourname) {
     ret = dnsdist::configuration::getCurrentRuntimeConfiguration().d_server_id;
+    std::replace(ret.begin(), ret.end(), '.', '_');
   }
-  std::replace(ret.begin(), ret.end(), '.', '_');
   return ret;
 }
 

--- a/pdns/dnsdistdist/dnsdist-carbon.hh
+++ b/pdns/dnsdistdist/dnsdist-carbon.hh
@@ -41,7 +41,7 @@ public:
     std::string instance_name;
     unsigned int interval;
 
-    const std::string getOurName() const;
+    [[nodiscard]] std::string getOurName() const;
   };
 
   static Endpoint newEndpoint(const std::string& address, const std::optional<std::string>& ourName, uint64_t interval, const std::string& namespace_name, const std::string& instance_name);

--- a/pdns/dnsdistdist/docs/reference/carbon.rst
+++ b/pdns/dnsdistdist/docs/reference/carbon.rst
@@ -6,8 +6,7 @@ Carbon export
   Export statistics to a Carbon / Graphite / Metronome server.
 
   :param string serverIP: Indicates the IP address where the statistics should be sent
-  :param string ourname: An optional string specifying the hostname that should be used
+  :param string ourname: An optional string specifying the hostname that should be used. While allowed, the use of dots in the hostname is not advised. Please consider using the ``namespace`` parameter to influence the metric hierarchy instead.
   :param int interval: An optional unsigned integer indicating the interval in seconds between exports
   :param string namespace: An optional string specifying the namespace name that should be used
   :param string instance: An optional string specifying the instance name that should be used
-

--- a/regression-tests.dnsdist/test_Carbon.py
+++ b/regression-tests.dnsdist/test_Carbon.py
@@ -10,7 +10,7 @@ class TestCarbon(DNSDistTest):
     _carbonServer1Port = pickAvailablePort()
     _carbonServer1Name = "carbonname1"
     _carbonServer2Port = pickAvailablePort()
-    _carbonServer2Name = "carbonname2"
+    _carbonServer2Name = "carbonname.with.dots"
     _carbonQueue1 = Queue()
     _carbonQueue2 = Queue()
     _carbonInterval = 2


### PR DESCRIPTION
### Short description
Backport of #17906 to dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
