### PR TITLE
my spaghetti code contains less pasta than yours

### DIFF
--- a/m4/pdns_with_libssl.m4
+++ b/m4/pdns_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_set_min_proto_version SSL_set_hostflags SSL_CTX_set_alpn_protos SSL_CTX_set_next_proto_select_cb SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_set_hostflags SSL_CTX_set_alpn_protos SSL_CTX_set_next_proto_select_cb SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/m4/pdns_with_libssl.m4
+++ b/m4/pdns_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_use_cert_and_key])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/m4/pdns_with_libssl.m4
+++ b/m4/pdns_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_set_hostflags SSL_CTX_set_alpn_protos SSL_CTX_set_next_proto_select_cb SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_set_alpn_protos SSL_CTX_set_next_proto_select_cb SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/m4/pdns_with_libssl.m4
+++ b/m4/pdns_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_set_alpn_protos SSL_CTX_set_next_proto_select_cb SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_set_next_proto_select_cb SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/m4/pdns_with_libssl.m4
+++ b/m4/pdns_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/m4/pdns_with_libssl.m4
+++ b/m4/pdns_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_set_next_proto_select_cb SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/m4/pdns_with_libssl.m4
+++ b/m4/pdns_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_get0_alpn_selected SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_get0_next_proto_negotiated SSL_CTX_set_alpn_select_cb SSL_CTX_use_cert_and_key])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -25,22 +25,6 @@ if dep_libssl.found()
     has = cxx.has_function(func, dependencies: dep_libssl)
     conf.set('HAVE_' + func.to_upper(), has, description: 'Have OpenSSL libssl ' + func)
   endforeach
-
-  funcs = [
-    'SSL_CTX_set1_groups_list',
-  ]
-  foreach func: funcs
-    has = cxx.has_header_symbol(
-      'openssl/ssl.h',
-      func,
-      dependencies: dep_libssl,
-    )
-    conf.set(
-      'HAVE_' + func.to_upper(),
-      has,
-      description: 'Have OpenSSL libssl ' + func,
-    )
-  endforeach
 endif
 
 conf.set('HAVE_LIBSSL', dep_libssl.found(), description: 'OpenSSL libssl')

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -18,7 +18,6 @@ if dep_libssl.found()
     'SSL_CTX_set_num_tickets',
     'SSL_CTX_set_keylog_callback',
     'SSL_CTX_get0_privatekey',
-    'SSL_CTX_set_alpn_select_cb',
     'SSL_CTX_use_cert_and_key',
     'TLS_client_method',
   ]

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -18,7 +18,6 @@ if dep_libssl.found()
     'SSL_CTX_set_num_tickets',
     'SSL_CTX_set_keylog_callback',
     'SSL_CTX_get0_privatekey',
-    'SSL_CTX_set_alpn_protos',
     'SSL_CTX_set_next_proto_select_cb',
     'SSL_get0_alpn_selected',
     'SSL_get0_next_proto_negotiated',

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -18,7 +18,6 @@ if dep_libssl.found()
     'SSL_CTX_set_num_tickets',
     'SSL_CTX_set_keylog_callback',
     'SSL_CTX_get0_privatekey',
-    'SSL_CTX_set_next_proto_select_cb',
     'SSL_get0_alpn_selected',
     'SSL_get0_next_proto_negotiated',
     'SSL_CTX_set_alpn_select_cb',

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -18,7 +18,6 @@ if dep_libssl.found()
     'SSL_CTX_set_num_tickets',
     'SSL_CTX_set_keylog_callback',
     'SSL_CTX_get0_privatekey',
-    'SSL_get0_alpn_selected',
     'SSL_get0_next_proto_negotiated',
     'SSL_CTX_set_alpn_select_cb',
     'SSL_CTX_use_cert_and_key',

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -19,7 +19,6 @@ if dep_libssl.found()
     'SSL_CTX_set_keylog_callback',
     'SSL_CTX_get0_privatekey',
     'SSL_CTX_use_cert_and_key',
