### PR TITLE
dnsdist-2.0: Backport 17575 - Fix build error on 32 bits systems (armhf, ...)

### DIFF
--- a/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
+++ b/pdns/dnsdistdist/dnsdist-configuration-yaml.cc
@@ -1171,7 +1171,7 @@ bool loadConfigurationFromFile(const std::string& fileName, [[maybe_unused]] boo
 
     for (const auto& cache : globalConfig.packet_caches) {
       DNSDistPacketCache::CacheSettings settings{
-        .d_maxEntries = cache.size,
+        .d_maxEntries = static_cast<size_t>(cache.size),
         .d_maxTTL = cache.max_ttl,
         .d_minTTL = cache.min_ttl,
         .d_tempFailureTTL = cache.temporary_failure_ttl,


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17575 to dnsdist-2.0.x

The YAML configuration field `cache.size` is a `uint64_t`, while `DNSDistPacketCache::CacheSettings::d_maxEntries` is a `size_t`. On 32-bit architectures (e.g. `armhf`) `size_t` is 32-bit, so the designated-initializer assignment is a narrowing conversion, which clang rejects with `-Wc++11-narrowing`. Cast explicitly to `size_t`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
