### PR TITLE
my spaghetti code contains less pasta than yours #2

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -11,6 +11,14 @@ upgrade notes if your version is older than 3.4.2.
 5.1.x to master
 ---------------
 
+Cryptographic library requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Vestigial (and probably by now not sufficient enough) support for building with
+very old OpenSSL (or compatible) libraries, not providing the OpenSSL 1.1.0
+API, has been removed. No operating system aged less than 10 years should be
+affected by this, but we're mentioning it, just in case.
+
 NAPTR additional answers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/m4/pdns_check_libcrypto.m4
+++ b/m4/pdns_check_libcrypto.m4
@@ -113,7 +113,7 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO], [
         [AC_LANG_PROGRAM([#include <openssl/bn.h>], [BN_new()])],
         [
             AC_MSG_RESULT([yes])
-            AC_CHECK_FUNCS([RAND_bytes RAND_pseudo_bytes CRYPTO_memcmp OPENSSL_init_crypto EVP_MD_CTX_new EVP_MD_CTX_free RSA_get0_key])
+            AC_CHECK_FUNCS([RAND_bytes CRYPTO_memcmp OPENSSL_init_crypto EVP_MD_CTX_new EVP_MD_CTX_free RSA_get0_key])
             # you might be wondering why the stdarg.h and stddef.h includes,
             # in which case please have a look at https://github.com/PowerDNS/pdns/issues/12926
             # and weep, yelling at Red Hat

--- a/m4/pdns_check_libcrypto.m4
+++ b/m4/pdns_check_libcrypto.m4
@@ -113,7 +113,7 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO], [
         [AC_LANG_PROGRAM([#include <openssl/bn.h>], [BN_new()])],
         [
             AC_MSG_RESULT([yes])
-            AC_CHECK_FUNCS([RAND_bytes CRYPTO_memcmp OPENSSL_init_crypto EVP_MD_CTX_new EVP_MD_CTX_free RSA_get0_key])
+            AC_CHECK_FUNCS([RAND_bytes CRYPTO_memcmp OPENSSL_init_crypto RSA_get0_key])
             # you might be wondering why the stdarg.h and stddef.h includes,
             # in which case please have a look at https://github.com/PowerDNS/pdns/issues/12926
             # and weep, yelling at Red Hat

--- a/m4/pdns_check_libcrypto.m4
+++ b/m4/pdns_check_libcrypto.m4
@@ -113,7 +113,7 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO], [
         [AC_LANG_PROGRAM([#include <openssl/bn.h>], [BN_new()])],
         [
             AC_MSG_RESULT([yes])
-            AC_CHECK_FUNCS([RAND_bytes CRYPTO_memcmp RSA_get0_key])
+            AC_CHECK_FUNCS([RAND_bytes CRYPTO_memcmp])
             # you might be wondering why the stdarg.h and stddef.h includes,
             # in which case please have a look at https://github.com/PowerDNS/pdns/issues/12926
             # and weep, yelling at Red Hat

--- a/m4/pdns_check_libcrypto.m4
+++ b/m4/pdns_check_libcrypto.m4
@@ -113,7 +113,7 @@ AC_DEFUN([PDNS_CHECK_LIBCRYPTO], [
         [AC_LANG_PROGRAM([#include <openssl/bn.h>], [BN_new()])],
         [
             AC_MSG_RESULT([yes])
-            AC_CHECK_FUNCS([RAND_bytes CRYPTO_memcmp OPENSSL_init_crypto RSA_get0_key])
+            AC_CHECK_FUNCS([RAND_bytes CRYPTO_memcmp RSA_get0_key])
             # you might be wondering why the stdarg.h and stddef.h includes,
             # in which case please have a look at https://github.com/PowerDNS/pdns/issues/12926
             # and weep, yelling at Red Hat

--- a/m4/pdns_with_libssl.m4
+++ b/m4/pdns_with_libssl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([PDNS_WITH_LIBSSL], [
         save_LIBS=$LIBS
         CFLAGS="$LIBSSL_CFLAGS $CFLAGS"
         LIBS="$LIBSSL_LIBS -lcrypto $LIBS"
-        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites OCSP_basic_sign SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_use_cert_and_key])
+        AC_CHECK_FUNCS([SSL_CTX_set_ciphersuites SSL_CTX_set_num_tickets SSL_CTX_set_keylog_callback SSL_CTX_get0_privatekey SSL_CTX_use_cert_and_key])
         CFLAGS=$save_CFLAGS
         LIBS=$save_LIBS
 

--- a/meson/libcrypto/meson.build
+++ b/meson/libcrypto/meson.build
@@ -81,7 +81,6 @@ endif
 funcs = [
   'RAND_bytes',
   'CRYPTO_memcmp',
-  'OPENSSL_init_crypto',
   'RSA_get0_key',
   'OCSP_basic_sign',
 ]

--- a/meson/libcrypto/meson.build
+++ b/meson/libcrypto/meson.build
@@ -81,7 +81,6 @@ endif
 funcs = [
   'RAND_bytes',
   'CRYPTO_memcmp',
-  'OCSP_basic_sign',
 ]
 
 foreach func: funcs

--- a/meson/libcrypto/meson.build
+++ b/meson/libcrypto/meson.build
@@ -81,7 +81,6 @@ endif
 funcs = [
   'RAND_bytes',
   'CRYPTO_memcmp',
-  'RSA_get0_key',
   'OCSP_basic_sign',
 ]
 

--- a/meson/libcrypto/meson.build
+++ b/meson/libcrypto/meson.build
@@ -80,7 +80,6 @@ endif
 
 funcs = [
   'RAND_bytes',
-  'RAND_pseudo_bytes',
   'CRYPTO_memcmp',
   'OPENSSL_init_crypto',
   'EVP_MD_CTX_new',

--- a/meson/libcrypto/meson.build
+++ b/meson/libcrypto/meson.build
@@ -82,8 +82,6 @@ funcs = [
   'RAND_bytes',
   'CRYPTO_memcmp',
   'OPENSSL_init_crypto',
-  'EVP_MD_CTX_new',
-  'EVP_MD_CTX_free',
   'RSA_get0_key',
   'OCSP_basic_sign',
 ]

--- a/pdns/digests.hh
+++ b/pdns/digests.hh
@@ -32,11 +32,7 @@ namespace pdns
 {
 inline std::string hash(const EVP_MD* messageDigest, const std::string& input)
 {
-#if defined(HAVE_EVP_MD_CTX_NEW) && defined(HAVE_EVP_MD_CTX_FREE)
   auto mdctx = std::unique_ptr<EVP_MD_CTX, void (*)(EVP_MD_CTX*)>(EVP_MD_CTX_new(), EVP_MD_CTX_free);
-#else
-  auto mdctx = std::unique_ptr<EVP_MD_CTX, void (*)(EVP_MD_CTX*)>(EVP_MD_CTX_create(), EVP_MD_CTX_destroy);
-#endif
   if (!mdctx) {
     throw std::runtime_error(std::string(EVP_MD_name(messageDigest)) + " context initialization failed");
   }

--- a/pdns/dnsdistdist/dnsdist-lua.cc
+++ b/pdns/dnsdistdist/dnsdist-lua.cc
@@ -3159,7 +3159,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
     }
   });
 
-#if defined(HAVE_LIBSSL) && defined(HAVE_OCSP_BASIC_SIGN) && !defined(DISABLE_OCSP_STAPLING)
+#if defined(HAVE_LIBSSL) && !defined(DISABLE_OCSP_STAPLING)
   luaCtx.writeFunction("generateOCSPResponse", [client](const std::string& certFile, const std::string& caCert, const std::string& caKey, const std::string& outFile, int ndays, int nmin) {
     if (client) {
       return;
@@ -3167,7 +3167,7 @@ static void setupLuaConfig(LuaContext& luaCtx, bool client, bool configCheck)
 
     libssl_generate_ocsp_response(certFile, caCert, caKey, outFile, ndays, nmin);
   });
-#endif /* HAVE_LIBSSL && HAVE_OCSP_BASIC_SIGN && !DISABLE_OCSP_STAPLING */
+#endif /* HAVE_LIBSSL && !DISABLE_OCSP_STAPLING */
 
   luaCtx.writeFunction("addCapabilitiesToRetain", [](LuaTypeOrArrayOf<std::string> caps) {
     try {

--- a/pdns/dnsdistdist/meson/libcrypto/meson.build
+++ b/pdns/dnsdistdist/meson/libcrypto/meson.build
@@ -81,7 +81,6 @@ endif
 funcs = [
   'RAND_bytes',
   'CRYPTO_memcmp',
-  'OPENSSL_init_crypto',
   'RSA_get0_key',
   'OCSP_basic_sign',
 ]

--- a/pdns/dnsdistdist/meson/libcrypto/meson.build
+++ b/pdns/dnsdistdist/meson/libcrypto/meson.build
@@ -81,7 +81,6 @@ endif
 funcs = [
   'RAND_bytes',
   'CRYPTO_memcmp',
-  'OCSP_basic_sign',
 ]
 
 foreach func: funcs

--- a/pdns/dnsdistdist/meson/libcrypto/meson.build
+++ b/pdns/dnsdistdist/meson/libcrypto/meson.build
@@ -81,7 +81,6 @@ endif
 funcs = [
   'RAND_bytes',
   'CRYPTO_memcmp',
-  'RSA_get0_key',
   'OCSP_basic_sign',
 ]
 

--- a/pdns/dnsdistdist/meson/libcrypto/meson.build
+++ b/pdns/dnsdistdist/meson/libcrypto/meson.build
@@ -80,7 +80,6 @@ endif
 
 funcs = [
   'RAND_bytes',
-  'RAND_pseudo_bytes',
   'CRYPTO_memcmp',
   'OPENSSL_init_crypto',
   'EVP_MD_CTX_new',

--- a/pdns/dnsdistdist/meson/libcrypto/meson.build
+++ b/pdns/dnsdistdist/meson/libcrypto/meson.build
@@ -82,8 +82,6 @@ funcs = [
   'RAND_bytes',
   'CRYPTO_memcmp',
   'OPENSSL_init_crypto',
-  'EVP_MD_CTX_new',
-  'EVP_MD_CTX_free',
   'RSA_get0_key',
   'OCSP_basic_sign',
 ]

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -65,7 +65,6 @@ static int s_keyLogIndex{-1};
 void registerOpenSSLUser()
 {
   if (s_users.fetch_add(1) == 0) {
-#ifdef HAVE_OPENSSL_INIT_CRYPTO
 #ifndef DISABLE_OPENSSL_ERROR_STRINGS
     uint64_t cryptoOpts = OPENSSL_INIT_LOAD_CONFIG;
     const uint64_t sslOpts = 0;
@@ -87,7 +86,6 @@ void registerOpenSSLUser()
 
     OPENSSL_init_crypto(cryptoOpts, nullptr);
     OPENSSL_init_ssl(sslOpts, nullptr);
-#endif /* HAVE_OPENSSL_INIT_CRYPTO */
 
     s_ticketsKeyIndex = SSL_CTX_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
 

--- a/pdns/libssl.cc
+++ b/pdns/libssl.cc
@@ -421,7 +421,6 @@ static std::map<int, std::string> libssl_load_ocsp_responses(const std::vector<s
   return ocspResponses;
 }
 
-#ifdef HAVE_OCSP_BASIC_SIGN
 bool libssl_generate_ocsp_response(const std::string& certFile, const std::string& caCert, const std::string& caKey, const std::string& outFile, int ndays, int nmin)
 {
   const EVP_MD* rmd = EVP_sha256();
@@ -466,7 +465,6 @@ bool libssl_generate_ocsp_response(const std::string& certFile, const std::strin
 
   return true;
 }
-#endif /* HAVE_OCSP_BASIC_SIGN */
 #endif /* DISABLE_OCSP_STAPLING */
 
 static int libssl_get_last_key_type(SSL_CTX& ctx)

--- a/pdns/libssl.hh
+++ b/pdns/libssl.hh
@@ -143,9 +143,7 @@ int libssl_ticket_key_callback(SSL* s, OpenSSLTLSTicketKeysRing& keyring, unsign
 
 #ifndef DISABLE_OCSP_STAPLING
 int libssl_ocsp_stapling_callback(SSL* ssl, const std::map<int, std::string>& ocspMap);
-#ifdef HAVE_OCSP_BASIC_SIGN
 bool libssl_generate_ocsp_response(const std::string& certFile, const std::string& caCert, const std::string& caKey, const std::string& outFile, int ndays, int nmin);
-#endif
 #endif /* DISABLE_OCSP_STAPLING */
 
 void libssl_set_error_counters_callback(SSL_CTX& ctx, TLSErrorCounters* counters);


### PR DESCRIPTION
### Short description
Continuing the recent work on acknowledging the world has moved and the systems PowerDNS software runs on are all providing the OpenSSL 1.1 API or a close equivalent, we can drop configure-time checks for various libcrypto functions which have been introduced in OpenSSL 1.1.0 or before. There were even a few of them, which are being checked for, but are not used anymore in the code.

I have also added a short crocodile tear to the auth release notes. Better wording suggestions welcome.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
