### PR TITLE
dnsdist-2.0: Backport 17559 - Fix naming And, Or and Not selectors, Continue action from YAML

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
@@ -701,6 +701,7 @@ def generate_rust_selector_to_config(output, def_dir):
         if name in ['And', 'Or']:
             enum_buffer += f'''        {suffix}::{name}({var}) => {{
              let mut config: dnsdistsettings::{name}{suffix}Configuration = Default::default();
+             config.name = {var}.name.clone();
              for sub_selector in &{var}.selectors {{
                  config.selectors.push(get_one_selector_from_serde(&sub_selector)?)
              }}
@@ -712,6 +713,7 @@ def generate_rust_selector_to_config(output, def_dir):
         elif name in ['Not']:
             enum_buffer += f'''        {suffix}::{name}({var}) => {{
              let mut config: dnsdistsettings::{name}{suffix}Configuration = Default::default();
+             config.name = {var}.name.clone();
              match get_one_selector_from_serde(&*{var}.selector) {{
                  Ok(sel) => config.selector = sel,
                  Err(e) => return Err(e),

--- a/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/dnsdist-settings-generator.py
@@ -666,6 +666,7 @@ def generate_rust_action_to_config(output, def_dir, response):
             enum_buffer += f'''        {suffix}::{name}(cont) => {{
              let mut config: dnsdistsettings::{name}{suffix}Configuration = Default::default();
              config.action = get_one_action_from_serde(&*cont.action)?;
+             config.name = cont.name.clone();
              return Ok(dnsdistsettings::SharedDNS{suffix} {{
                  action: dnsdistsettings::get{name}{suffix}(&config)?,
              }});

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
@@ -67,6 +67,8 @@ struct NotSelectorConfigurationSerde {
 #[serde(deny_unknown_fields)]
 struct ContinueActionConfigurationSerde {
     #[serde(default, skip_serializing_if = "crate::is_default")]
+    name: String,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     action: Box<Action>,
 }
 

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
@@ -40,6 +40,8 @@ impl Default for dnsdistsettings::SharedDNSSelector {
 #[serde(deny_unknown_fields)]
 struct AndSelectorConfigurationSerde {
     #[serde(default, skip_serializing_if = "crate::is_default")]
+    name: String,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     selectors: Vec<Selector>,
 }
 
@@ -47,12 +49,16 @@ struct AndSelectorConfigurationSerde {
 #[serde(deny_unknown_fields)]
 struct OrSelectorConfigurationSerde {
     #[serde(default, skip_serializing_if = "crate::is_default")]
+    name: String,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     selectors: Vec<Selector>,
 }
 
 #[derive(Default, Deserialize, Serialize, Debug, PartialEq)]
 #[serde(deny_unknown_fields)]
 struct NotSelectorConfigurationSerde {
+    #[serde(default, skip_serializing_if = "crate::is_default")]
+    name: String,
     #[serde(default, skip_serializing_if = "crate::is_default")]
     selector: Box<Selector>,
 }

--- a/regression-tests.dnsdist/test_Yaml.py
+++ b/regression-tests.dnsdist/test_Yaml.py
@@ -55,6 +55,15 @@ selectors:
     tcp: true
 
 query_rules:
+  - name: "test continue action with a name"
+    selector:
+      type: "All"
+    action:
+      name: "continue after allow"
+      type: "Continue"
+      action:
+        name: "simply allow"
+        type: "Allow"
   - name: "route inline-yaml to inline pool"
     selector:
       type: "QNameSet"

--- a/regression-tests.dnsdist/test_Yaml.py
+++ b/regression-tests.dnsdist/test_Yaml.py
@@ -67,6 +67,7 @@ query_rules:
   - name: "my-rule"
     selector:
       type: "And"
+      name: "tcp-and-not-rd-selector"
       selectors:
         - type: "ByName"
           selector_name: "is-tcp"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17559 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
