### PR TITLE
dnsdist-2.0: Backport 17747 - Gracefully handle errors in DynBlock's suffix match policy

### DIFF
--- a/pdns/dnsdistdist/dnsdist-dynblocks.cc
+++ b/pdns/dnsdistdist/dnsdist-dynblocks.cc
@@ -130,26 +130,31 @@ void DynBlockRulesGroup::applySMT(const struct timespec& now, StatNode& statNode
   StatNode::Stat node;
   std::unordered_map<DNSName, SMTBlockParameters> namesToBlock;
   statNodeRoot.visit([this, &namesToBlock](const StatNode* node_, const StatNode::Stat& self, const StatNode::Stat& children) {
-    bool block = false;
-    SMTBlockParameters blockParameters;
-    if (d_smtVisitorFFI) {
-      dnsdist_ffi_stat_node_t tmp(*node_, self, children, blockParameters);
-      block = d_smtVisitorFFI(&tmp);
-    }
-    else {
-      auto ret = d_smtVisitor(*node_, self, children);
-      block = std::get<0>(ret);
-      if (block) {
-        if (boost::optional<std::string> tmp = std::get<1>(ret)) {
-          blockParameters.d_reason = std::move(*tmp);
+    try {
+      bool block = false;
+      SMTBlockParameters blockParameters;
+      if (d_smtVisitorFFI) {
+        dnsdist_ffi_stat_node_t tmp(*node_, self, children, blockParameters);
+        block = d_smtVisitorFFI(&tmp);
+      }
+      else {
+        auto ret = d_smtVisitor(*node_, self, children);
+        block = std::get<0>(ret);
+        if (block) {
+          if (boost::optional<std::string> tmp = std::get<1>(ret)) {
+            blockParameters.d_reason = std::move(*tmp);
+          }
+          if (boost::optional<int> tmp = std::get<2>(ret)) {
+            blockParameters.d_action = static_cast<DNSAction::Action>(*tmp);
+          }
         }
-        if (boost::optional<int> tmp = std::get<2>(ret)) {
-          blockParameters.d_action = static_cast<DNSAction::Action>(*tmp);
+        if (block) {
+          namesToBlock.insert({DNSName(node_->fullname), std::move(blockParameters)});
         }
       }
     }
-    if (block) {
-      namesToBlock.insert({DNSName(node_->fullname), std::move(blockParameters)});
+    catch (const std::exception& exp) {
+      warnlog("Error while executing the Dynamic Block Suffix Match policy: %s", exp.what());
     }
   },
                      node);
@@ -480,7 +485,12 @@ void DynBlockRulesGroup::processResponseRules(counts_t& counts, StatNode& root, 
 
       if (suffixMatchRuleMatches) {
         const bool hit = ringEntry.isACacheHit();
-        root.submit(ringEntry.name, ((ringEntry.dh.rcode == 0 && ringEntry.usec == std::numeric_limits<unsigned int>::max()) ? -1 : ringEntry.dh.rcode), ringEntry.size, hit, std::nullopt);
+        try {
+          root.submit(ringEntry.name, ((ringEntry.dh.rcode == 0 && ringEntry.usec == std::numeric_limits<unsigned int>::max()) ? -1 : ringEntry.dh.rcode), ringEntry.size, hit, std::nullopt);
+        }
+        catch (const std::exception& exp) {
+          warnlog("Error submitting name %s to Dynamic Block Suffix Match Rule policy: %s", ringEntry.name, exp.what());
+        }
       }
     }
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17747 to dnsdist-2.0.x

There is no need to stop the whole processing if we choked on one entry, or even could not properly insert one new rule.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
