### PR TITLE
dnsdist-2.0.x: Backport 17925 - Add more counters for TCP frontends

### DIFF
--- a/pdns/dnsdistdist/dnsdist-carbon.cc
+++ b/pdns/dnsdistdist/dnsdist-carbon.cc
@@ -146,6 +146,10 @@ static bool doOneCarbonExport(const Carbon::Endpoint& endpoint)
       str << base << "tcpgaveup" << ' ' << front->tcpGaveUp.load() << " " << now << "\r\n";
       str << base << "tcpclienttimeouts" << ' ' << front->tcpClientTimeouts.load() << " " << now << "\r\n";
       str << base << "tcpdownstreamtimeouts" << ' ' << front->tcpDownstreamTimeouts.load() << " " << now << "\r\n";
+      str << base << "tcpdiedduringprocessing" << ' ' << front->tcpDiedDuringProcessing.load() << " " << now << "\r\n";
+      str << base << "tcpbadalpn" << ' ' << front->tcpBadALPN.load() << " " << now << "\r\n";
+      str << base << "tcpbadproxyprotocol" << ' ' << front->tcpBadProxyProtocol.load() << " " << now << "\r\n";
+      str << base << "tcpmaxdurationreached" << ' ' << front->tcpMaxDurationReached.load() << " " << now << "\r\n";
       str << base << "tcpcurrentconnections" << ' ' << front->tcpCurrentConnections.load() << " " << now << "\r\n";
       str << base << "tcpmaxconcurrentconnections" << ' ' << front->tcpMaxConcurrentConnections.load() << " " << now << "\r\n";
       str << base << "tcpavgqueriesperconnection" << ' ' << front->tcpAvgQueriesPerConnection.load() << " " << now << "\r\n";

--- a/pdns/dnsdistdist/dnsdist-lua-inspection.cc
+++ b/pdns/dnsdistdist/dnsdist-lua-inspection.cc
@@ -738,12 +738,12 @@ void setupLuaInspection(LuaContext& luaCtx)
     ret << endl;
 
     ret << "Frontends:" << endl;
