### PR TITLE
auth: improve robustness when facing unmanageable keys

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -578,6 +578,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const ZoneName& zone, bool useCache
 
   keyset_t retkeyset;
   vector<DNSBackend::KeyData> dbkeyset;
+  size_t unusableKeys{0};
 
   d_keymetadb->getDomainKeys(zone, dbkeyset);
 
@@ -586,43 +587,57 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const ZoneName& zone, bool useCache
   vector<uint8_t> algoHasSeparateKSK;
   for(const DNSBackend::KeyData &keydata : dbkeyset) {
     DNSKEYRecordContent dkrc;
-    auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(d_slog, dkrc, keydata.content));
     DNSSECPrivateKey dpk;
-    dpk.setKey(key, dkrc.d_flags);
+    try {
+      auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(d_slog, dkrc, keydata.content));
+      dpk.setKey(key, dkrc.d_flags);
 
-    if(keydata.active) {
-      if((keydata.flags & DNSKEYFlag::SEP) != 0) {
-        algoSEP.insert(dkrc.d_algorithm);
-      } else {
-        algoNoSEP.insert(dkrc.d_algorithm);
+      if(keydata.active) {
+        if((keydata.flags & DNSKEYFlag::SEP) != 0) {
+          algoSEP.insert(dkrc.d_algorithm);
+        } else {
+          algoNoSEP.insert(dkrc.d_algorithm);
+        }
       }
+    }
+    catch (const std::exception&) {
+      ++unusableKeys;
     }
   }
   set_intersection(algoSEP.begin(), algoSEP.end(), algoNoSEP.begin(), algoNoSEP.end(), std::back_inserter(algoHasSeparateKSK));
-  retkeyset.reserve(dbkeyset.size());
+  retkeyset.reserve(dbkeyset.size() - unusableKeys);
 
   for(DNSBackend::KeyData& kd : dbkeyset)
   {
     DNSKEYRecordContent dkrc;
-    auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(d_slog, dkrc, kd.content));
     DNSSECPrivateKey dpk;
-    dpk.setKey(key, kd.flags, dkrc.d_algorithm);
+    try {
+      auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(d_slog, dkrc, kd.content));
+      dpk.setKey(key, kd.flags, dkrc.d_algorithm);
 
-    KeyMetaData kmd;
+      KeyMetaData kmd;
 
-    kmd.active = kd.active;
-    kmd.published = kd.published;
-    kmd.hasSEPBit = (kd.flags & DNSKEYFlag::SEP) != 0;
-    kmd.id = kd.id;
+      kmd.active = kd.active;
+      kmd.published = kd.published;
+      kmd.hasSEPBit = (kd.flags & DNSKEYFlag::SEP) != 0;
+      kmd.id = kd.id;
 
-    if (find(algoHasSeparateKSK.begin(), algoHasSeparateKSK.end(), dpk.getAlgorithm()) == algoHasSeparateKSK.end())
-      kmd.keyType = CSK;
-    else if(kmd.hasSEPBit)
-      kmd.keyType = KSK;
-    else
-      kmd.keyType = ZSK;
+      if (find(algoHasSeparateKSK.begin(), algoHasSeparateKSK.end(), dpk.getAlgorithm()) == algoHasSeparateKSK.end()) {
+        kmd.keyType = CSK;
+      }
+      else if(kmd.hasSEPBit) {
+        kmd.keyType = KSK;
+      }
+      else {
+        kmd.keyType = ZSK;
+      }
 
-    retkeyset.emplace_back(dpk, kmd);
+      retkeyset.emplace_back(dpk, kmd);
+    }
+    catch (const std::exception&) {
+      // Nothing. We ignore keys we can't construct here; checkKeys() will
+      // report them.
+    }
   }
   sort(retkeyset.begin(), retkeyset.end(), keyCompareByKindAndID);
 
