### PR TITLE
dnsdist-2.0: Backport 17798 - `nghttp2`'s error callback is "solely for debugging purpose"

### DIFF
--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -1208,13 +1208,13 @@ int IncomingHTTP2Connection::on_data_chunk_recv_callback(nghttp2_session* sessio
 int IncomingHTTP2Connection::on_error_callback(nghttp2_session* session, int lib_error_code, const char* msg, size_t len, void* user_data)
 {
   (void)session;
-  auto* conn = static_cast<IncomingHTTP2Connection*>(user_data);
+  const auto* conn = static_cast<const IncomingHTTP2Connection*>(user_data);
 
   vinfolog("Error in HTTP/2 connection from %s: %s (%d)", conn->d_ci.remote.toStringWithPort(), std::string(msg, len), lib_error_code);
-  conn->d_connectionClosing = true;
-  conn->d_needFlush = true;
-  nghttp2_session_terminate_session(conn->d_session.get(), NGHTTP2_NO_ERROR);
 
+  /* nothing to do except logging here, the library will take
+     care of closing the offending stream if possible, or the whole
+     connection if needed. */
   return 0;
 }
 

--- a/pdns/dnsdistdist/dnsdist-nghttp2.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2.cc
@@ -799,14 +799,12 @@ int DoHConnectionToBackend::on_header_callback(nghttp2_session* session, const n
   return 0;
 }
 
-int DoHConnectionToBackend::on_error_callback(nghttp2_session* session, int lib_error_code, const char* msg, size_t len, void* user_data)
+int DoHConnectionToBackend::on_error_callback([[maybe_unused]] nghttp2_session* session, int lib_error_code, const char* msg, size_t len, [[maybe_unused]] void* user_data)
 {
-  (void)session;
   vinfolog("Error in HTTP/2 connection: %s (%d)", std::string(msg, len), lib_error_code);
-
-  DoHConnectionToBackend* conn = reinterpret_cast<DoHConnectionToBackend*>(user_data);
-  conn->d_connectionDied = true;
-  ++conn->d_ds->tcpDiedReadingResponse;
+  /* nothing to do except logging here, the library will take
+     care of closing the offending stream if possible, or the whole
+     connection if needed. */
 
   return 0;
 }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backports #17798 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
