### PR TITLE
dnsdist-2.1: Backport 17691 - Use a longer timeout for DoT connections in the proxy tests

### DIFF
--- a/regression-tests.dnsdist/test_ProxyProtocol.py
+++ b/regression-tests.dnsdist/test_ProxyProtocol.py
@@ -893,7 +893,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
         receivedResponse = None
         conn = self.openTLSConnection(reverseProxyPort, self._serverName, self._caCert, timeout=2.0)
         self.sendTCPQueryOverConnection(conn, query, response=response)
-        receivedResponse = self.recvTCPResponseOverConnection(conn)
+        # longer timeout, this often fails on CI
+        receivedResponse = self.recvTCPResponseOverConnection(conn, timeout=4.0)
         (receivedProxyPayload, receivedDNSData) = fromProxyQueue.get(True, 2.0)
         self.assertTrue(receivedProxyPayload)
         self.assertTrue(receivedDNSData)
@@ -945,7 +946,8 @@ class TestProxyProtocolIncoming(ProxyProtocolTest):
         conn = self.openTLSConnection(reverseProxyPort, self._serverName, self._caCert, timeout=2.0)
 
         self.sendTCPQueryOverConnection(conn, query, response=response)
-        receivedResponse = self.recvTCPResponseOverConnection(conn)
+        # longer timeout, this often fails on CI
+        receivedResponse = self.recvTCPResponseOverConnection(conn, timeout=4.0)
         (receivedProxyPayload, receivedDNSData) = fromProxyQueue.get(True, 2.0)
         self.assertTrue(receivedProxyPayload)
         self.assertTrue(receivedDNSData)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17691 to dnsdist-2.1.x

These tests regularly fail when the CI is overloaded, probably because establishing the TLS connection is taking a long time.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