@@ -647,8 +662,18 @@ bool DNSSECKeeper::checkKeys(const ZoneName& zone, std::optional<std::reference_
 
   for(const DNSBackend::KeyData &keydata : dbkeyset) {
     DNSKEYRecordContent dkrc;
-    auto dke = DNSCryptoKeyEngine::makeFromISCString(d_slog, dkrc, keydata.content);
-    retval = dke->checkKey(errorMessages) && retval;
+    try {
+      auto dke = DNSCryptoKeyEngine::makeFromISCString(d_slog, dkrc, keydata.content);
+      retval = dke->checkKey(errorMessages) && retval;
+    }
+    catch (const std::exception& err) {
+      if (errorMessages.has_value()) {
+        const std::string status = keydata.active ? "active" : "inactive";
+        std::string error = "Unable to process " + status + " key id #" + std::to_string(keydata.id) + ": " + err.what();
+        errorMessages->get().emplace_back(error);
+      }
+      retval = false;
+    }
   }
 
   return retval;

--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -654,6 +654,30 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const ZoneName& zone, bool useCache
   return retkeyset;
 }
 
+unsigned int DNSSECKeeper::getUnusableKeyCount(const ZoneName& zone)
+{
+  unsigned int unusableKeys{0};
+
+  if(((++s_ops) % 100000) == 0) {
+    cleanup();
+  }
+
+  vector<DNSBackend::KeyData> dbkeyset;
+  d_keymetadb->getDomainKeys(zone, dbkeyset);
+
+  for(const DNSBackend::KeyData &keydata : dbkeyset) {
+    DNSKEYRecordContent dkrc;
+    try {
+      auto key = shared_ptr<DNSCryptoKeyEngine>(DNSCryptoKeyEngine::makeFromISCString(d_slog, dkrc, keydata.content));
+    }
+    catch (const std::exception&) {
+      ++unusableKeys;
+    }
+  }
+
+  return unusableKeys;
+}
+
 bool DNSSECKeeper::checkKeys(const ZoneName& zone, std::optional<std::reference_wrapper<std::vector<std::string>>> errorMessages)
 {
   vector<DNSBackend::KeyData> dbkeyset;

--- a/pdns/dnsseckeeper.hh
+++ b/pdns/dnsseckeeper.hh
@@ -87,6 +87,7 @@ public:
   bool isSecuredZone(const ZoneName& zone, bool useCache=true);
   keyset_t getEntryPoints(const ZoneName& zname);
   keyset_t getKeys(const ZoneName& zone, bool useCache = true);
+  unsigned int getUnusableKeyCount(const ZoneName& zone);
   DNSSECPrivateKey getKeyById(const ZoneName& zname, unsigned int keyId);
   bool addKey(const ZoneName& zname, bool setSEPBit, int algorithm, int64_t& keyId, int bits=0, bool active=true, bool published=true);
   bool addKey(const ZoneName& zname, const DNSSECPrivateKey& dpk, int64_t& keyId, bool active=true, bool published=true);

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3360,121 +3360,14 @@ static int setZoneKind(const ZoneName& zone, const DomainInfo::DomainKind kind)
   return EXIT_SUCCESS;
 }
 
