### PR TITLE
auth: tighten socket permission on webserver if using a unix socket

### DIFF
--- a/pdns/Makefile.am
+++ b/pdns/Makefile.am
@@ -1413,7 +1413,7 @@ testrunner_SOURCES = \
 	gss_context.cc gss_context.hh \
 	histogram.hh \
 	ipcipher.cc ipcipher.hh \
-	iputils.cc \
+	iputils.cc iputils.hh \
 	ixfr.cc ixfr.hh \
 	logger.cc logger.hh \
 	logging.cc logging.hh \

--- a/pdns/dynlistener.cc
+++ b/pdns/dynlistener.cc
@@ -64,36 +64,23 @@ DynListener::~DynListener()
     unlink(d_socketname.c_str());
 }
 
-void DynListener::createSocketAndBind(int family, struct sockaddr*local, size_t len)
+void DynListener::createSocketAndBind(SockaddrWrapper& wrap)
 {
-  d_s=socket(family, SOCK_STREAM,0);
+  d_s = socket(wrap.sin4.sin_family, SOCK_STREAM, 0);
   setCloseOnExec(d_s);
 
   if(d_s < 0) {
-    if (family == AF_UNIX) {
-      SLOG(g_log<<Logger::Error<<"Unable to create control socket at '"<<((struct sockaddr_un*)local)->sun_path<<"', reason: "<<stringerror()<<endl,
-           d_slog->error(Logr::Error, errno, "Unable to create control socket", "path", Logging::Loggable(reinterpret_cast<struct sockaddr_un*>(local)->sun_path)));
-    }
-    else {
-      SLOG(g_log<<Logger::Error<<"Unable to create control socket on '"<<((ComboAddress *)local)->toStringWithPort()<<"', reason: "<<stringerror()<<endl,
-           d_slog->error(Logr::Error, errno, "Unable to create control socket", "socket", Logging::Loggable(reinterpret_cast<ComboAddress*>(local)->toStringWithPort())));
-    }
+    SLOG(g_log<<Logger::Error<<"Unable to create control socket on '"<<wrap.toStringWithPort()<<"', reason: "<<stringerror()<<endl,
+         d_slog->error(Logr::Error, errno, "Unable to create control socket", "socket", Logging::Loggable(wrap.toStringWithPort())));
     exit(1);
   }
   
-  int tmp=1;
-  if(setsockopt(d_s,SOL_SOCKET,SO_REUSEADDR,(char*)&tmp,sizeof tmp)<0)
-    throw PDNSException(string("Setsockopt failed on control socket: ")+stringerror());
+  setReuseAddr(d_s);
     
-  if(bind(d_s, local, len) < 0) {
-    if (family == AF_UNIX) {
-      SLOG(g_log<<Logger::Critical<<"Unable to bind to control socket at '"<<((struct sockaddr_un*)local)->sun_path<<"', reason: "<<stringerror()<<endl,
-           d_slog->error(Logr::Critical, errno, "Unable to bind to control socket", "path", Logging::Loggable(reinterpret_cast<struct sockaddr_un*>(local)->sun_path)));
-    }
-    else {
-      SLOG(g_log<<Logger::Critical<<"Unable to bind to control socket on '"<<((ComboAddress *)local)->toStringWithPort()<<"', reason: "<<stringerror()<<endl,
-           d_slog->error(Logr::Critical, errno, "Unable to bind to control socket", "socket", Logging::Loggable(reinterpret_cast<ComboAddress*>(local)->toStringWithPort())));
-    }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  if(bind(d_s, reinterpret_cast<const struct sockaddr*>(&wrap), wrap.getSocklen()) < 0) {
+    SLOG(g_log<<Logger::Critical<<"Unable to bind to control socket on '"<<wrap.toStringWithPort()<<"', reason: "<<stringerror()<<endl,
+         d_slog->error(Logr::Critical, errno, "Unable to bind to control socket", "socket", Logging::Loggable(wrap.toStringWithPort())));
     exit(1);
   }
 }
@@ -140,22 +127,15 @@ void DynListener::listenOnUnixDomain(const string& fname)
          d_slog->info(Logr::Critical, "Unable to bind to control socket, for it is not a valid UNIX socket path", "path", Logging::Loggable(fname)));
     exit(1);
   }
