### PR TITLE
dnsdist-2.1: Backport 17697 - Increase testrunner timeouts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1097,6 +1097,7 @@ if get_option('unit-tests')
       'BOOST_TEST_LOG_LEVEL': 'message',
     },
     is_parallel: false,
+    timeout: 300,
   )
 endif
 
@@ -1149,6 +1150,7 @@ if get_option('unit-tests-backends')
         workdir: product_source_dir / fs.parent(module_remotebackend_testrunner),
         is_parallel: false,
         depends: get_variable(exec_var_name),
+        timeout: 300,
       )
     endforeach
   endif
@@ -1172,6 +1174,7 @@ if get_option('unit-tests-backends')
         workdir: product_source_dir / 'regression-tests',
         depends: [pdns_server, pdnsutil, sdig, saxfr, pdns_notify, nsec3dig],
         is_parallel: false,
+        timeout: 300,
       )
     endif
   endforeach

--- a/pdns/dnsdistdist/meson.build
+++ b/pdns/dnsdistdist/meson.build
@@ -671,11 +671,11 @@ foreach tool, info: tools
 endforeach
 
 if get_option('unit-tests')
-  test('testrunner', testrunner)
+  test('testrunner', testrunner, timeout: 300)
 endif
 
 if get_option('benchmark')
-  benchmark('benchmarkrunner', benchmarkrunner, timeout:240)
+  benchmark('benchmarkrunner', benchmarkrunner, timeout: 300)
 endif
 
 # Man-pages.

--- a/pdns/recursordist/meson.build
+++ b/pdns/recursordist/meson.build
@@ -606,7 +606,7 @@ endforeach
 
 if get_option('unit-tests')
   # default timeout of 30s is too short for some ubicloud targets. Unknown *why* they are so slow.
-  test('testrunner', testrunner, timeout: 120)
+  test('testrunner', testrunner, timeout: 300)
 endif
 
 # Man-pages.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17697 to dnsdist-2.1.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