-static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool exportDS = false) // NOLINT(readability-function-cognitive-complexity)
+static void showZoneKeys(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool exportDS, DomainInfo& di) //NOLINT(readability-identifier-length)
 {
-  UtilBackend B("default"); //NOLINT(readability-identifier-length)
-  DomainInfo di;
-
-  if (!B.getDomainInfo(zone, di)){
-    cerr << "No such zone in the database" << endl;
-    return false;
-  }
-
-  if (!di.account.empty()) {
-      cout<<"This zone is owned by "<<di.account<<endl;
-  }
-  if (!exportDS) {
-    cout << "This is a " << DomainInfo::getKindString(di.kind) << " zone";
-    if (g_verbose) {
-      cout << " (" << di.id << ")";
-    }
-    cout << endl;
-    auto variant = di.zone.getVariant();
-    if (!variant.empty()) {
-      cout<<"Variant: " << variant << endl;
-    }
-    if (di.isPrimaryType()) {
-      cout<<"Last SOA serial number we notified: "<<di.notified_serial<<" ";
-      SOAData sd;
-      if(B.getSOAUncached(zone, sd)) {
-        if(sd.serial == di.notified_serial)
-          cout<< "== ";
-        else
-          cout << "!= ";
-        cout<<sd.serial<<" (serial in the database)"<<endl;
-      }
-    }
-    else if (di.isSecondaryType()) {
-      cout << "Primar" << addS(di.primaries, "y", "ies") << ": ";
-      for (const auto& m : di.primaries)
-        cout<<m.toStringWithPort()<<" ";
-      cout<<endl;
-      struct tm tm;
-      localtime_r(&di.last_check, &tm);
-      char buf[80];
-      if(di.last_check != 0) {
-        strftime(buf, sizeof(buf)-1, "%a %F %H:%M:%S", &tm);
-      }
-      else {
-        strncpy(buf, "Never", sizeof(buf)-1);
-      }
-      buf[sizeof(buf)-1] = '\0';
-      cout << "Last time we got update from primary: " << buf << endl;
-      SOAData sd;
-      if(B.getSOAUncached(zone, sd)) {
-        cout<<"SOA serial in database: "<<sd.serial<<endl;
-        cout<<"Refresh interval: "<<sd.refresh<<" seconds"<<endl;
-      }
-      else
-        cout<<"No SOA serial found in database"<<endl;
-    }
-  }
-
-  if(!dnsseckeeper.isSecuredZone(zone)) {
-    auto &outstream = (exportDS ? cerr : cout);
-    outstream << "Zone is not actively secured" << endl;
-    if (exportDS) {
-      // it does not make sense to proceed here, and it might be useful
-      // for scripts to know that something is odd here
-      return false;
-    }
-  }
-
-  g_soa_edit_spread = ::arg().asBoundedNum<uint32_t>("soa-edit-spread", 0, 604800);
-  if (g_verbose && g_soa_edit_spread > 0) {
-    auto [inception, _] = getStartOfWeek();
-    auto delay = weekSpreadDelay(zone);
-    time_t bumpTt = inception + delay;
-    std::tm bumpTm{};
-    localtime_r(&bumpTt, &bumpTm);
-    cout << "soa-edit spread delay: " << delay << " (change time " << std::put_time(&bumpTm, "%c %Z") << ")" << endl;
-  }
+  DNSSECKeeper::keyset_t keyset;
+  keyset=dnsseckeeper.getKeys(zone);
 
   NSEC3PARAMRecordContent ns3pr;
   bool narrow = false;
   bool haveNSEC3=dnsseckeeper.getNSEC3PARAM(zone, &ns3pr, &narrow);
-
-  DNSSECKeeper::keyset_t keyset=dnsseckeeper.getKeys(zone);
-
-  if (!exportDS) {
-    std::vector<std::string> meta;
-
-    if (B.getDomainMetadata(zone, "TSIG-ALLOW-AXFR", meta) && !meta.empty()) {
-      cout << "Zone has following allowed TSIG key(s): " << boost::join(meta, ",") << endl;
-    }
-
-    meta.clear();
-    if (B.getDomainMetadata(zone, "AXFR-MASTER-TSIG", meta) && !meta.empty()) {
-      // Although AXFR-MASTER-TSIG may contain a list of keys, the current
-      // state of DNSSECKeeper::getTSIGForAccess() causes only the first one
-      // to be ever used, so only list the first item here.
-      cout << "Zone uses following TSIG key: " << meta.front() << endl;
-    }
-
-    std::map<std::string, std::vector<std::string> > metamap;
-    if(B.getAllDomainMetadata(zone, metamap)) {
-      cout<<"Metadata items: ";
-      if(metamap.empty())
-        cout<<"None";
-      cout<<endl;
-
-      for(const auto& m : metamap) {
-        for(const auto& i : m.second)
-          cout << '\t' << m.first<<'\t' << i <<endl;
-      }
-    }
-
-  }
 
   if (dnsseckeeper.isPresigned(zone)) {
     if (!exportDS) {
@@ -3492,7 +3385,7 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
 
     if(keys.empty()) {
       cerr << "No keys for zone '"<<zone<<"'."<<endl;
-      return true;
+      return;
     }
 
     if (!exportDS) {
@@ -3598,6 +3491,119 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
       }
     }
   }
+}
+
+static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool exportDS = false)
+{
+  UtilBackend B("default"); //NOLINT(readability-identifier-length)
+  DomainInfo di; //NOLINT(readability-identifier-length)
+
+  if (!B.getDomainInfo(zone, di)){
+    cerr << "No such zone in the database" << endl;
+    return false;
+  }
+
+  if (!di.account.empty()) {
+      cout<<"This zone is owned by "<<di.account<<endl;
+  }
+  if (!exportDS) {
+    cout << "This is a " << DomainInfo::getKindString(di.kind) << " zone";
+    if (g_verbose) {
+      cout << " (" << di.id << ")";
+    }
+    cout << endl;
+    auto variant = di.zone.getVariant();
+    if (!variant.empty()) {
+      cout<<"Variant: " << variant << endl;
+    }
+    if (di.isPrimaryType()) {
+      cout<<"Last SOA serial number we notified: "<<di.notified_serial<<" ";
+      SOAData sd;
+      if(B.getSOAUncached(zone, sd)) {
+        if(sd.serial == di.notified_serial)
+          cout<< "== ";
+        else
+          cout << "!= ";
+        cout<<sd.serial<<" (serial in the database)"<<endl;
+      }
+    }
+    else if (di.isSecondaryType()) {
+      cout << "Primar" << addS(di.primaries, "y", "ies") << ": ";
+      for (const auto& m : di.primaries)
+        cout<<m.toStringWithPort()<<" ";
+      cout<<endl;
+      struct tm tm;
+      localtime_r(&di.last_check, &tm);
+      char buf[80];
+      if(di.last_check != 0) {
+        strftime(buf, sizeof(buf)-1, "%a %F %H:%M:%S", &tm);
+      }
+      else {
+        strncpy(buf, "Never", sizeof(buf)-1);
+      }
+      buf[sizeof(buf)-1] = '\0';
+      cout << "Last time we got update from primary: " << buf << endl;
+      SOAData sd;
+      if(B.getSOAUncached(zone, sd)) {
+        cout<<"SOA serial in database: "<<sd.serial<<endl;
+        cout<<"Refresh interval: "<<sd.refresh<<" seconds"<<endl;
+      }
+      else
+        cout<<"No SOA serial found in database"<<endl;
+    }
+  }
+
+  if(!dnsseckeeper.isSecuredZone(zone)) {
+    auto &outstream = (exportDS ? cerr : cout);
+    outstream << "Zone is not actively secured" << endl;
+    if (exportDS) {
+      // it does not make sense to proceed here, and it might be useful
+      // for scripts to know that something is odd here
+      return false;
+    }
+  }
+
+  g_soa_edit_spread = ::arg().asBoundedNum<uint32_t>("soa-edit-spread", 0, 604800);
+  if (g_verbose && g_soa_edit_spread > 0) {
+    auto [inception, _] = getStartOfWeek();
+    auto delay = weekSpreadDelay(zone);
+    time_t bumpTt = inception + delay;
+    std::tm bumpTm{};
+    localtime_r(&bumpTt, &bumpTm);
+    cout << "soa-edit spread delay: " << delay << " (change time " << std::put_time(&bumpTm, "%c %Z") << ")" << endl;
+  }
+
+  if (!exportDS) {
+    std::vector<std::string> meta;
+
+    if (B.getDomainMetadata(zone, "TSIG-ALLOW-AXFR", meta) && !meta.empty()) {
+      cout << "Zone has following allowed TSIG key(s): " << boost::join(meta, ",") << endl;
+    }
+
+    meta.clear();
+    if (B.getDomainMetadata(zone, "AXFR-MASTER-TSIG", meta) && !meta.empty()) {
+      // Although AXFR-MASTER-TSIG may contain a list of keys, the current
+      // state of DNSSECKeeper::getTSIGForAccess() causes only the first one
+      // to be ever used, so only list the first item here.
+      cout << "Zone uses following TSIG key: " << meta.front() << endl;
+    }
+
+    std::map<std::string, std::vector<std::string> > metamap;
+    if(B.getAllDomainMetadata(zone, metamap)) {
+      cout<<"Metadata items: ";
+      if(metamap.empty())
+        cout<<"None";
+      cout<<endl;
+
+      for(const auto& m : metamap) {
+        for(const auto& i : m.second)
+          cout << '\t' << m.first<<'\t' << i <<endl;
+      }
+    }
+
+  }
+
+  showZoneKeys(dnsseckeeper, zone, exportDS, di);
   if (!di.options.empty()) {
     cout << "Options:" << endl;
     cout << di.options << endl;

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -1038,11 +1038,17 @@ static int checkZone(DNSSECKeeper &dk, UeberBackend &B, const ZoneName& zone, co
 
     for (DNSBackend::KeyData& kd : dbkeyset) {
       DNSKEYRecordContent dkrc;
-      DNSCryptoKeyEngine::makeFromISCString(nullptr /* no structured logging */, dkrc, kd.content);
+      try {
+        DNSCryptoKeyEngine::makeFromISCString(nullptr /* no structured logging */, dkrc, kd.content);
 
-      if(dkrc.d_algorithm == DNSSECKeeper::RSASHA1) {
-        cout<<"[Error] zone '"<<zone<<"' has NSEC3 semantics, but the "<< (kd.active ? "" : "in" ) <<"active key with id "<<kd.id<<" has 'Algorithm: 5'. This should be corrected to 'Algorithm: 7' in the database (or NSEC3 should be disabled)."<<endl;
-        numerrors++;
+        if(dkrc.d_algorithm == DNSSECKeeper::RSASHA1) {
+          cout<<"[Error] zone '"<<zone<<"' has NSEC3 semantics, but the "<< (kd.active ? "" : "in" ) <<"active key with id "<<kd.id<<" has 'Algorithm: 5'. This should be corrected to 'Algorithm: 7' in the database (or NSEC3 should be disabled)."<<endl;
+          numerrors++;
+        }
+      }
+      catch (const std::exception& err) {
+        // Nothing. A proper diagnostic has already been fed to checkKeyErrors
+        // by the dk.checkKeys() call above.
       }
     }
   }

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3442,11 +3442,21 @@ static void showZoneKeys(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool 
     return;
   }
 
+  auto unusableKeys = dnsseckeeper.getUnusableKeyCount(zone);
+  if (unusableKeys != 0) {
+    cerr << "Zone has " << unusableKeys << " unusable keys, use 'zone check' for details" << endl;
+  }
+
   DNSSECKeeper::keyset_t keyset;
   keyset=dnsseckeeper.getKeys(zone);
 
   if(keyset.empty())  {
-    cerr << "No keys for zone '"<<zone<<"'."<<endl;
+    if (unusableKeys != 0) {
+      cerr << "No usable keys for zone '"<<zone<<"'."<<endl;
+    }
+    else {
+      cerr << "No keys for zone '"<<zone<<"'."<<endl;
+    }
     return;
   }
 

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3366,11 +3366,8 @@ static int setZoneKind(const ZoneName& zone, const DomainInfo::DomainKind kind)
   return EXIT_SUCCESS;
 }
 
-static void showZoneKeys(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool exportDS, DomainInfo& di) //NOLINT(readability-identifier-length)
+static void showZoneKeys(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool exportDS, DomainInfo& di) //NOLINT(readability-function-cognitive-complexity,readability-identifier-length)
 {
-  DNSSECKeeper::keyset_t keyset;
-  keyset=dnsseckeeper.getKeys(zone);
-
   NSEC3PARAMRecordContent ns3pr;
   bool narrow = false;
   bool haveNSEC3=dnsseckeeper.getNSEC3PARAM(zone, &ns3pr, &narrow);
@@ -3382,7 +3379,7 @@ static void showZoneKeys(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool 
 
     // get us some keys
     vector<DNSKEYRecordContent> keys;
-    DNSZoneRecord zr;
+    DNSZoneRecord zr; // NOLINT(readability-identifier-length)
 
     di.backend->lookup(QType(QType::DNSKEY), zone.operator const DNSName&(), di.id );
     while(di.backend->get(zr)) {
@@ -3395,10 +3392,12 @@ static void showZoneKeys(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool 
     }
 
     if (!exportDS) {
-      if(!haveNSEC3)
+      if(!haveNSEC3) {
         cout<<"Zone has NSEC semantics"<<endl;
-      else
+      }
+      else {
         cout<<"Zone has " << (narrow ? "NARROW " : "") <<"hashed NSEC3 semantics, configuration: "<<ns3pr.getZoneRepresentation()<<endl;
+      }
       cout << "keys: "<<endl;
     }
 
@@ -3440,61 +3439,68 @@ static void showZoneKeys(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool 
       catch(...)
       {}
     }
+    return;
   }
-  else if(keyset.empty())  {
+
+  DNSSECKeeper::keyset_t keyset;
+  keyset=dnsseckeeper.getKeys(zone);
+
+  if(keyset.empty())  {
     cerr << "No keys for zone '"<<zone<<"'."<<endl;
+    return;
   }
-  else {
+
+  if (!exportDS) {
+    if(!haveNSEC3) {
+      cout<<"Zone has NSEC semantics"<<endl;
+    }
+    else {
+      cout<<"Zone has " << (narrow ? "NARROW " : "") <<"hashed NSEC3 semantics, configuration: "<<ns3pr.getZoneRepresentation()<<endl;
+    }
+    cout << "keys: "<<endl;
+  }
+
+  for(const DNSSECKeeper::keyset_t::value_type& value :  keyset) {
+    string algname = DNSSECKeeper::algorithm2name(value.first.getAlgorithm());
     if (!exportDS) {
-      if(!haveNSEC3)
-        cout<<"Zone has NSEC semantics"<<endl;
-      else
-        cout<<"Zone has " << (narrow ? "NARROW " : "") <<"hashed NSEC3 semantics, configuration: "<<ns3pr.getZoneRepresentation()<<endl;
-      cout << "keys: "<<endl;
+      cout<<"ID = "<<value.second.id<<" ("<<DNSSECKeeper::keyTypeToString(value.second.keyType)<<")";
+    }
+    if (value.first.getKey()->getBits() < 1) {
+      cout<<" <key missing or defunct, perhaps you should run 'pdnsutil hsm create-key'>" <<endl;
+      continue;
+    }
+    if (!exportDS) {
+      cout<<", flags = "<<std::to_string(value.first.getFlags());
+      cout<<", tag = "<<value.first.getDNSKEY().getTag();
+      cout<<", algo = "<<(int)value.first.getAlgorithm()<<", bits = "<<value.first.getKey()->getBits()<<"\t"<<((int)value.second.active == 1 ? "  A" : "Ina")<<"ctive\t"<<(value.second.published ? " Published" : " Unpublished")<<"  ( " + algname + " ) "<<endl;
     }
 
-    for(const DNSSECKeeper::keyset_t::value_type& value :  keyset) {
-      string algname = DNSSECKeeper::algorithm2name(value.first.getAlgorithm());
-      if (!exportDS) {
-        cout<<"ID = "<<value.second.id<<" ("<<DNSSECKeeper::keyTypeToString(value.second.keyType)<<")";
+    if (!exportDS) {
+      if (value.second.keyType == DNSSECKeeper::KSK || value.second.keyType == DNSSECKeeper::CSK || ::arg().mustDo("direct-dnskey")) {
+        cout<<DNSSECKeeper::keyTypeToString(value.second.keyType)<<" DNSKEY = "<<zone.operator const DNSName&().toString()<<" IN DNSKEY "<< value.first.getDNSKEY().getZoneRepresentation() << " ; ( "  + algname + " )" << endl;
       }
-      if (value.first.getKey()->getBits() < 1) {
-        cout<<" <key missing or defunct, perhaps you should run 'pdnsutil hsm create-key'>" <<endl;
-        continue;
+    }
+    if (value.second.keyType == DNSSECKeeper::KSK || value.second.keyType == DNSSECKeeper::CSK) {
+      const auto &key = value.first.getDNSKEY();
+      const std::string prefix(exportDS ? "" : "DS = ");
+      if (g_verbose) {
+        cout<<prefix<<zone.operator const DNSName&().toString()<<" IN DS "<<makeDSFromDNSKey(nullptr /* no structured logging */, zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;
       }
-      if (!exportDS) {
-        cout<<", flags = "<<std::to_string(value.first.getFlags());
-        cout<<", tag = "<<value.first.getDNSKEY().getTag();
-        cout<<", algo = "<<(int)value.first.getAlgorithm()<<", bits = "<<value.first.getKey()->getBits()<<"\t"<<((int)value.second.active == 1 ? "  A" : "Ina")<<"ctive\t"<<(value.second.published ? " Published" : " Unpublished")<<"  ( " + algname + " ) "<<endl;
-      }
-
-      if (!exportDS) {
-        if (value.second.keyType == DNSSECKeeper::KSK || value.second.keyType == DNSSECKeeper::CSK || ::arg().mustDo("direct-dnskey")) {
-          cout<<DNSSECKeeper::keyTypeToString(value.second.keyType)<<" DNSKEY = "<<zone.operator const DNSName&().toString()<<" IN DNSKEY "<< value.first.getDNSKEY().getZoneRepresentation() << " ; ( "  + algname + " )" << endl;
-        }
-      }
-      if (value.second.keyType == DNSSECKeeper::KSK || value.second.keyType == DNSSECKeeper::CSK) {
-        const auto &key = value.first.getDNSKEY();
-        const std::string prefix(exportDS ? "" : "DS = ");
-        if (g_verbose) {
-          cout<<prefix<<zone.operator const DNSName&().toString()<<" IN DS "<<makeDSFromDNSKey(nullptr /* no structured logging */, zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA1).getZoneRepresentation() << " ; ( SHA1 digest )" << endl;
-        }
-        cout<<prefix<<zone.operator const DNSName&().toString()<<" IN DS "<<makeDSFromDNSKey(nullptr /* no structured logging */, zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA256).getZoneRepresentation() << " ; ( SHA256 digest )" << endl;
-        if (g_verbose) {
-          try {
-            string output=makeDSFromDNSKey(nullptr /* no structured logging */, zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
-            cout<<prefix<<zone.operator const DNSName&().toString()<<" IN DS "<<output<< " ; ( GOST R 34.11-94 digest )" << endl;
-          }
-          catch(...)
-          {}
-        }
+      cout<<prefix<<zone.operator const DNSName&().toString()<<" IN DS "<<makeDSFromDNSKey(nullptr /* no structured logging */, zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA256).getZoneRepresentation() << " ; ( SHA256 digest )" << endl;
+      if (g_verbose) {
         try {
-          string output=makeDSFromDNSKey(nullptr /* no structured logging */, zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA384).getZoneRepresentation();
-          cout<<prefix<<zone.operator const DNSName&().toString()<<" IN DS "<<output<< " ; ( SHA-384 digest )" << endl;
+          string output=makeDSFromDNSKey(nullptr /* no structured logging */, zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_GOST).getZoneRepresentation();
+          cout<<prefix<<zone.operator const DNSName&().toString()<<" IN DS "<<output<< " ; ( GOST R 34.11-94 digest )" << endl;
         }
         catch(...)
         {}
       }
+      try {
+        string output=makeDSFromDNSKey(nullptr /* no structured logging */, zone.operator const DNSName&(), key, DNSSECKeeper::DIGEST_SHA384).getZoneRepresentation();
+        cout<<prefix<<zone.operator const DNSName&().toString()<<" IN DS "<<output<< " ; ( SHA-384 digest )" << endl;
+      }
+      catch(...)
+      {}
     }
   }
 }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -922,14 +922,14 @@ static void addDefaultDNSSECKeys(DNSSECKeeper& dnssecKeeper, const ZoneName& zon
   try {
     if (k_algo != -1) {
       int64_t keyID{-1};
-      if (!dnssecKeeper.addKey(zonename, true, k_algo, keyID, k_size)) {
+      if (!dnssecKeeper.addKey(zonename, true, k_algo, keyID, static_cast<int>(k_size))) {
         throwUnableToSecure(zonename);
       }
     }
 
     if (z_algo != -1) {
       int64_t keyID{-1};
-      if (!dnssecKeeper.addKey(zonename, false, z_algo, keyID, z_size)) {
+      if (!dnssecKeeper.addKey(zonename, false, z_algo, keyID, static_cast<int>(z_size))) {
         throwUnableToSecure(zonename);
       }
     }

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -919,18 +919,23 @@ static void addDefaultDNSSECKeys(DNSSECKeeper& dnssecKeeper, const ZoneName& zon
   auto k_size = arg().asNum<size_t>("default-ksk-size");
   auto z_size = arg().asNum<size_t>("default-zsk-size");
 
-  if (k_algo != -1) {
-    int64_t keyID{-1};
-    if (!dnssecKeeper.addKey(zonename, true, k_algo, keyID, k_size)) {
-      throwUnableToSecure(zonename);
+  try {
+    if (k_algo != -1) {
+      int64_t keyID{-1};
+      if (!dnssecKeeper.addKey(zonename, true, k_algo, keyID, k_size)) {
+        throwUnableToSecure(zonename);
+      }
+    }
+
+    if (z_algo != -1) {
+      int64_t keyID{-1};
+      if (!dnssecKeeper.addKey(zonename, false, z_algo, keyID, z_size)) {
+        throwUnableToSecure(zonename);
+      }
     }
   }
-
-  if (z_algo != -1) {
-    int64_t keyID{-1};
-    if (!dnssecKeeper.addKey(zonename, false, z_algo, keyID, z_size)) {
-      throwUnableToSecure(zonename);
-    }
+  catch (std::runtime_error& error) {
+    throw ApiException(error.what());
   }
 }
 


### PR DESCRIPTION
### Short description
As reported in #17960, being unable to deserialize a key causes a lot of things to fail.

This PR changes the behaviour of `DNSSECKeeper::getKeys()`, to only return the keys it has been able to deserialize. This in turn causes `::isSecuredZone()` to no longer throw in this case.

The `::checkKeys()` method will correctly report an error for these keys, which allows `pdnsutil zone show` or `pdnsutil zone check` to loudly complain about these keys.

The second commit moves things around in `pdnsutil` and can be skimmed quickly, the important beef lies in the last commit.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