-    'TLS_client_method',
   ]
 
   foreach func: funcs

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -34,7 +34,6 @@ if dep_libssl.found()
   endforeach
 
   funcs = [
-    'SSL_CTX_set_min_proto_version',
     'SSL_CTX_set1_groups_list',
   ]
   foreach func: funcs

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -18,7 +18,6 @@ if dep_libssl.found()
     'SSL_CTX_set_num_tickets',
     'SSL_CTX_set_keylog_callback',
     'SSL_CTX_get0_privatekey',
-    'SSL_get0_next_proto_negotiated',
     'SSL_CTX_set_alpn_select_cb',
     'SSL_CTX_use_cert_and_key',
     'TLS_client_method',

--- a/meson/libssl/meson.build
+++ b/meson/libssl/meson.build
@@ -18,7 +18,6 @@ if dep_libssl.found()
     'SSL_CTX_set_num_tickets',
     'SSL_CTX_set_keylog_callback',
     'SSL_CTX_get0_privatekey',
-    'SSL_set_hostflags',
     'SSL_CTX_set_alpn_protos',
     'SSL_CTX_set_next_proto_select_cb',
     'SSL_get0_alpn_selected',

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -589,7 +589,6 @@ const std::string& libssl_tls_version_to_string(LibsslTLSVersion version)
 
 static bool libssl_set_min_tls_version(SSL_CTX& ctx, LibsslTLSVersion version)
 {
-#if defined(HAVE_SSL_CTX_SET_MIN_PROTO_VERSION) || defined(SSL_CTX_set_min_proto_version)
   /* These functions have been introduced in 1.1.0, and the use of SSL_OP_NO_* is deprecated
      Warning: SSL_CTX_set_min_proto_version is a function-like macro in OpenSSL */
   int vers;
@@ -618,28 +617,6 @@ static bool libssl_set_min_tls_version(SSL_CTX& ctx, LibsslTLSVersion version)
     return false;
   }
   return true;