+
+  SockaddrWrapper wrap(&local);
   
-  createSocketAndBind(AF_UNIX, (struct sockaddr*)& local, sizeof(local));
-  d_socketname=fname;
-  if(!arg()["setgid"].empty()) {
-    if(chmod(fname.c_str(),0660)<0) {
-      SLOG(g_log<<Logger::Error<<"Unable to change group access mode of controlsocket at '"<<fname<<"', reason: "<<stringerror()<<endl,
-           d_slog->error(Logr::Error, errno, "Unable to change group access mode of control socket", "path", Logging::Loggable(fname)));
-    }
-    if(chown(fname.c_str(),static_cast<uid_t>(-1), strToGID(arg()["setgid"]))<0) {
-      SLOG(g_log<<Logger::Error<<"Unable to change group ownership of controlsocket at '"<<fname<<"', reason: "<<stringerror()<<endl,
-           d_slog->error(Logr::Error, errno, "Unable to change group ownership of control socket", "path", Logging::Loggable(fname)));
-    }
-  }
-  
+  createSocketAndBind(wrap);
+  wrap.tightenSocketPermissions(d_slog, ::arg()["setgid"]);
+
   listen(d_s, 10);
   
+  d_socketname=fname;
   SLOG(g_log<<Logger::Warning<<"Listening on controlsocket in '"<<fname<<"'"<<endl,
        d_slog->info(Logr::Warning, "Listening on control socket", "path", Logging::Loggable(fname)));
   d_nonlocal=true;
