### PR TITLE
rec: padding should be last of all EDE options

### DIFF
--- a/pdns/recursordist/pdns_recursor.cc
+++ b/pdns/recursordist/pdns_recursor.cc
@@ -1716,30 +1716,6 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
       }
     }
 
-    if (haveEDNS && addPaddingToResponse) {
-      size_t currentSize = packetWriter.getSizeWithOpts(returnedEdnsOptions);
-      /* we don't use maxawnswersize because it accounts for some EDNS options, but
-         not all of them (for example ECS) */
-      size_t maxSize = min(static_cast<uint16_t>(edo.d_packetsize >= 512 ? edo.d_packetsize : 512), g_udpTruncationThreshold);
-
-      if (currentSize < (maxSize - 4)) {
-        size_t remaining = maxSize - (currentSize + 4);
-        /* from rfc8647, "4.1.  Recommended Strategy: Block-Length Padding":
-           If a server receives a query that includes the EDNS(0) "Padding"
-           option, it MUST pad the corresponding response (see Section 4 of
-           RFC 7830) and SHOULD pad the corresponding response to a
-           multiple of 468 octets (see below).
-        */
-        const size_t blockSize = 468;
-        size_t modulo = (currentSize + 4) % blockSize;
-        size_t padSize = 0;
-        if (modulo > 0) {
-          padSize = std::min(blockSize - modulo, remaining);
-        }
-        returnedEdnsOptions.emplace_back(EDNSOptionCode::PADDING, makeEDNSPaddingOptString(padSize));
-      }
-    }
-
     std::optional<EDNSExtendedError> eee;
     if (haveEDNS) {
       auto state = resolver.getValidationState();
@@ -1808,6 +1784,30 @@ void startDoResolve(void* arg) // NOLINT(readability-function-cognitive-complexi
 
         if (packetWriter.size() < maxanswersize && (maxanswersize - packetWriter.size()) >= (EDNSOptionCodeSize + EDNSOptionLengthSize + sizeof(EDNSExtendedError::code) + eee->extraText.size())) {
           returnedEdnsOptions.emplace_back(EDNSOptionCode::EXTENDEDERROR, makeEDNSExtendedErrorOptString(*eee));
+        }
+      }
+
+      if (addPaddingToResponse) {
+        size_t currentSize = packetWriter.getSizeWithOpts(returnedEdnsOptions);
+        /* we don't use maxawnswersize because it accounts for some EDNS options, but
+           not all of them (for example ECS) */
+        size_t maxSize = min(static_cast<uint16_t>(edo.d_packetsize >= 512 ? edo.d_packetsize : 512), g_udpTruncationThreshold);
+
+        if (currentSize < (maxSize - 4)) {
+          size_t remaining = maxSize - (currentSize + 4);
+          /* from rfc8647, "4.1.  Recommended Strategy: Block-Length Padding":
+             If a server receives a query that includes the EDNS(0) "Padding"
+             option, it MUST pad the corresponding response (see Section 4 of
+             RFC 7830) and SHOULD pad the corresponding response to a
+             multiple of 468 octets (see below).
+          */
+          const size_t blockSize = 468;
+          size_t modulo = (currentSize + 4) % blockSize;
+          size_t padSize = 0;
+          if (modulo > 0) {
+            padSize = std::min(blockSize - modulo, remaining);
+          }
+          returnedEdnsOptions.emplace_back(EDNSOptionCode::PADDING, makeEDNSPaddingOptString(padSize));
         }
       }
 

--- a/regression-tests.recursor-dnssec/test_EDNSPadding.py
+++ b/regression-tests.recursor-dnssec/test_EDNSPadding.py
@@ -12,6 +12,7 @@ class RecursorEDNSPaddingTest(RecursorTest):
     _confdir = "RecursorEDNSPadding"
 
     def checkPadding(self, message, numberOfBytes=None):
+        self.assertEqual(len(message.wire) % 468, 0)
         self.assertEqual(message.edns, 0)
         self.assertEqual(len(message.options), 1)
         for option in message.options:
@@ -156,6 +157,26 @@ packetcache-ttl=60
         res = self.sendUDPQuery(query)
         self.checkPadding(res)
         self.assertRRsetInAnswer(res, expected)
+
+    def testQueryWithPaddingAndEDE(self):
+        name = "xxx.secure.example."
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, "A", want_dnssec=True, options=[po])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.checkPadding(res)
+
+        # This one shoudl have padding and EDE
+        name = "yyy.secure.example."
+        po = paddingoption.PaddingOption(64)
+        query = dns.message.make_query(name, "A", want_dnssec=True, options=[po])
+        query.flags |= dns.flags.CD
+        res = self.sendUDPQuery(query)
+        self.assertEqual(len(res.wire) % 468, 0)
+        self.assertEqual(res.edns, 0)
+        self.assertEqual(len(res.options), 2)
+        self.assertEqual(res.options[0].otype, 15)
+        self.assertEqual(res.options[1].otype, 12)
 
     def testQueryWithPaddingButDisabledViaLua(self):
         name = "host1.secure.example."


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Since padding is based on the length of the wire-format message so far, no more new options should be added after padding has been added. Right now we are violating *SHOULD pad the corresponding response to a
multiple of 468 octets* from rfc8647 4.1 when an EDE is added to the response.

Discovered while looking at #17978.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
