### PR TITLE
axfr: ALIAS record TTL fix

### DIFF
--- a/pdns/tcpreceiver.cc
+++ b/pdns/tcpreceiver.cc
@@ -902,6 +902,7 @@ int TCPNameserver::doAXFR(const ZoneName &targetZone, std::unique_ptr<DNSPacket>
         if(!::arg().mustDo("direct-dnskey")) {
           continue;
         } else {
+          // Override TTL
           zrr.dr.d_ttl = sd.minimum;
         }
       }
@@ -933,6 +934,7 @@ int TCPNameserver::doAXFR(const ZoneName &targetZone, std::unique_ptr<DNSPacket>
         }
         for (auto& ip: ips) {
           zrr.dr.d_type = ip.dr.d_type;
+          zrr.dr.d_ttl = ip.dr.d_ttl;
           zrr.dr.setContent(ip.dr.getContent());
           zrrs.push_back(zrr);
         }


### PR DESCRIPTION
### Short description
When AXFR'ing an expanded alias record, we would send it with the TTL of the previous record, instead of its correct value.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
