### PR TITLE
dnsdist-2.0: backport 17549 - Don't close DoH on timeout, do on release

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -74,6 +74,10 @@ public:
   void release(bool removeFromCache) override
   {
     (void)removeFromCache;
+    if (d_ioState) {
+      d_ioState.reset();
+    }
+    nghttp2_session_terminate_session(d_session.get(), NGHTTP2_NO_ERROR);
   }
 
 private:
@@ -540,7 +544,7 @@ void DoHConnectionToBackend::updateIO(IOState newState, const FDMultiplexer::cal
 void DoHConnectionToBackend::watchForRemoteHostClosingConnection()
 {
   if (willBeReusable(false) && !d_healthCheckQuery) {
-    updateIO(IOState::NeedRead, handleReadableIOCallback, false);
+    updateIO(IOState::NeedRead, handleReadableIOCallback, true);
   }
 }
 

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -484,7 +484,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
         sock.close()
 
     @classmethod
-    def handleDoHConnection(cls, config, conn, fromQueue, toQueue, trailingDataResponse, multipleResponses, callback, tlsContext, useProxyProtocol):
+    def handleDoHConnection(cls, config, conn, fromQueue, toQueue, trailingDataResponse, multipleResponses, callback, tlsContext, useProxyProtocol, closeConnCallback):
         ignoreTrailing = trailingDataResponse is True
         try:
           h2conn = h2.connection.H2Connection(config=config)
@@ -505,18 +505,24 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             header = conn.recv(proxy.HEADER_SIZE)
             if not header:
                 print('unable to get header')
+                if closeConnCallback:
+                    closeConnCallback(conn)
                 conn.close()
                 return
 
             if not proxy.parseHeader(header):
                 print('unable to parse header')
                 print(header)
+                if closeConnCallback:
+                    closeConnCallback(conn)
                 conn.close()
                 return
 
             proxyContent = conn.recv(proxy.contentLen)
             if not proxyContent:
                 print('unable to get content')
+                if closeConnCallback:
+                    closeConnCallback(conn)
                 conn.close()
                 return
 
@@ -536,6 +542,8 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
 
             events = h2conn.receive_data(data)
             for event in events:
+                if isinstance(event, h2.events.ConnectionTerminated):
+                    break
                 if isinstance(event, h2.events.RequestReceived):
                     requestHeaders = event.headers
                 if isinstance(event, h2.events.DataReceived):
@@ -556,13 +564,15 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                             forceRcode = trailingDataResponse
 
                         if callback:
-                            status, wire = callback(request, requestHeaders, fromQueue, toQueue)
+                            status, wire = callback(request, requestHeaders, fromQueue, toQueue, conn)
                         else:
                             response = cls._getResponse(request, fromQueue, toQueue, synthesize=forceRcode)
                             if response:
                                 wire = response.to_wire(max_size=65535)
 
                         if not wire:
+                            if closeConnCallback:
+                                closeConnCallback(conn)
                             conn.close()
                             conn = None
                             break
@@ -585,10 +595,12 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                 break
 
         if conn is not None:
+            if closeConnCallback:
+                closeConnCallback(conn)
             conn.close()
 
     @classmethod
-    def DOHResponder(cls, port, fromQueue, toQueue, trailingDataResponse=False, multipleResponses=False, callback=None, tlsContext=None, useProxyProtocol=False):
+    def DOHResponder(cls, port, fromQueue, toQueue, trailingDataResponse=False, multipleResponses=False, callback=None, tlsContext=None, useProxyProtocol=False, closeConnCallback=False, connTimeout=5.0):
         cls._backgroundThreads[threading.get_native_id()] = True
         # trailingDataResponse=True means "ignore trailing data".
         # Other values are either False (meaning "raise an exception")
@@ -628,7 +640,7 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             conn.settimeout(5.0)
             thread = threading.Thread(name='DoH Connection Handler',
                                       target=cls.handleDoHConnection,
-                                      args=[config, conn, fromQueue, toQueue, trailingDataResponse, multipleResponses, callback, tlsContext, useProxyProtocol])
+                                      args=[config, conn, fromQueue, toQueue, trailingDataResponse, multipleResponses, callback, tlsContext, useProxyProtocol, closeConnCallback])
             thread.daemon = True
             thread.start()
 

--- a/regression-tests.dnsdist/test_HealthChecks.py
+++ b/regression-tests.dnsdist/test_HealthChecks.py
@@ -281,7 +281,7 @@ class TestLazyHealthChecks(HealthCheckTest):
         return cls.HandleDNSQuery(request)
 
     @classmethod
-    def DoHCallback(cls, request, requestHeaders, fromQueue, toQueue):
+    def DoHCallback(cls, request, requestHeaders, fromQueue, toQueue, conn):
         global _dohHealthCheckQueries
         if str(request.question[0].name).startswith('a.root-servers.net'):
             _dohHealthCheckQueries = _dohHealthCheckQueries + 1

