### PR TITLE
dnsdist-2.0: Backport 17740 - Improve exception handling when parsing our YAML configuration

### DIFF
--- a/pdns/dnsdistdist/dnsdist-rust-bridge.hh
+++ b/pdns/dnsdistdist/dnsdist-rust-bridge.hh
@@ -20,7 +20,7 @@ namespace rust::behavior
 {
 
 template <typename Try, typename Fail>
-static void trycatch(Try &&func, Fail &&fail) noexcept
+static void trycatch(Try&& func, Fail&& fail) noexcept
 {
   try {
     func();

--- a/pdns/dnsdistdist/dnsdist-rust-bridge.hh
+++ b/pdns/dnsdistdist/dnsdist-rust-bridge.hh
@@ -9,6 +9,32 @@ class DNSRule;
 
 #include "rust/cxx.h"
 
+/* the following replaces the default handling of exceptions
+   thrown from C++ code called from Rust. It is necessary because
+   some of our legacy code uses the special PDNSException that does
+   not inherit from std::exception
+*/
+#include "pdnsexception.hh"
+
+namespace rust::behavior
+{
+
+template <typename Try, typename Fail>
+static void trycatch(Try &&func, Fail &&fail) noexcept
+{
+  try {
+    func();
+  }
+  catch (const std::exception& exp) {
+    fail(exp.what());
+  }
+  catch (const PDNSException& exp) {
+    fail(exp.reason);
+  }
+}
+
+}
+
 namespace dnsdist::rust::settings
 {
 

--- a/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/meson.build
@@ -1,6 +1,10 @@
 sources = files(
   'dnsdist-settings-generator.py',
+  '../dnsdist-actions-definitions.yml',
+  '../dnsdist-selectors-definitions.yml',
   '../dnsdist-settings-definitions.yml',
+  '../dnsdist-response-actions-definitions.yml',
+  '../dnsdist-rust-bridge.hh',
   'dnsdist-configuration-yaml-items-pre-in.cc',
   'rust-pre-in.rs',
   'rust-middle-in.rs',

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-middle-in.rs
@@ -12,11 +12,11 @@
         type DNSSelector;
         type DNSActionWrapper;
         type DNSResponseActionWrapper;
-        fn registerProtobufLogger(config: &ProtobufLoggerConfiguration);
-        fn registerDnstapLogger(config: &DnstapLoggerConfiguration);
-        fn registerKVSObjects(config: &KeyValueStoresConfiguration);
-        fn registerNMGObjects(nmgs: &Vec<NetmaskGroupConfiguration>);
-        fn registerTimedIPSetObjects(sets: &Vec<TimedIpSetConfiguration>);
+        fn registerProtobufLogger(config: &ProtobufLoggerConfiguration) -> Result<()>;
+        fn registerDnstapLogger(config: &DnstapLoggerConfiguration) -> Result<()>;
+        fn registerKVSObjects(config: &KeyValueStoresConfiguration) -> Result<()>;
+        fn registerNMGObjects(nmgs: &Vec<NetmaskGroupConfiguration>) -> Result<()>;
+        fn registerTimedIPSetObjects(sets: &Vec<TimedIpSetConfiguration>) -> Result<()>;
     }
 }
 

--- a/pdns/dnsdistdist/dnsdist-rust-lib/rust-post-in.rs
+++ b/pdns/dnsdistdist/dnsdist-rust-lib/rust-post-in.rs
@@ -47,13 +47,14 @@ fn get_response_rules_from_serde(
 
 fn register_remote_loggers(
   config: &dnsdistsettings::RemoteLoggingConfiguration,
-) {
+) -> Result<(), cxx::Exception> {
   for logger in &config.protobuf_loggers {
-    dnsdistsettings::registerProtobufLogger(&logger);
+    dnsdistsettings::registerProtobufLogger(&logger)?;
   }
   for logger in &config.dnstap_loggers {
-    dnsdistsettings::registerDnstapLogger(&logger);
+    dnsdistsettings::registerDnstapLogger(&logger)?;
   }
+  Ok(())
 }
 
 fn get_global_configuration_from_serde(
@@ -88,13 +89,13 @@ fn get_global_configuration_from_serde(
     config.webserver = serde.webserver;
     config.xsk = serde.xsk;
     // this needs to be done before the rules so that they can refer to the loggers
-    register_remote_loggers(&config.remote_logging);
+    register_remote_loggers(&config.remote_logging)?;
     // this needs to be done before the rules so that they can refer to the KVS objects
-    dnsdistsettings::registerKVSObjects(&config.key_value_stores);
+    dnsdistsettings::registerKVSObjects(&config.key_value_stores)?;
     // this needs to be done before the rules so that they can refer to the NMG objects
-    dnsdistsettings::registerNMGObjects(&config.netmask_groups);
+    dnsdistsettings::registerNMGObjects(&config.netmask_groups)?;
     // this needs to be done before the rules so that they can refer to the TimeIPSet objects
-    dnsdistsettings::registerTimedIPSetObjects(&config.timed_ip_sets);
+    dnsdistsettings::registerTimedIPSetObjects(&config.timed_ip_sets)?;
     // this needs to be done BEFORE the rules so that they can refer to the selectors
     // by name
     config.selectors = get_selectors_from_serde(&serde.selectors)?;

--- a/pdns/pdnsexception.hh
+++ b/pdns/pdnsexception.hh
@@ -20,25 +20,23 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #pragma once
-#include<string>
+#include <string>
 #include <utility>
 
-#include "namespaces.hh"
-
-//! Generic Exception thrown 
+//! Generic Exception thrown
 class PDNSException
 {
 public:
   PDNSException() : reason("Unspecified") {};
-  PDNSException(string r) :
+  PDNSException(std::string r) :
     reason(std::move(r)) {};
 
-  string reason; //! Print this to tell the user what went wrong
+  std::string reason; //! Print this to tell the user what went wrong
 };
 
 class TimeoutException : public PDNSException
 {
 public:
   TimeoutException() : PDNSException() {}
-  TimeoutException(const string& r) : PDNSException(r) {}
+  TimeoutException(const std::string& r) : PDNSException(r) {}
 };

--- a/regression-tests.dnsdist/test_Yaml.py
+++ b/regression-tests.dnsdist/test_Yaml.py
@@ -544,6 +544,60 @@ pools:
         if cls._dnsdist:
             cls.killProcess(cls._dnsdist)
 
+
+class TestYamlInvalidComboAddress(DNSDistTest):
+    _yaml_config_template = """---
+logging:
+  structured:
+    enabled: false
+
+binds:
+  - listen_address: "127.0.0.1:%d"
+    protocol: Do53
+
+backends:
+  - address: "127.0.0.1:%d"
+    protocol: Do53
+
+query_rules:
+  - name: "A to (invalid) Tee Action"
+    selector:
+      type: "QType"
+      qtype: "A"
+    action:
+      type: "Tee"
+      rca: "a:"
+      lca: "127.0.0.1"
+"""
+    _yaml_config_params = ["_dnsDistPort", "_testServerPort"]
+    _config_params = []
+    _enableStructuredLoggingOnCL = False
+
+    def testFailToStart(self):
+        """
+        YAML: Fails to start with an invalid ComboAddress raising a PDNSException from C++ via the Rust library
+        """
+        pass
+
+    @classmethod
+    def setUpClass(cls):
+        failed = False
+        try:
+            cls.startDNSDist()
+        except AssertionError as err:
+            failed = True
+            expected = "dnsdist --check-config failed (1): b\"Error while parsing YAML file configs/dnsdist_TestYamlInvalidComboAddress.yml: Unable to convert presentation address 'a:'\\n\""
+            if str(err) != expected:
+                raise AssertionError("DNSdist should not start with an invalid ComboAddress in listen_address: %s" % (err))
+        if not failed:
+            raise AssertionError("DNSdist should not start with an invalid ComboAddress in listen_address")
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._dnsdist:
+            cls.killProcess(cls._dnsdist)
+
+
 class TestYamlLuaCodeUsingObjects(DNSDistTest):
 
     _yaml_config_template = """---

--- a/regression-tests.dnsdist/test_Yaml.py
+++ b/regression-tests.dnsdist/test_Yaml.py
@@ -588,7 +588,9 @@ query_rules:
             failed = True
             expected = "dnsdist --check-config failed (1): b\"Error while parsing YAML file configs/dnsdist_TestYamlInvalidComboAddress.yml: Unable to convert presentation address 'a:'\\n\""
             if str(err) != expected:
-                raise AssertionError("DNSdist should not start with an invalid ComboAddress in listen_address: %s" % (err))
+                raise AssertionError(
+                    "DNSdist should not start with an invalid ComboAddress in listen_address: %s" % (err)
+                )
         if not failed:
             raise AssertionError("DNSdist should not start with an invalid ComboAddress in listen_address")
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17740 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