-    fmt = boost::format("%-3d %-20.20s %-20d %-20d %-20d %-25d %-20d %-20d %-20d %-20f %-20f %-20d %-20d %-25d %-25d %-15d %-15d %-15d %-15d %-15d %-15d");
-    ret << (fmt % "#" % "Address" % "Connections" % "Max concurrent conn" % "Died reading query" % "Died sending response" % "Gave up" % "Client timeouts" % "Downstream timeouts" % "Avg queries/conn" % "Avg duration" % "Avg read IOs/conn" % "TLS new sessions" % "TLS Resumptions" % "TLS unknown ticket keys" % "TLS inactive ticket keys" % "TLS 1.0" % "TLS 1.1" % "TLS 1.2" % "TLS 1.3" % "TLS other") << endl;
+    fmt = boost::format("%-3d %-20.20s %-20d %-20d %-20d %-25d %-20d %-20d %-20d %-20d %-10d %-10d %-15d %-20f %-20f %-20d %-20d %-25d %-25d %-15d %-15d %-15d %-15d %-15d %-15d");
+    ret << (fmt % "#" % "Address" % "Connections" % "Max concurrent conn" % "Died reading query" % "Died sending response" % "Gave up" % "Client timeouts" % "Downstream timeouts" % "Processing error" % "Bad ALPN" % "Bad PP" % "Max duration" % "Avg queries/conn" % "Avg duration" % "Avg read IOs/conn" % "TLS new sessions" % "TLS Resumptions" % "TLS unknown ticket keys" % "TLS inactive ticket keys" % "TLS 1.0" % "TLS 1.1" % "TLS 1.2" % "TLS 1.3" % "TLS other") << endl;
 
     size_t counter = 0;
     for (const auto& frontend : dnsdist::getFrontends()) {
-      ret << (fmt % counter % frontend->local.toStringWithPort() % frontend->tcpCurrentConnections % frontend->tcpMaxConcurrentConnections % frontend->tcpDiedReadingQuery % frontend->tcpDiedSendingResponse % frontend->tcpGaveUp % frontend->tcpClientTimeouts % frontend->tcpDownstreamTimeouts % frontend->tcpAvgQueriesPerConnection % frontend->tcpAvgConnectionDuration % frontend->tcpAvgIOsPerConnection % frontend->tlsNewSessions % frontend->tlsResumptions % frontend->tlsUnknownTicketKey % frontend->tlsInactiveTicketKey % frontend->tls10queries % frontend->tls11queries % frontend->tls12queries % frontend->tls13queries % frontend->tlsUnknownqueries) << endl;
+      ret << (fmt % counter % frontend->local.toStringWithPort() % frontend->tcpCurrentConnections % frontend->tcpMaxConcurrentConnections % frontend->tcpDiedReadingQuery % frontend->tcpDiedSendingResponse % frontend->tcpGaveUp % frontend->tcpClientTimeouts % frontend->tcpDownstreamTimeouts % frontend->tcpDiedDuringProcessing % frontend->tcpBadALPN % frontend->tcpBadProxyProtocol % frontend->tcpMaxDurationReached % frontend->tcpAvgQueriesPerConnection % frontend->tcpAvgConnectionDuration % frontend->tcpAvgIOsPerConnection % frontend->tlsNewSessions % frontend->tlsResumptions % frontend->tlsUnknownTicketKey % frontend->tlsInactiveTicketKey % frontend->tls10queries % frontend->tls11queries % frontend->tls12queries % frontend->tls13queries % frontend->tlsUnknownqueries) << endl;
       ++counter;
     }
     ret << endl;

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.cc
@@ -353,6 +353,7 @@ IOState IncomingHTTP2Connection::handleHandshake(const struct timeval& now)
     if (d_handler.isTLS()) {
       if (!checkALPN()) {
         d_connectionDied = true;
+        ++d_ci.cs->tcpBadALPN;
         stopIO();
         return iostate;
       }
@@ -401,6 +402,7 @@ void IncomingHTTP2Connection::handleIO()
   try {
     if (maxConnectionDurationReached(dnsdist::configuration::getCurrentRuntimeConfiguration().d_maxTCPConnectionDuration, now)) {
       vinfolog("Terminating DoH connection from %s because it reached the maximum TCP connection duration", d_ci.remote.toStringWithPort());
+      ++d_ci.cs->tcpMaxDurationReached;
       stopIO();
       d_connectionClosing = true;
       return;
@@ -443,6 +445,7 @@ void IncomingHTTP2Connection::handleIO()
         }
       }
       else if (status == ProxyProtocolResult::Error) {
+        ++d_ci.cs->tcpBadProxyProtocol;
         d_connectionDied = true;
         stopIO();
         return;
@@ -500,6 +503,7 @@ void IncomingHTTP2Connection::handleIO()
   }
   catch (const std::exception& e) {
     vinfolog("Exception when processing IO for incoming DoH connection from %s: %s", d_ci.remote.toStringWithPort(), e.what());
+    ++d_ci.cs->tcpDiedDuringProcessing;
     d_connectionDied = true;
     stopIO();
   }
@@ -530,7 +534,7 @@ void IncomingHTTP2Connection::writeToSocket(bool socketReady)
   }
   catch (const std::exception& e) {
     vinfolog("Exception while trying to write (%s) to HTTP client connection to %s: %s", (socketReady ? "ready" : "send"), d_ci.remote.toStringWithPort(), e.what());
-    handleIOError();
+    handleIOError(ErrorContext::ErrorWhileWritingToClient);
   }
 }
 
@@ -1250,7 +1254,7 @@ IOState IncomingHTTP2Connection::readHTTPData()
   }
   catch (const std::exception& e) {
     vinfolog("Exception while trying to read from HTTP client connection to %s: %s", d_ci.remote.toStringWithPort(), e.what());
-    handleIOError();
+    handleIOError(ErrorContext::ErrorWhileReadingFromClient);
     return IOState::Done;
   }
   return newState;