--- a/regression-tests.dnsdist/test_OutgoingDOH.py
+++ b/regression-tests.dnsdist/test_OutgoingDOH.py
@@ -534,7 +534,7 @@ class TestOutgoingDOHBrokenResponsesOpenSSL(DNSDistTest, OutgoingDOHBrokenRespon
     addAction(SuffixMatchNodeRule(smn), PoolAction('cache'))
     """
 
-    def callback(request, headers, fromQueue, toQueue):
+    def callback(request, headers, fromQueue, toQueue, conn):
 
         if str(request.question[0].name) == '500-status.broken-responses.outgoing-doh.test.powerdns.com.':
             print("returning 500")
@@ -571,7 +571,7 @@ class TestOutgoingDOHBrokenResponsesGnuTLS(DNSDistTest, OutgoingDOHBrokenRespons
     """
     _verboseMode = True
 
-    def callback(request, headers, fromQueue, toQueue):
+    def callback(request, headers, fromQueue, toQueue, conn):
 
         if str(request.question[0].name) == '500-status.broken-responses.outgoing-doh.test.powerdns.com.':
             print("returning 500")
@@ -653,7 +653,7 @@ class TestOutgoingDOHXForwarded(DNSDistTest):
     """
     _verboseMode = True
 
-    def callback(request, headersList, fromQueue, toQueue):
+    def callback(request, headersList, fromQueue, toQueue, conn):
 
         if str(request.question[0].name) == 'a.root-servers.net.':
             # do not check headers on health-check queries
@@ -714,3 +714,89 @@ class TestOutgoingDOHXForwarded(DNSDistTest):
         (receivedQuery, receivedResponse) = self.sendTCPQuery(query, expectedResponse)
         self.assertEqual(query, receivedQuery)
         self.assertEqual(receivedResponse, expectedResponse)
+
+
+class TestOutgoingDOHKeepsConnection(DNSDistTest):
+    _tlsBackendPort = pickAvailablePort()
+    _config_params = ["_tlsBackendPort"]
+    _config_template = """
+    setMaxTCPClientThreads(1)
+    newServer{address="127.0.0.1:%d", tls='gnutls', validateCertificates=true, caStore='ca.pem', subjectName='powerdns.com', dohPath='/dns-query', tcpRecvTimeout=2}
+    setDoHDownstreamMaxIdleTime(8)
+    setDoHDownstreamCleanupInterval(4)
+    """
+    _verboseMode = True
+
+    _upconns = []
+    _lock = threading.Lock()
+
+    @classmethod
+    def callback(cls, request, headersList, fromQueue, toQueue, conn):
+        # we want to track up connections on the backend, but not the healthchecks
+        # however we cannot tell connections apart until they send a request
+        if str(request.question[0].name) == "a.root-servers.net.":
+            return 200, dns.message.make_response(request).to_wire()
+
+        with cls._lock:
+            if conn not in cls._upconns:
+                cls._upconns.append(conn)
+
+        return 200, dns.message.make_response(request).to_wire()
+
+    @classmethod
+    def closeConnCallback(cls, conn):
+        with cls._lock:
+            if conn in cls._upconns:
+                cls._upconns.remove(conn)
+
+    @classmethod
+    def startResponders(cls):
+        tlsContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        tlsContext.set_alpn_protocols(["h2"])
+        tlsContext.load_cert_chain("server.chain", "server.key")
+
+        print("Launching DOH responder..")
+        cls._DOHResponder = threading.Thread(
+            name="DOH Responder",
+            target=cls.DOHResponder,
+            args=[
+                cls._tlsBackendPort,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                cls.callback,
+                tlsContext,
+                False,
+                cls.closeConnCallback,
+                35.0,
+            ],
+        )
+        cls._DOHResponder.daemon = True
+        cls._DOHResponder.start()
+
+    def testKeepsAndClosesConnection(self):
+        """
+        Outgoing DOH: keeps and closes idle DOH connections properly
+        """
+        name = "anything.powerdns.com."
+        query = dns.message.make_query(name, "A", "IN")
+        expectedResponse = dns.message.make_response(query)
+        rrset = dns.rrset.from_text(name, 60, dns.rdataclass.IN, dns.rdatatype.A, "127.0.0.1")
+        expectedResponse.answer.append(rrset)
+
+        self.sendUDPQuery(query, expectedResponse)
+        time.sleep(3)
+        with self._lock:
+            up = len(self._upconns)
+
+        self.assertEqual(up, 1)
+
+        for _ in range(10):
+            with self._lock:
+                up = len(self._upconns)
+            if up == 0:
+                break
+            time.sleep(1)
+
+        self.assertEqual(up, 0)

--- a/regression-tests.dnsdist/test_TimeoutResponse.py
+++ b/regression-tests.dnsdist/test_TimeoutResponse.py
@@ -40,10 +40,10 @@ def normalResponseCallback(request):
     response.answer.append(rrset)
     return response.to_wire()
 
-def dohTimeoutResponseCallback(request, headers, fromQueue, toQueue):
+def dohTimeoutResponseCallback(request, headers, fromQueue, toQueue, conn):
     return 200, timeoutResponseCallback(request)
 
-def dohNormalResponseCallback(request, headers, fromQueue, toQueue):
+def dohNormalResponseCallback(request, headers, fromQueue, toQueue, conn):
     return 200, normalResponseCallback(request)
 
 class TestTimeoutBackendUdpTcp(DNSDistTest):


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17549 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
