### PR TITLE
chore: Stop using the 257 DNSKEY flag value directly

### DIFF
--- a/pdns/dbdnsseckeeper.cc
+++ b/pdns/dbdnsseckeeper.cc
@@ -128,7 +128,8 @@ bool DNSSECKeeper::addKey(const ZoneName& name, bool setSEPBit, int algorithm, i
     throw runtime_error("The algorithm does not support the given bit size.");
   }
   DNSSECPrivateKey dspk;
-  dspk.setKey(dpk, setSEPBit ? 257 : 256, algorithm);
+  auto flags = DNSKEYFlag::ZONE | (setSEPBit ? DNSKEYFlag::SEP : 0);
+  dspk.setKey(dpk, flags, algorithm);
   return addKey(name, dspk, keyId, active, published) && clearKeyCache(name);
 }
 
@@ -590,10 +591,11 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const ZoneName& zone, bool useCache
     dpk.setKey(key, dkrc.d_flags);
 
     if(keydata.active) {
-      if(keydata.flags == 257)
+      if((keydata.flags & DNSKEYFlag::SEP) != 0) {
         algoSEP.insert(dkrc.d_algorithm);
-      else
+      } else {
         algoNoSEP.insert(dkrc.d_algorithm);
+      }
     }
   }
   set_intersection(algoSEP.begin(), algoSEP.end(), algoNoSEP.begin(), algoNoSEP.end(), std::back_inserter(algoHasSeparateKSK));
@@ -610,7 +612,7 @@ DNSSECKeeper::keyset_t DNSSECKeeper::getKeys(const ZoneName& zone, bool useCache
 
     kmd.active = kd.active;
     kmd.published = kd.published;
-    kmd.hasSEPBit = (kd.flags == 257);
+    kmd.hasSEPBit = (kd.flags & DNSKEYFlag::SEP) != 0;
     kmd.id = kd.id;
 
     if (find(algoHasSeparateKSK.begin(), algoHasSeparateKSK.end(), dpk.getAlgorithm()) == algoHasSeparateKSK.end())

--- a/pdns/dnssecinfra.hh
+++ b/pdns/dnssecinfra.hh
@@ -204,6 +204,12 @@ class DNSCryptoKeyEngine
     const unsigned int d_algorithm;
 };
 
