### PR TITLE
auth: reject multiple TKEY records

### DIFF
--- a/pdns/dnspacket.cc
+++ b/pdns/dnspacket.cc
@@ -548,13 +548,12 @@ bool DNSPacket::getTKEYRecord(TKEYRecordContent *tr, DNSName *keyname) const
     bool gotit=false;
 
     for(const auto & answer : mdp.d_answers) {
-      if (gotit) {
-        SLOG(g_log<<Logger::Error<<"More than one TKEY record found in query"<<endl,
-             d_slog->info(Logr::Error, "More than one TKEY record found in query"));
-        return false;
-      }
-
       if(answer.d_type == QType::TKEY) {
+        if (gotit) {
+          SLOG(g_log<<Logger::Error<<"More than one TKEY record found in query"<<endl,
+               d_slog->info(Logr::Error, "More than one TKEY record found in query"));
+          return false;
+        }
         // cast can fail, f.e. if d_content is an UnknownRecordContent.
         auto content = getRR<TKEYRecordContent>(answer);
         if (!content) {


### PR DESCRIPTION
### Short description
This correctly reject multiple TKEY records in DNSPacket::getTKEYRecord(). Previously,
any other non-TKEY record following the TKEY would error with the incorrect "more than one TKEY record found" diagnostic.

This trivial PR fixes that logic.

Reported by Qifan Zhang.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
