### PR TITLE
auth: stricter wire data parsing

### DIFF
--- a/pdns/dnsrecords.cc
+++ b/pdns/dnsrecords.cc
@@ -507,6 +507,9 @@ std::shared_ptr<DNSRecordContent> EUI48RecordContent::make(const DNSRecord &dr, 
 
     auto ret=std::make_shared<EUI48RecordContent>();
     pr.copyRecord((uint8_t*) &ret->d_eui48, 6);
+    if (!pr.eof()) {
+      throw MOADNSException("When parsing EUI48 trailing data was not parsed: '" + pr.getRemaining() + "'");
+    }
     return ret;
 }
 std::shared_ptr<DNSRecordContent> EUI48RecordContent::make(const string& zone)
@@ -551,6 +554,9 @@ std::shared_ptr<DNSRecordContent> EUI64RecordContent::make(const DNSRecord &dr, 
 
     auto ret=std::make_shared<EUI64RecordContent>();
     pr.copyRecord((uint8_t*) &ret->d_eui64, 8);
+    if (!pr.eof()) {
+      throw MOADNSException("When parsing EUI64 trailing data was not parsed: '" + pr.getRemaining() + "'");
+    }
     return ret;
 }
 std::shared_ptr<DNSRecordContent> EUI64RecordContent::make(const string& zone)
@@ -627,12 +633,16 @@ std::shared_ptr<DNSRecordContent> APLRecordContent::make(const DNSRecord &dr, Pa
       memset(ard.d_ip.d_ip6, 0, sizeof(ard.d_ip.d_ip6));
       for (u_int i=0; i < ard.d_afdlength; i++)
         pr.xfr8BitInt(ard.d_ip.d_ip6[i]);
-    } else
-    throw MOADNSException("Unknown family for APL record");
+    } else {
+      throw MOADNSException("Unknown family for APL record");
+    }
 
     processed += 4 + ard.d_afdlength;
 
     ret->aplrdata.push_back(ard);
+  }
+  if (!pr.eof()) {
+    throw MOADNSException("When parsing APL trailing data was not parsed: '" + pr.getRemaining() + "'");
   }
 
   return ret;

--- a/pdns/nsecrecords.cc
+++ b/pdns/nsecrecords.cc
@@ -198,6 +198,9 @@ std::shared_ptr<NSECRecordContent::DNSRecordContent> NSECRecordContent::make(con
   pr.xfrName(ret->d_next);
 
   ret->d_bitmap.fromPacket(pr);
+  if (!pr.eof()) {
+    throw MOADNSException("When parsing NSEC trailing data was not parsed: '" + pr.getRemaining() + "'");
+  }
 
   return ret;
 }
@@ -268,6 +271,9 @@ std::shared_ptr<NSEC3RecordContent::DNSRecordContent> NSEC3RecordContent::make(c
   pr.xfrBlob(ret->d_nexthash, len);
 
   ret->d_bitmap.fromPacket(pr);
+  if (!pr.eof()) {
+    throw MOADNSException("When parsing NSEC3 trailing data was not parsed: '" + pr.getRemaining() + "'");
+  }
   return ret;
 }
 
@@ -381,6 +387,9 @@ std::shared_ptr<CSYNCRecordContent::DNSRecordContent> CSYNCRecordContent::make(c
   pr.xfr16BitInt(ret->d_flags);
 
   ret->d_bitmap.fromPacket(pr);
+  if (!pr.eof()) {
+    throw MOADNSException("When parsing CSYNC trailing data was not parsed: '" + pr.getRemaining() + "'");
+  }
   return ret;
 }
 

--- a/pdns/sillyrecords.cc
+++ b/pdns/sillyrecords.cc
@@ -233,6 +233,9 @@ std::shared_ptr<LOCRecordContent::DNSRecordContent> LOCRecordContent::make(const
   pr.xfr32BitInt(ret->d_latitude);
   pr.xfr32BitInt(ret->d_longitude);
   pr.xfr32BitInt(ret->d_altitude);
+  if (!pr.eof()) {
+    throw MOADNSException("When parsing LOC trailing data was not parsed: '" + pr.getRemaining() + "'");
+  }
 
   return ret;
 }


### PR DESCRIPTION
### Short description
We have added checks that there are no unconsumed bytes when parsing records from the wire, but the few record types which do not use the macros framework to parse their data, did not benefit from this.

This PR adds these checks to these records. (I know it would be even better to convert these to the regular framework, but this will be a larger work and more difficult to review)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
