### PR TITLE
dnsdist-2.0: Backport 17923 - Use the proper ALPN on auto-upgraded DoT/DoH backends

### DIFF
--- a/pdns/dnsdistdist/dnsdist-discovery.cc
+++ b/pdns/dnsdistdist/dnsdist-discovery.cc
@@ -432,6 +432,7 @@ bool ServiceDiscovery::tryToUpgradeBackend(const UpgradeableBackend& backend)
     config.d_tlsSubjectName = backend.d_ds->d_config.remote.toString();
     config.d_tlsSubjectIsAddr = true;
   }
+  config.d_tlsParams.d_alpn = discoveredConfig.d_protocol == dnsdist::Protocol::DoT ? TLSFrontend::ALPN::DoT : TLSFrontend::ALPN::DoH;
 
   if (!backend.d_poolAfterUpgrade.empty()) {
     config.pools.clear();

--- a/regression-tests.dnsdist/dnsdisttests.py
+++ b/regression-tests.dnsdist/dnsdisttests.py
@@ -436,7 +436,20 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
       conn.close()
 
     @classmethod
-    def TCPResponder(cls, port, fromQueue, toQueue, trailingDataResponse=False, multipleResponses=False, callback=None, tlsContext=None, multipleConnections=False, listeningAddr='127.0.0.1', partialWrite=False):
+    def TCPResponder(
+        cls,
+        port,
+        fromQueue,
+        toQueue,
+        trailingDataResponse=False,
+        multipleResponses=False,
+        callback=None,
+        tlsContext=None,
+        multipleConnections=False,
+        listeningAddr="127.0.0.1",
+        partialWrite=False,
+        expectedALPN=None,
+    ):
         cls._backgroundThreads[threading.get_native_id()] = True
         # trailingDataResponse=True means "ignore trailing data".
         # Other values are either False (meaning "raise an exception")
@@ -472,6 +485,12 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                 continue
 
             conn.settimeout(5.0)
+            if tlsContext and expectedALPN:
+                alpn = conn.selected_alpn_protocol()
+                if alpn != expectedALPN:
+                    print(f"Wrong ALPN, got {alpn}, expected {expectedALPN}")
+                    continue
+
             if multipleConnections:
               thread = threading.Thread(name='TCP Connection Handler',
                                         target=cls.handleTCPConnection,
@@ -600,7 +619,20 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
             conn.close()
 
     @classmethod
-    def DOHResponder(cls, port, fromQueue, toQueue, trailingDataResponse=False, multipleResponses=False, callback=None, tlsContext=None, useProxyProtocol=False, closeConnCallback=False, connTimeout=5.0):
+    def DOHResponder(
+        cls,
+        port,
+        fromQueue,
+        toQueue,
+        trailingDataResponse=False,
+        multipleResponses=False,
+        callback=None,
+        tlsContext=None,
+        useProxyProtocol=False,
+        closeConnCallback=False,
+        connTimeout=5.0,
+        expectedALPN=None,
+    ):
         cls._backgroundThreads[threading.get_native_id()] = True
         # trailingDataResponse=True means "ignore trailing data".
         # Other values are either False (meaning "raise an exception")
@@ -637,10 +669,30 @@ class DNSDistTest(AssertEqualDNSMessageMixin, unittest.TestCase):
                 else:
                     continue
 
-            conn.settimeout(5.0)
-            thread = threading.Thread(name='DoH Connection Handler',
-                                      target=cls.handleDoHConnection,
-                                      args=[config, conn, fromQueue, toQueue, trailingDataResponse, multipleResponses, callback, tlsContext, useProxyProtocol, closeConnCallback])
+            conn.settimeout(connTimeout)
+
+            if tlsContext and expectedALPN:
+                alpn = conn.selected_alpn_protocol()
+                if alpn != expectedALPN:
+                    print(f"Wrong ALPN, got {alpn}, expected {expectedALPN}")
+                    continue
+
+            thread = threading.Thread(
+                name="DoH Connection Handler",
+                target=cls.handleDoHConnection,
+                args=[
+                    config,
+                    conn,
+                    fromQueue,
+                    toQueue,
+                    trailingDataResponse,
+                    multipleResponses,
+                    callback,
+                    tlsContext,
+                    useProxyProtocol,
+                    closeConnCallback,
+                ],
+            )
             thread.daemon = True
             thread.start()
 

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -260,10 +260,10 @@ class TestBackendDiscovery(DNSDistTest):
     def startResponders(cls):
         dotContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         dotContext.load_cert_chain("server.chain", "server.key")
-        dotContext.set_alpn_protocols(['dot'])
+        dotContext.set_alpn_protocols(["dot"])
         dohContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         dohContext.load_cert_chain("server.chain", "server.key")
-        dohContext.set_alpn_protocols(['h2'])
+        dohContext.set_alpn_protocols(["h2"])
 
         TCPNoSVCResponder = threading.Thread(name='TCP no SVC Responder', target=cls.TCPResponder, args=[cls._noSVCBackendPort, cls._toResponderQueue, cls._fromResponderQueue, True, False, cls.NoSVCCallback])
         TCPNoSVCResponder.daemon = True
@@ -281,7 +281,19 @@ class TestBackendDiscovery(DNSDistTest):
         UpgradedDoTResponder = threading.Thread(
             name="DoT upgraded Responder",
             target=cls.TCPResponder,
-            args=[10652, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dotContext, False, "127.0.0.1", False, "dot"],
+            args=[
+                10652,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                None,
+                dotContext,
+                False,
+                "127.0.0.1",
+                False,
+                "dot",
+            ],
         )
         UpgradedDoTResponder.daemon = True
         UpgradedDoTResponder.start()
@@ -293,7 +305,19 @@ class TestBackendDiscovery(DNSDistTest):
         UpgradedDOHResponder = threading.Thread(
             name="DOH Responder",
             target=cls.DOHResponder,
-            args=[10653, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dohContext, False, False, 5.0, "h2"],
+            args=[
+                10653,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                None,
+                dohContext,
+                False,
+                False,
+                5.0,
+                "h2",
+            ],
         )
         UpgradedDOHResponder.daemon = True
         UpgradedDOHResponder.start()
@@ -329,7 +353,19 @@ class TestBackendDiscovery(DNSDistTest):
         UpgradedDoTResponder = threading.Thread(
             name="DoT upgraded different addr 2 Responder",
             target=cls.TCPResponder,
-            args=[10655, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dotContext, False, "127.0.0.1", False, "dot"],
+            args=[
+                10655,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                None,
+                dotContext,
+                False,
+                "127.0.0.1",
+                False,
+                "dot",
+            ],
         )
         UpgradedDoTResponder.daemon = True
         UpgradedDoTResponder.start()

--- a/regression-tests.dnsdist/test_BackendDiscovery.py
+++ b/regression-tests.dnsdist/test_BackendDiscovery.py
@@ -258,8 +258,12 @@ class TestBackendDiscovery(DNSDistTest):
 
     @classmethod
     def startResponders(cls):
-        tlsContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        tlsContext.load_cert_chain('server.chain', 'server.key')
+        dotContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        dotContext.load_cert_chain("server.chain", "server.key")
+        dotContext.set_alpn_protocols(['dot'])
+        dohContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        dohContext.load_cert_chain("server.chain", "server.key")
+        dohContext.set_alpn_protocols(['h2'])
 
         TCPNoSVCResponder = threading.Thread(name='TCP no SVC Responder', target=cls.TCPResponder, args=[cls._noSVCBackendPort, cls._toResponderQueue, cls._fromResponderQueue, True, False, cls.NoSVCCallback])
         TCPNoSVCResponder.daemon = True
@@ -274,7 +278,11 @@ class TestBackendDiscovery(DNSDistTest):
         TCPUpgradeToDoTResponder.daemon = True
         TCPUpgradeToDoTResponder.start()
         # and the corresponding DoT responder
-        UpgradedDoTResponder = threading.Thread(name='DoT upgraded Responder', target=cls.TCPResponder, args=[10652, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, tlsContext])
+        UpgradedDoTResponder = threading.Thread(
+            name="DoT upgraded Responder",
+            target=cls.TCPResponder,
+            args=[10652, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dotContext, False, "127.0.0.1", False, "dot"],
+        )
         UpgradedDoTResponder.daemon = True
         UpgradedDoTResponder.start()
 
@@ -282,7 +290,11 @@ class TestBackendDiscovery(DNSDistTest):
         TCPUpgradeToDoHResponder.daemon = True
         TCPUpgradeToDoHResponder.start()
         # and the corresponding DoH responder
-        UpgradedDOHResponder = threading.Thread(name='DOH Responder', target=cls.DOHResponder, args=[10653, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, tlsContext])
+        UpgradedDOHResponder = threading.Thread(
+            name="DOH Responder",
+            target=cls.DOHResponder,
+            args=[10653, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dohContext, False, False, 5.0, "h2"],
+        )
         UpgradedDOHResponder.daemon = True
         UpgradedDOHResponder.start()
 
@@ -290,7 +302,23 @@ class TestBackendDiscovery(DNSDistTest):
         TCPUpgradeToDoTDifferentAddrResponder.daemon = True
         TCPUpgradeToDoTDifferentAddrResponder.start()
         # and the corresponding DoT responder
-        UpgradedDoTResponder = threading.Thread(name='DoT upgraded different addr 1 Responder', target=cls.TCPResponder, args=[10654, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, tlsContext, False, '127.0.0.2'])
+        UpgradedDoTResponder = threading.Thread(
+            name="DoT upgraded different addr 1 Responder",
+            target=cls.TCPResponder,
+            args=[
+                10654,
+                cls._toResponderQueue,
+                cls._fromResponderQueue,
+                False,
+                False,
+                None,
+                dotContext,
+                False,
+                "127.0.0.2",
+                False,
+                "dot",
+            ],
+        )
         UpgradedDoTResponder.daemon = True
         UpgradedDoTResponder.start()
 
@@ -298,7 +326,11 @@ class TestBackendDiscovery(DNSDistTest):
         TCPUpgradeToDoTDifferentAddrResponder.daemon = True
         TCPUpgradeToDoTDifferentAddrResponder.start()
         # and the corresponding DoT responder
-        UpgradedDoTResponder = threading.Thread(name='DoT upgraded different addr 2 Responder', target=cls.TCPResponder, args=[10655, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, tlsContext, False])
+        UpgradedDoTResponder = threading.Thread(
+            name="DoT upgraded different addr 2 Responder",
+            target=cls.TCPResponder,
+            args=[10655, cls._toResponderQueue, cls._fromResponderQueue, False, False, None, dotContext, False, "127.0.0.1", False, "dot"],
+        )
         UpgradedDoTResponder.daemon = True
         UpgradedDoTResponder.start()
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17923 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
