### PR TITLE
Backport 17973 to rec 5.4.x: make getOpenFileDescriptors fast 

### DIFF
--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1401,7 +1401,31 @@ uint64_t getOpenFileDescriptors(const std::string&)
   if (ret != 0) {
     return 0;
   }
-  return status.st_size;
+  if (status.st_size != 0) { // Until linux 6.1, this would return 0
+    return status.st_size;
+  }
+
+  // This can lead to performance issues with *many* open fds
+  uint64_t nbFileDescriptors = 0;
+  const auto dirName = "/proc/" + std::to_string(getpid()) + "/fd/";
+  auto directoryError = pdns::visit_directory(dirName, [&nbFileDescriptors]([[maybe_unused]] ino_t inodeNumber, const std::string_view& name) {
+    uint32_t num{};
+    try {
+      pdns::checked_stoi_into(num, std::string(name));
+      if (std::to_string(num) == name) {
+        nbFileDescriptors++;
+      }
+    }
+    catch (...) {
+      // was not a number.
+      ;
+    }
+    return true;
+  });
+  if (directoryError) {
+    return 0U;
+  }
+  return nbFileDescriptors;
 #elif defined(__OpenBSD__)
   // FreeBSD also has this in libopenbsd, but I don't know if that's available always
   return getdtablecount();

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1396,24 +1396,13 @@ DNSName getTSIGAlgoName(TSIGHashEnum& algoEnum)
 uint64_t getOpenFileDescriptors(const std::string&)
 {
 #ifdef __linux__
-  uint64_t nbFileDescriptors = 0;
   const auto dirName = "/proc/" + std::to_string(getpid()) + "/fd/";
-  auto directoryError = pdns::visit_directory(dirName, [&nbFileDescriptors]([[maybe_unused]] ino_t inodeNumber, const std::string_view& name) {
-    uint32_t num;
-    try {
-      pdns::checked_stoi_into(num, std::string(name));
-      if (std::to_string(num) == name) {
-        nbFileDescriptors++;
-      }
-    } catch (...) {
-      // was not a number.
-    }
-    return true;
-  });
-  if (directoryError) {
-    return 0U;
+  struct stat status; // NOLINT(cppcoreguidelines-pro-type-member-init)
+  auto ret = stat(dirName.c_str(), &status);
+  if (ret != 0) {
+    return 0;
   }
-  return nbFileDescriptors;
+  return status.st_size;
 #elif defined(__OpenBSD__)
   // FreeBSD also has this in libopenbsd, but I don't know if that's available always
   return getdtablecount();

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1396,9 +1396,8 @@ DNSName getTSIGAlgoName(TSIGHashEnum& algoEnum)
 uint64_t getOpenFileDescriptors(const std::string&)
 {
 #ifdef __linux__
-  const auto dirName = "/proc/" + std::to_string(getpid()) + "/fd/";
   struct stat status; // NOLINT(cppcoreguidelines-pro-type-member-init)
-  auto ret = stat(dirName.c_str(), &status);
+  auto ret = stat("/proc/self/fd", &status);
   if (ret != 0) {
     return 0;
   }

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -1396,8 +1396,9 @@ DNSName getTSIGAlgoName(TSIGHashEnum& algoEnum)
 uint64_t getOpenFileDescriptors(const std::string&)
 {
 #ifdef __linux__
+  const auto* const dirName = "/proc/self/fd";
   struct stat status; // NOLINT(cppcoreguidelines-pro-type-member-init)
-  auto ret = stat("/proc/self/fd", &status);
+  auto ret = stat(dirName, &status);
   if (ret != 0) {
     return 0;
   }
@@ -1407,7 +1408,6 @@ uint64_t getOpenFileDescriptors(const std::string&)
 
   // This can lead to performance issues with *many* open fds
   uint64_t nbFileDescriptors = 0;
-  const auto dirName = "/proc/" + std::to_string(getpid()) + "/fd/";
   auto directoryError = pdns::visit_directory(dirName, [&nbFileDescriptors]([[maybe_unused]] ino_t inodeNumber, const std::string_view& name) {
     uint32_t num{};
     try {

--- a/pdns/misc.cc
+++ b/pdns/misc.cc
@@ -43,6 +43,7 @@
 #include <cstring>
 #include <iostream>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <dirent.h>
 #include <algorithm>
 #include <poll.h>


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

Backport of #17973 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
