### PR TITLE
dnsdist-2.1: Backport 17947 - Keep the SSL context alive until all async ops are done

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -1313,6 +1313,7 @@ void IncomingHTTP2Connection::stopIO()
   if (d_ioState) {
     d_ioState->reset();
   }
+  waitUntilAsyncOperationsAreDone();
 }
 
 uint32_t IncomingHTTP2Connection::getConcurrentStreamsCount() const

--- a/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
+++ b/pdns/dnsdistdist/dnsdist-tcp-upstream.hh
@@ -99,6 +99,7 @@ public:
   void handleCrossProtocolResponse(const struct timeval& now, TCPResponse&& response);
 
   void terminateClientConnection();
+  void waitUntilAsyncOperationsAreDone();
 
   bool canAcceptNewQueries(const struct timeval& now);
 

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -474,23 +474,8 @@ IOState IncomingTCPConnectionState::sendResponse(const struct timeval& now, TCPR
   }
 }
 
-void IncomingTCPConnectionState::terminateClientConnection()
+void IncomingTCPConnectionState::waitUntilAsyncOperationsAreDone()
 {
-  DEBUGLOG("terminating client connection");
-  d_queuedResponses.clear();
-  /* we have already released idle connections that could be reused,
-     we don't care about the ones still waiting for responses */
-  for (auto& backend : d_ownedConnectionsToBackend) {
-    for (auto& conn : backend.second) {
-      conn->release(true);
-    }
-  }
-  d_ownedConnectionsToBackend.clear();
-
-  /* meaning we will no longer be 'active' when the backend
-     response or timeout comes in */
-  d_ioState.reset();
-
   /* if we do have remaining async descriptors associated with this TLS
      connection, we need to defer the destruction of the TLS object until
      the engine has reported back, otherwise we have a use-after-free.. */
@@ -510,6 +495,26 @@ void IncomingTCPConnectionState::terminateClientConnection()
       }
     }
   }
+}
+
+void IncomingTCPConnectionState::terminateClientConnection()
+{
+  DEBUGLOG("terminating client connection");
+  d_queuedResponses.clear();
+  /* we have already released idle connections that could be reused,
+     we don't care about the ones still waiting for responses */
+  for (auto& backend : d_ownedConnectionsToBackend) {
+    for (auto& conn : backend.second) {
+      conn->release(true);
+    }
+  }
+  d_ownedConnectionsToBackend.clear();
+
+  /* meaning we will no longer be 'active' when the backend
+     response or timeout comes in */
+  d_ioState.reset();
+
+  waitUntilAsyncOperationsAreDone();
 }
 
 void IncomingTCPConnectionState::queueResponse(std::shared_ptr<IncomingTCPConnectionState>& state, const struct timeval& now, TCPResponse&& response, bool fromBackend)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backports #17947 to dnsdist-2.1.x

Otherwise this causes a crash in `ASYNC_WAIT_CTX_get_fd()` because OpenSSL tries to access the context that we have destroyed.
### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
