### PR TITLE
Backport 17869 to rec-5.4.x: skip unexpected tags when deserializing protobuf messages

### DIFF
--- a/pdns/recursordist/rec-nsspeeds.cc
+++ b/pdns/recursordist/rec-nsspeeds.cc
@@ -133,11 +133,17 @@ bool nsspeeds_t::putPBEntry(time_t cutoff, T& message)
         case PBNSSpeedMap::required_int32_last:
           last = map.get_int32();
           break;
+        default:
+          map.skip();
+          break;
         }
       }
       entry.insert(address, val, last);
       break;
     }
+    default:
+      message.skip();
+      break;
     }
   }
   if (!entry.stale(cutoff)) {
@@ -202,6 +208,9 @@ size_t nsspeeds_t::putPB(time_t cutoff, const std::string& pbuf)
         ++theCount;
         break;
       }
+      default:
+        full.skip();
+        break;
       }
     }
     log->info(Logr::Info, "Processed nsspeed dump", "processed", Logging::Loggable(theCount), "inserted", Logging::Loggable(inserted));

--- a/pdns/recursordist/recursor_cache.cc
+++ b/pdns/recursordist/recursor_cache.cc
@@ -1148,6 +1148,7 @@ static void putAuthRecord(protozero::pbf_message<PBCacheEntry>& message, const D
       authRecord.d_clen = auth.get_uint32();
       break;
     default:
+      auth.skip();
       break;
     }
   }
@@ -1219,6 +1220,7 @@ bool MemRecursorCache::putRecordSet(T& message)
       cacheEntry.d_tcp = message.get_bool();
       break;
     default:
+      message.skip();
       break;
     }
   }
@@ -1287,6 +1289,9 @@ size_t MemRecursorCache::putRecordSets(const std::string& pbuf)
         ++count;
         break;
       }
+      default:
+        full.skip();
+        break;
       }
     }
     log->info(Logr::Info, "Processed cache dump", "processed", Logging::Loggable(count), "inserted", Logging::Loggable(inserted));


### PR DESCRIPTION
Buys more robustness against future changes.

(cherry picked from commit fdb8b60dd023277d9e6e72e3dd04ceca0a09e662)

Backport of #17869 

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [X] <!-- remove this line if your PR is against master --> checked that this code was merged to master
