### PR TITLE
auth: avoid views-related work unless views are enabled

### DIFF
--- a/modules/remotebackend/test-remotebackend.cc
+++ b/modules/remotebackend/test-remotebackend.cc
@@ -46,6 +46,7 @@
 
 bool g_slogStructured{false};
 bool g_logDNSQueries{false};
+bool g_views{false};
 
 extern std::unique_ptr<DNSBackend> backendUnderTest;
 

--- a/pdns/ixfrdist.cc
+++ b/pdns/ixfrdist.cc
@@ -71,6 +71,7 @@ AuthPacketCache PC;
 AuthQueryCache QC;
 AuthZoneCache g_zoneCache;
 bool g_logDNSQueries{false};
+bool g_views{false};
 
 ArgvMap &arg()
 {

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -68,6 +68,7 @@ po::variables_map g_vm;
 bool g_slogStructured{false};
 bool g_logDNSQueries{false};
 static Logger::Urgency s_logUrgency;
+bool g_views{false};
 
 string g_programname="pdns";
 

--- a/pdns/testrunner.cc
+++ b/pdns/testrunner.cc
@@ -20,6 +20,7 @@ AuthZoneCache g_zoneCache;
 uint16_t g_maxNSEC3Iterations{0};
 bool g_slogStructured{false};
 bool g_logDNSQueries{false};
+bool g_views{false};
 
 ArgvMap& arg()
 {

--- a/pdns/ueberbackend.cc
+++ b/pdns/ueberbackend.cc
@@ -31,6 +31,7 @@
 #include <string>
 #include <sys/types.h>
 
+#include "auth-main.hh"
 #include "dns.hh"
 #include "arguments.hh"
 #include "dnsbackend.hh"
@@ -554,11 +555,13 @@ bool UeberBackend::getAuth(const ZoneName& target, const QType& qtype, SOAData* 
   std::string view{};
   if (g_zoneCache.isEnabled()) {
     Netmask _remote(remote);
-    view = g_zoneCache.getViewFromNetwork(&_remote);
-    // Remember the view and its netmask, if applicable, for ECS responses.
-    if (!view.empty() && pkt_p != nullptr) {
-      pkt_p->d_view = view;
-      pkt_p->d_span = _remote;
+    if (g_views) {
+      view = g_zoneCache.getViewFromNetwork(&_remote);
+      // Remember the view and its netmask, if applicable, for ECS responses.
+      if (!view.empty() && pkt_p != nullptr) {
+        pkt_p->d_view = view;
+        pkt_p->d_span = _remote;
+      }
     }
   }
 


### PR DESCRIPTION
### Short description
I missed one area where we do not need to search for a view, if views are not enabled.
This trivial PR fixes this.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