@@ -1348,8 +1352,18 @@ void IncomingHTTP2Connection::updateIO(IOState newState, const FDMultiplexer::ca
   }
 }
 
-void IncomingHTTP2Connection::handleIOError()
+void IncomingHTTP2Connection::handleIOError(ErrorContext context)
 {
+  if (context == ErrorContext::ErrorWhileReadingFromClient) {
+    ++d_ci.cs->tcpDiedReadingQuery;
+  }
+  else if (context == ErrorContext::ErrorWhileWritingToClient) {
+    ++d_ci.cs->tcpDiedSendingResponse;
+  }
+  else {
+    ++d_ci.cs->tcpDiedDuringProcessing;
+  }
+
   d_connectionDied = true;
   d_out.clear();
   d_outPos = 0;

--- a/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
+++ b/pdns/dnsdistdist/dnsdist-nghttp2-in.hh
@@ -77,6 +77,12 @@ private:
   static void handleWritableIOCallback(int descriptor, FDMultiplexer::funcparam_t& param);
 
   static constexpr size_t s_initialReceiveBufferSize{256U};
+  enum class ErrorContext : uint8_t
+  {
+    ErrorWhileReadingFromClient = 0,
+    ErrorWhileProcessingContent,
+    ErrorWhileWritingToClient
+  };
 
   IOState sendResponse(const struct timeval& now, TCPResponse&& response) override;
   bool forwardViaUDPFirst() const override
@@ -91,7 +97,7 @@ private:
   uint32_t getConcurrentStreamsCount() const;
   void updateIO(IOState newState, const timeval& now) override;
   void updateIO(IOState newState, const FDMultiplexer::callbackfunc_t& callback);
-  void handleIOError();
+  void handleIOError(ErrorContext context);
   bool sendResponse(StreamID streamID, PendingQuery& context, uint16_t responseCode, const HeadersMap& customResponseHeaders, const std::string& contentType = "", bool addContentType = true);
   void handleIncomingQuery(PendingQuery&& query, StreamID streamID);
   bool checkALPN();

--- a/pdns/dnsdistdist/dnsdist-tcp.cc
+++ b/pdns/dnsdistdist/dnsdist-tcp.cc
@@ -1221,6 +1221,7 @@ void IncomingTCPConnectionState::handleIO()
 
     if (maxConnectionDurationReached(dnsdist::configuration::getCurrentRuntimeConfiguration().d_maxTCPConnectionDuration, now)) {
       vinfolog("Terminating TCP connection from %s because it reached the maximum TCP connection duration", d_ci.remote.toStringWithPort());
+      ++d_ci.cs->tcpMaxDurationReached;
       // will be handled by the ioGuard
       // handleNewIOState(state, IOState::Done, fd, handleIOCallback);
       return;

--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -727,6 +727,14 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
   output << "# TYPE " << frontsbase << "tcpclienttimeouts " << "counter" << "\n";
   output << "# HELP " << frontsbase << "tcpdownstreamtimeouts " << "Amount of TCP connections terminated by a timeout while reading from the backend" << "\n";
   output << "# TYPE " << frontsbase << "tcpdownstreamtimeouts " << "counter" << "\n";
+  output << "# HELP " << frontsbase << "tcpdiedduringprocessing " << "Amount of TCP connections terminated by an internal error during processing" << "\n";
+  output << "# TYPE " << frontsbase << "tcpdiedduringprocessing " << "counter" << "\n";
+  output << "# HELP " << frontsbase << "tcpbadalpn " << "Amount of TCP connections terminated because the client did not send the expected ALPN" << "\n";
+  output << "# TYPE " << frontsbase << "tcpbadalpn " << "counter" << "\n";
+  output << "# HELP " << frontsbase << "tcpbadproxyprotocol " << "Amount of TCP connections terminated because the client send an invalid Proxy Protocol payload" << "\n";
+  output << "# TYPE " << frontsbase << "tcpbadproxyprotocol " << "counter" << "\n";
+  output << "# HELP " << frontsbase << "tcpmaxdurationreached " << "Amount of TCP connections terminated because the connection reached its maximum configured duration" << "\n";
+  output << "# TYPE " << frontsbase << "tcpmaxdurationreached " << "counter" << "\n";
   output << "# HELP " << frontsbase << "tcpcurrentconnections " << "Amount of current incoming TCP connections from clients" << "\n";
   output << "# TYPE " << frontsbase << "tcpcurrentconnections " << "gauge" << "\n";
   output << "# HELP " << frontsbase << "tcpmaxconcurrentconnections " << "Maximum number of concurrent incoming TCP connections from clients" << "\n";
@@ -779,6 +787,10 @@ static void handlePrometheus(const YaHTTP::Request& req, YaHTTP::Response& resp)
       output << frontsbase << "tcpgaveup" << label << front->tcpGaveUp.load() << "\n";
       output << frontsbase << "tcpclienttimeouts" << label << front->tcpClientTimeouts.load() << "\n";
       output << frontsbase << "tcpdownstreamtimeouts" << label << front->tcpDownstreamTimeouts.load() << "\n";
+      output << frontsbase << "tcpdiedduringprocessing" << label << front->tcpDiedDuringProcessing.load() << "\n";
+      output << frontsbase << "tcpbadalpn" << label << front->tcpBadALPN.load() << "\n";
+      output << frontsbase << "tcpbadproxyprotocol" << label << front->tcpBadProxyProtocol.load() << "\n";
+      output << frontsbase << "tcpmaxdurationreached" << label << front->tcpMaxDurationReached.load() << "\n";
       output << frontsbase << "tcpcurrentconnections" << label << front->tcpCurrentConnections.load() << "\n";
       output << frontsbase << "tcpmaxconcurrentconnections" << label << front->tcpMaxConcurrentConnections.load() << "\n";
       output << frontsbase << "tcpavgqueriesperconnection" << label << front->tcpAvgQueriesPerConnection.load() << "\n";
@@ -1220,6 +1232,10 @@ static void handleStats(const YaHTTP::Request& req, YaHTTP::Response& resp)
       {"tcpGaveUp", (double)front->tcpGaveUp.load()},
       {"tcpClientTimeouts", (double)front->tcpClientTimeouts},
       {"tcpDownstreamTimeouts", (double)front->tcpDownstreamTimeouts},
+      {"tcpDiedDuringProcessing", (double)front->tcpDiedDuringProcessing},
+      {"tcpBadALPN", (double)front->tcpBadALPN},
+      {"tcpBadProxyProtocol", (double)front->tcpBadProxyProtocol},
+      {"tcpMaxDurationReached", (double)front->tcpMaxDurationReached},
       {"tcpCurrentConnections", (double)front->tcpCurrentConnections},
       {"tcpMaxConcurrentConnections", (double)front->tcpMaxConcurrentConnections},
       {"tcpAvgQueriesPerConnection", (double)front->tcpAvgQueriesPerConnection},

--- a/pdns/dnsdistdist/dnsdist.hh
+++ b/pdns/dnsdistdist/dnsdist.hh
@@ -329,6 +329,10 @@ struct ClientState
   mutable stat_t responses{0};
   mutable stat_t tcpDiedReadingQuery{0};
   mutable stat_t tcpDiedSendingResponse{0};
+  mutable stat_t tcpDiedDuringProcessing{0};
+  mutable stat_t tcpBadALPN{0};
+  mutable stat_t tcpMaxDurationReached{0};
+  mutable stat_t tcpBadProxyProtocol{0};
   mutable stat_t tcpGaveUp{0};
   mutable stat_t tcpClientTimeouts{0};
   mutable stat_t tcpDownstreamTimeouts{0};

--- a/regression-tests.dnsdist/test_TCPLimits.py
+++ b/regression-tests.dnsdist/test_TCPLimits.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import requests
 import ssl
 import struct
 import time
@@ -17,6 +18,17 @@ class TestTCPLimits(DNSDistTest):
     _testServerPort = pickAvailablePort()
     _answerUnexpected = True
 
+    _webTimeout = 2.0
+    _webServerPort = pickAvailablePort()
+    _webServerBasicAuthPassword = "secret"
+    _webServerBasicAuthPasswordHashed = (
+        "$scrypt$ln=10,p=1,r=8$6DKLnvUYEeXWh3JNOd3iwg==$kSrhdHaRbZ7R74q3lGBqO1xetgxRxhmWzYJ2Qvfm7JM="
+    )
+    _webServerAPIKey = "apisecret"
+    _webServerAPIKeyHashed = (
+        "$scrypt$ln=10,p=1,r=8$9v8JxDfzQVyTpBkTbkUqYg==$bDQzAOHeK1G9UvTPypNhrX48w974ZXbFPtRKS34+aso="
+    )
+
     _tcpIdleTimeout = 2
     _maxTCPQueriesPerConn = 5
     _maxTCPConnsPerClient = 3
@@ -32,8 +44,41 @@ class TestTCPLimits(DNSDistTest):
     -- disable the maximum number of read IOs per query, otherwise the maximum duration (testTCPDuration)
     -- test gets us banned very quickly
     setMaxTCPReadIOsPerQuery(0)
+
+    -- to check metrics
+    webserver("127.0.0.1:%d")
+    setWebserverConfig({password="%s", apiKey="%s"})
     """
-    _config_params = ['_testServerPort', '_tcpIdleTimeout', '_maxTCPQueriesPerConn', '_maxTCPConnsPerClient', '_maxTCPConnDuration']
+    _config_params = [
+        "_testServerPort",
+        "_tcpIdleTimeout",
+        "_maxTCPQueriesPerConn",
+        "_maxTCPConnsPerClient",
+        "_maxTCPConnDuration",
+        "_webServerPort",
+        "_webServerBasicAuthPasswordHashed",
+        "_webServerAPIKeyHashed",
+    ]
+
+    def getFrontendMetrics(self):
+        headers = {"x-api-key": self._webServerAPIKey}
+        url = "http://127.0.0.1:" + str(self._webServerPort) + "/api/v1/servers/localhost"
+        r = requests.get(url, headers=headers, timeout=self._webTimeout)
+        self.assertTrue(r)
+        self.assertEqual(r.status_code, 200)
+
+        content = r.json()
+        self.assertIsNotNone(content)
+        self.assertIn("frontends", content)
+        frontends = content["frontends"]
+        self.assertEqual(len(frontends), 2)
+        for front in frontends:
+            self.assertIn("type", front)
+            if front["type"] == "TCP":
+                return front
+
+        # not found
+        self.fail()
 
     def testTCPQueriesPerConn(self):
         """
@@ -111,6 +156,9 @@ class TestTCPLimits(DNSDistTest):
         """
         name = 'duration.tcp.tests.powerdns.com.'
 
+        metrics = self.getFrontendMetrics()
+        self.assertIn("tcpMaxDurationReached", metrics)
+        counterBefore = metrics["tcpMaxDurationReached"]
         start = time.time()
         conn = self.openTCPConnection()
         # immediately send the maximum size
@@ -129,9 +177,13 @@ class TestTCPLimits(DNSDistTest):
                 break
 
         end = time.time()
-
         self.assertAlmostEqual(count / 10, self._maxTCPConnDuration, delta=2)
         self.assertAlmostEqual(end - start, self._maxTCPConnDuration, delta=2)
+
+        metrics = self.getFrontendMetrics()
+        self.assertIn("tcpMaxDurationReached", metrics)
+        counterAfter = metrics["tcpMaxDurationReached"]
+        self.assertEqual(counterAfter, counterBefore + 1)
 
         conn.close()
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Backport of #17925 to dnsdist-2.0.x

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [x] <!-- remove this line if your PR is against master --> checked that this code was merged to master
