### PR TITLE
dnsdist: Handle having no TLS ticket keys

### DIFF
--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -653,8 +653,15 @@ void OpenSSLTLSTicketKeysRing::addKey(std::shared_ptr<OpenSSLTLSTicketKey>&& new
 {
   d_ticketKeys.write_lock()->push_front(std::move(newKey));
   if (TLSCtx::hasTicketsKeyAddedHook()) {
-    auto key = d_ticketKeys.read_lock()->front();
-    auto keyContent = key->content();
+    std::string keyContent;
+    {
+      auto keyRing = d_ticketKeys.read_lock();
+      if (keyRing->empty()) {
+        return;
+      }
+      const auto& key = keyRing->front();
+      keyContent = key->content();
+    }
     TLSCtx::getTicketsKeyAddedHook()(keyContent);
     // fills mem with 0's
     OPENSSL_cleanse(keyContent.data(), keyContent.size());
@@ -663,13 +670,17 @@ void OpenSSLTLSTicketKeysRing::addKey(std::shared_ptr<OpenSSLTLSTicketKey>&& new
 
 std::shared_ptr<OpenSSLTLSTicketKey> OpenSSLTLSTicketKeysRing::getEncryptionKey()
 {
-  return d_ticketKeys.read_lock()->front();
+  auto keyRing = d_ticketKeys.read_lock();
+  if (keyRing->empty()) {
+    return nullptr;
+  }
+  return keyRing->front();
 }
 
 std::shared_ptr<OpenSSLTLSTicketKey> OpenSSLTLSTicketKeysRing::getDecryptionKey(unsigned char name[TLS_TICKETS_KEY_NAME_SIZE], bool& activeKey)
 {
   auto keys = d_ticketKeys.read_lock();
-  for (auto& key : *keys) {
+  for (const auto& key : *keys) {
     if (key->nameMatches(name)) {
       activeKey = (key == keys->front());
       return key;

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -740,6 +740,9 @@ public:
 
     try {
       if (frontend.d_tlsConfig.d_ticketKeyFile.empty()) {
+        if (d_ticketsKeyRotationDelay == 0) {
+          throw std::runtime_error("Trying to start a TLS frontend without any TLS session ticket encryption key loaded AND with rotation disabled!");
+        }
         handleTicketsKeyRotation(time(nullptr));
       }
       else {
@@ -1787,6 +1790,9 @@ public:
 
     try {
       if (frontend.d_tlsConfig.d_ticketKeyFile.empty()) {
+        if (d_ticketsKeyRotationDelay == 0) {
+          throw std::runtime_error("Trying to start a TLS frontend without any TLS session ticket encryption key loaded AND with rotation disabled!");
+        }
         handleTicketsKeyRotation(time(nullptr));
       }
       else {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
We used to crash if:
- TLS tickets were kept enabled (default)
- no external ticket key were added (default)
- automatic TLS ticket keys rotation was disabled (no the default!)

The crash happened as soon as a client tried to open a new TLS connection, so there is no way this would not have been detected by the administrator, but it is still not nice.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