-#else
-  long vers = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
-  switch(version) {
-  case LibsslTLSVersion::TLS10:
-    break;
-  case LibsslTLSVersion::TLS11:
-    vers |= SSL_OP_NO_TLSv1;
-    break;
-  case LibsslTLSVersion::TLS12:
-    vers |= SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1;
-    break;
-  case LibsslTLSVersion::TLS13:
-    vers |= SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2;
-    break;
-  default:
-    return false;
-  }
-
-  long options = SSL_CTX_get_options(&ctx);
-  SSL_CTX_set_options(&ctx, options | vers);
-  return true;
-#endif
 }
 
 OpenSSLTLSTicketKeysRing::OpenSSLTLSTicketKeysRing(size_t capacity)

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -954,13 +954,11 @@ static std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)> getNewServerContext(con
 #endif /* OPENSSL_VERSION_MAJOR < 4 */
 #endif
 
-#ifdef HAVE_SSL_CTX_SET1_GROUPS_LIST
   if (!config.d_ecdheCurves.empty()) {
     if (SSL_CTX_set1_groups_list(ctx.get(), config.d_ecdheCurves.c_str()) != 1) {
       throw std::runtime_error("Failed to set the TLS ECDHE curve to '" + config.d_ecdheCurves + "': " + libssl_get_error_string());
     }
   }
-#endif /* HAVE_SSL_CTX_SET1_GROUPS_LIST */
 
   if (config.d_maxStoredSessions == 0) {
     /* disable stored sessions entirely */

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -1296,11 +1296,9 @@ pdns::UniqueFilePtr libssl_set_key_log_file([[maybe_unused]] SSL_CTX* ctx, [[may
 }
 
 /* called in a client context, if the client advertised more than one ALPN value and the server returned more than one as well, to select the one to use. */
-void libssl_set_alpn_select_callback([[maybe_unused]] SSL_CTX* ctx, [[maybe_unused]] int (*callback)(SSL* ssl, const unsigned char** out, unsigned char* outlen, const unsigned char* inPtr, unsigned int inlen, void* arg), [[maybe_unused]] void* arg)
+void libssl_set_alpn_select_callback(SSL_CTX* ctx, int (*callback)(SSL* ssl, const unsigned char** out, unsigned char* outlen, const unsigned char* inPtr, unsigned int inlen, void* arg), void* arg)
 {
-#ifdef HAVE_SSL_CTX_SET_ALPN_SELECT_CB
   SSL_CTX_set_alpn_select_cb(ctx, callback, arg);
-#endif
 }
 
 bool libssl_set_alpn_protos(SSL_CTX* ctx, const std::vector<std::vector<uint8_t>>& protos)

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -1303,9 +1303,8 @@ void libssl_set_alpn_select_callback([[maybe_unused]] SSL_CTX* ctx, [[maybe_unus
 #endif
 }
 
-bool libssl_set_alpn_protos([[maybe_unused]] SSL_CTX* ctx, [[maybe_unused]] const std::vector<std::vector<uint8_t>>& protos)
+bool libssl_set_alpn_protos(SSL_CTX* ctx, const std::vector<std::vector<uint8_t>>& protos)
 {
-#ifdef HAVE_SSL_CTX_SET_ALPN_PROTOS
   std::vector<uint8_t> wire;
   for (const auto& proto : protos) {
     if (proto.size() > std::numeric_limits<uint8_t>::max()) {
@@ -1316,9 +1315,6 @@ bool libssl_set_alpn_protos([[maybe_unused]] SSL_CTX* ctx, [[maybe_unused]] cons
     wire.insert(wire.end(), proto.begin(), proto.end());
   }
   return SSL_CTX_set_alpn_protos(ctx, wire.data(), wire.size()) == 0;
-#else
-  return false;
-#endif
 }
 
 

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -810,14 +810,12 @@ public:
     }
 #endif /* HAVE_SSL_CTX_SET_CIPHERSUITES */
 
-#ifdef HAVE_SSL_CTX_SET1_GROUPS_LIST
   if (!params.d_ecdheCurves.empty()) {
     if (SSL_CTX_set1_groups_list(d_tlsCtx.get(), params.d_ecdheCurves.c_str()) != 1) {
       ERR_print_errors_fp(stderr);
       throw std::runtime_error("Failed to set the TLS ECDHE curve to '" + params.d_ecdheCurves + "' for the TLS context");
     }
   }
-#endif /* HAVE_SSL_CTX_SET1_GROUPS_LIST */
 
     if (params.d_validateCertificates) {
       if (params.d_caStore.empty())  {

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -782,11 +782,7 @@ public:
 
     OpenSSLTLSConnection::generateConnectionIndexIfNeeded();
 
-#ifdef HAVE_TLS_CLIENT_METHOD
     d_tlsCtx = std::shared_ptr<SSL_CTX>(SSL_CTX_new(TLS_client_method()), SSL_CTX_free);
-#else
-    d_tlsCtx = std::shared_ptr<SSL_CTX>(SSL_CTX_new(SSLv23_client_method()), SSL_CTX_free);
-#endif
     if (!d_tlsCtx) {
       ERR_print_errors_fp(stderr);
       throw std::runtime_error("Error creating TLS context");

--- a/pdns/tcpiohandler.cc
+++ b/pdns/tcpiohandler.cc
@@ -550,11 +550,9 @@ public:
 
     const unsigned char* alpn = nullptr;
     unsigned int alpnLen  = 0;
-#ifdef HAVE_SSL_GET0_ALPN_SELECTED
     if (alpn == nullptr) {
       SSL_get0_alpn_selected(d_conn.get(), &alpn, &alpnLen);
     }
-#endif /* HAVE_SSL_GET0_ALPN_SELECTED */
     if (alpn != nullptr && alpnLen > 0) {
       result.insert(result.end(), alpn, alpn + alpnLen);
     }


### PR DESCRIPTION
### Short description
Continuing the recent work on acknowledging the world has moved and the systems PowerDNS software runs on are all providing the OpenSSL 1.1 API or a close equivalent, we can drop configure-time checks for various `libssl` functions which have been introduced in OpenSSL 1.1.0 or before. There were even a few of them, which are being checked for, but are not used anymore in the code.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