@@ -163,11 +143,11 @@ void DynListener::listenOnUnixDomain(const string& fname)
 
 void DynListener::listenOnTCP(const ComboAddress& local)
 {
-  if (local.isIPv4()) {
-    createSocketAndBind(AF_INET, (struct sockaddr*)& local, local.getSocklen());
-  } else if (local.isIPv6()) {
-    createSocketAndBind(AF_INET6, (struct sockaddr*)& local, local.getSocklen());
-  }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  SockaddrWrapper wrap(reinterpret_cast<const struct sockaddr*>(&local), local.getSocklen());
+  
+  createSocketAndBind(wrap);
+
   listen(d_s, 10);
 
   d_socketaddress=local;

--- a/pdns/dynlistener.hh
+++ b/pdns/dynlistener.hh
@@ -36,6 +36,8 @@
 
 #include "namespaces.hh"
 
+#include "iputils.hh"
+
 class DynListener : public boost::noncopyable
 {
 public:
@@ -60,7 +62,7 @@ private:
 
   void listenOnUnixDomain(const std::string& fname);
   void listenOnTCP(const ComboAddress&);
-  void createSocketAndBind(int family, struct sockaddr*local, size_t len);
+  void createSocketAndBind(SockaddrWrapper& wrap);
 
   NetmaskGroup d_tcprange;
   int d_s{-1};

--- a/pdns/iputils.cc
+++ b/pdns/iputils.cc
@@ -24,11 +24,14 @@
 #endif
 
 #include "iputils.hh"
+#include "logger.hh"
+#include "logging.hh"
 
 #ifdef __linux__
 #include <fstream>
 #endif
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <boost/format.hpp>
 
 #ifdef HAVE_GETIFADDRS
@@ -749,3 +752,19 @@ std::vector<Netmask> getListOfRangesOfNetworkInterface(const std::string& /* itf
   return result;
 }
 #endif // HAVE_GETIFADDRS
+
+#if !defined(DNSDIST) // [
+void SockaddrWrapper::tightenSocketPermissions(Logr::log_t slog, const std::string& gid) const
+{
+  if (!gid.empty()) {
+    if (chmod(toString().c_str(), 0660) < 0) {
+      SLOG(g_log << Logger::Error << "Unable to change permissions of Unix socket '" << toString() << "': " << stringerror() << endl,
+           slog->error(Logr::Error, errno, "Unable to change permissions of Unix socket", "path", Logging::Loggable(toString())));
+    }
+    if (chown(toString().c_str(), static_cast<uid_t>(-1), strToGID(gid)) < 0) {
+      SLOG(g_log << Logger::Error << "Unable to change group ownership of Unix socket '" << toString() << "': " << stringerror() << endl,
+           slog->error(Logr::Error, errno, "Unable to change group ownership of Unix socket", "path", Logging::Loggable(toString())));
+    }
+  }
+}
+#endif // ] DNSDIST

--- a/pdns/iputils.hh
+++ b/pdns/iputils.hh
@@ -632,6 +632,8 @@ union SockaddrWrapper
   {
     memset(&sinun, 0, sizeof(sinun));
   }
+
+  void tightenSocketPermissions(Logr::log_t slog, const std::string& gid) const;
 };
 
 /** This exception is thrown by the Netmask class and by extension by the NetmaskGroup class */

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include "arguments.hh"
 #include "webserver.hh"
 #include "misc.hh"
 #include <thread>
@@ -129,11 +130,14 @@ void HttpResponse::setSuccessResult(const std::string& message, const int status
 
 #ifndef RUST_WS
 
-Server::Server(const string& localaddress, int port) :
+Server::Server(const string& localaddress, int port, Logr::log_t slog) :
   d_local(localaddress.empty() ? "0.0.0.0" : localaddress, port), d_server_socket(d_local.sin4.sin_family, SOCK_STREAM, 0)
 {
   d_server_socket.setReuseAddr();
   d_server_socket.bind(d_local);
+  if (d_local.isUnixSocket()) {
+    d_local.tightenSocketPermissions(slog, ::arg()["setgid"]);
+  }
   d_server_socket.listen();
 }
 

--- a/pdns/webserver.cc
+++ b/pdns/webserver.cc
@@ -129,6 +129,14 @@ void HttpResponse::setSuccessResult(const std::string& message, const int status
 
 #ifndef RUST_WS
 
+Server::Server(const string& localaddress, int port) :
+  d_local(localaddress.empty() ? "0.0.0.0" : localaddress, port), d_server_socket(d_local.sin4.sin_family, SOCK_STREAM, 0)
+{
+  d_server_socket.setReuseAddr();
+  d_server_socket.bind(d_local);
+  d_server_socket.listen();
+}
+
 static void bareHandlerWrapper(const WebServer::HandlerFunction& handler, YaHTTP::Request* req, YaHTTP::Response* resp)
 {
   // wrapper to convert from YaHTTP::* to our subclasses

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -195,7 +195,7 @@ public:
   Server(Server&&) = delete;
   Server& operator=(const Server&) = delete;
   Server& operator=(Server&&) = delete;
-  Server(const string& localaddress, int port);
+  Server(const string& localaddress, int port, Logr::log_t slog);
   virtual ~Server() = default;
 
   SockaddrWrapper d_local;
@@ -338,7 +338,7 @@ protected:
 
   virtual std::shared_ptr<Server> createServer()
   {
-    return std::make_shared<Server>(d_listenaddress, d_port);
+    return std::make_shared<Server>(d_listenaddress, d_port, d_slog);
   }
 
   void apiWrapper(const WebServer::HandlerFunction& handler, HttpRequest* req, HttpResponse* resp, bool allowPassword);

--- a/pdns/webserver.hh
+++ b/pdns/webserver.hh
@@ -195,13 +195,7 @@ public:
   Server(Server&&) = delete;
   Server& operator=(const Server&) = delete;
   Server& operator=(Server&&) = delete;
-  Server(const string& localaddress, int port) :
-    d_local(localaddress.empty() ? "0.0.0.0" : localaddress, port), d_server_socket(d_local.sin4.sin_family, SOCK_STREAM, 0)
-  {
-    d_server_socket.setReuseAddr();
-    d_server_socket.bind(d_local);
-    d_server_socket.listen();
-  }
+  Server(const string& localaddress, int port);
   virtual ~Server() = default;
 
   SockaddrWrapper d_local;


### PR DESCRIPTION
### Short description
As reported in #17994, the logic changing the permission on unix domain sockets is missing for the webserver (this was overlooked when unix domain socket support was added).

This PR:
- introduces a `SockaddrWrapper` routine to perform that tightening. I would have put in it `iputils.cc`, but the dependency on `arguments` prevents most of the tools from building, so I have moved it to a separate file, imaginatively called `iputils2.cc`. This might also break non-auth builds, I might need to add symlinks in future commits to this PR.
- makes the webserver use it automagically, if operating on a unix domain socket.
- change `pdns_control` to use a `SockaddrWrapper` for socket creation, in order to also be able to use the new code and stop having that logic duplicated.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