+enum DNSKEYFlag : uint16_t {
+  ZONE    = 1<<8, // RFC 4034
+  REVOKED = 1<<7, // RFC 5011
+  SEP     = 1,    // RFC 4034
+};
+
 struct DNSSECPrivateKey
 {
   uint16_t getTag() const

--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -3517,7 +3517,7 @@ static bool showZone(DNSSECKeeper& dnsseckeeper, const ZoneName& zone, bool expo
         cerr<<"Could not process key to extract metadata: "<<e.what()<<endl;
       }
       if (!exportDS) {
-        cout << (key.d_flags == 257 ? "KSK" : "ZSK") << ", tag = " << key.getTag() << ", algo = "<<(int)key.d_algorithm << ", bits = " << bits << endl;
+        cout << ((key.d_flags & DNSKEYFlag::SEP) != 0 ? "KSK" : "ZSK") << ", tag = " << key.getTag() << ", algo = "<<(int)key.d_algorithm << ", bits = " << bits << endl;
         cout << "DNSKEY = " <<zone.operator const DNSName&().toString()<<" IN DNSKEY "<< key.getZoneRepresentation() << "; ( " + algname + " ) " <<endl;
       }
 
@@ -3648,7 +3648,7 @@ static bool secureZone(DNSSECKeeper& dsk, const ZoneName& zone)
     else
       cout << "Securing zone with default key size" << endl;
 
-    cout << "Adding " << (z_algo.empty() ? "CSK (257)" : "KSK") << " with algorithm " << k_algo << endl;
+    cout << "Adding " << (z_algo.empty() ? "CSK (with SEP bit)" : "KSK") << " with algorithm " << k_algo << endl;
 
     int k_real_algo = DNSSECKeeper::shorthand2algorithm(k_algo);
 
@@ -5074,13 +5074,13 @@ static int importZoneKeyPEM(vector<string>& cmds, const std::string_view synopsi
 
   cerr << std::to_string(algo) << endl;
 
-  uint16_t flags = 0;
+  uint16_t flags = DNSKEYFlag::ZONE;
   if (cmds.size() > 3) {
     if (pdns_iequals(cmds.at(3), "ZSK")) {
-      flags = 256;
+      flags |= 0;
     }
     else if (pdns_iequals(cmds.at(3), "KSK")) {
-      flags = 257;
+      flags |= DNSKEYFlag::SEP;
     }
     else {
       cerr << "Unknown key flag '" << cmds.at(3) << "'" << endl;
@@ -5088,7 +5088,7 @@ static int importZoneKeyPEM(vector<string>& cmds, const std::string_view synopsi
     }
   }
   else {
-    flags = 257; // ksk
+    flags |= DNSKEYFlag::SEP; // ksk
   }
   dpk.setKey(key, flags, algo);
 
@@ -5111,16 +5111,16 @@ static int importZoneKey(vector<string>& cmds, const std::string_view synopsis)
   DNSKEYRecordContent drc;
   shared_ptr<DNSCryptoKeyEngine> key(DNSCryptoKeyEngine::makeFromISCFile(nullptr /* no structured logging */, drc, fname.c_str()));
 
-  uint16_t flags = 257;
+  uint16_t flags = DNSKEYFlag::ZONE | DNSKEYFlag::SEP;
   bool active=true;
   bool published=true;
 
   for(unsigned int n = 2; n < cmds.size(); ++n) { // NOLINT(readability-identifier-length)
     if (pdns_iequals(cmds.at(n), "ZSK")) {
-      flags = 256;
+      flags &= ~DNSKEYFlag::SEP;
     }
     else if (pdns_iequals(cmds.at(n), "KSK")) {
-      flags = 257;
+      flags |= DNSKEYFlag::SEP;
     }
     else if (pdns_iequals(cmds.at(n), "active")) {
       active = true;
@@ -5225,7 +5225,8 @@ static int generateZoneKey(vector<string>& cmds, const std::string_view synopsis
   }
   dpk->create(bits);
   DNSSECPrivateKey dspk;
-  dspk.setKey(dpk, keyOrZone ? 257 : 256, algorithm);
+  uint16_t flags = DNSKEYFlag::ZONE | (keyOrZone? DNSKEYFlag::SEP : 0);
+  dspk.setKey(dpk, flags, algorithm);
 
   // print key to stdout
   cout << "Flags: " << dspk.getFlags() << endl <<
@@ -5537,7 +5538,8 @@ static int HSMAssign(vector<string>& cmds, const std::string_view synopsis)
     return 1;
   }
   DNSSECPrivateKey dpk;
-  dpk.setKey(dke, keyOrZone ? 257 : 256);
+  uint16_t flags = DNSKEYFlag::ZONE | (keyOrZone? DNSKEYFlag::SEP : 0);
+  dpk.setKey(dke, flags);
 
   // make sure this key isn't being reused.
   B.getDomainKeys(zone, keys);

--- a/pdns/validate.cc
+++ b/pdns/validate.cc
@@ -23,6 +23,7 @@
 #include "validate.hh"
 #include "dnssec.hh"
 #include "base32.hh"
+#include "dnssecinfra.hh"
 
 uint32_t g_signatureInceptionSkew{0};
 uint16_t g_maxNSEC3Iterations{0};
@@ -43,13 +44,13 @@ static bool isAZoneKey(const DNSKEYRecordContent& key)
      Let's check that this is a ZONE key, even though there is no other
      types of DNSKEYs at the moment.
   */
-  return (key.d_flags & 256) != 0;
+  return (key.d_flags & DNSKEYFlag::ZONE) != 0;
 }
 
 static bool isRevokedKey(const DNSKEYRecordContent& key)
 {
   /* rfc5011 Section 3 */
-  return (key.d_flags & 128) != 0;
+  return (key.d_flags & DNSKEYFlag::REVOKED) != 0;
 }
 
 static vector<shared_ptr<const DNSKEYRecordContent>> getByTag(const skeyset_t& keys, uint16_t tag, uint8_t algorithm, const OptLog& log)

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -1738,12 +1738,9 @@ static void apiZoneCryptokeysPOST(HttpRequest* req, HttpResponse* resp)
           throw ApiException("Private key algorithm (" + DNSSECKeeper::algorithm2name(dke->getBits()) + ") is inconsistent with the 'algorithm' field");
         }
       }
-      uint16_t flags = 0;
+      uint16_t flags = DNSKEYFlag::ZONE;
       if (keyOrZone) {
-        flags = 257;
-      }
-      else {
-        flags = 256;
+        flags |= DNSKEYFlag::SEP;
       }
 
       algorithm = dkrc.d_algorithm;


### PR DESCRIPTION
### Short description

Delegation Extensions define a new flag that we'll use in the future.
So don't compare with 257 or 256 directly, but use the DNSKEYFlag enum values.

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
