### PR TITLE
auth: more consistency in Lua script environment

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -19,6 +19,13 @@ very old OpenSSL (or compatible) libraries, not providing the OpenSSL 1.1.0
 API, has been removed. No operating system aged less than 10 years should be
 affected by this, but we're mentioning it, just in case.
 
+lua-records-exec-limit feature applies to all scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :ref:`setting-lua-records-exec-limit` setting, which will abort Lua records
+taking too much time to complete, is now applied to all Lua scripts, including
+prequery, axfr, and DNS Update policy scripts.
+
 NAPTR additional answers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pdns/auth-main.cc
+++ b/pdns/auth-main.cc
@@ -108,7 +108,6 @@ bool g_8bitDNS;
 bool g_logDNSQueries;
 #ifdef HAVE_LUA_RECORDS
 bool g_doLuaRecord;
-int g_luaRecordExecLimit;
 time_t g_luaHealthChecksInterval{5};
 time_t g_luaHealthChecksExpireDelay{3600};
 time_t g_luaConsistentHashesExpireDelay{86400};
@@ -819,7 +818,7 @@ static void mainthread()
 #ifdef HAVE_LUA_RECORDS
     g_doLuaRecord = ::arg().mustDo("enable-lua-records");
     g_LuaRecordSharedState = (::arg()["enable-lua-records"] == "shared");
-    ::arg().assignNum(g_luaRecordExecLimit, "lua-records-exec-limit");
+    ::arg().assignNum(AuthLua4::s_luaRecordExecLimit, "lua-records-exec-limit");
     g_luaRecordInsertWhitespace = ::arg().mustDo("lua-records-insert-whitespace");
     ::arg().assignNum(g_luaHealthChecksInterval, "lua-health-checks-interval");
     ::arg().assignNum(g_luaConsistentHashesExpireDelay, "lua-consistent-hashes-expire-delay");

--- a/pdns/auth-secondarycommunicator.cc
+++ b/pdns/auth-secondarycommunicator.cc
@@ -818,6 +818,7 @@ void CommunicatorClass::suck(const ZoneName& domain, const ComboAddress& remote,
     if (!script.empty()) {
       try {
         pdl = make_unique<AuthLua4>(::arg()["lua-global-include-dir"]);
+        pdl->setExecLimit();
         pdl->loadFile(script);
         SLOG(g_log << Logger::Info << ctx.logPrefix << "loaded Lua script '" << script << "'" << endl,
              ctx.slog->info(Logr::Info, "XFR: loaded Lua script", "name", Logging::Loggable(script)));

--- a/pdns/lua-auth4.cc
+++ b/pdns/lua-auth4.cc
@@ -169,4 +169,25 @@ std::unique_ptr<DNSPacket> AuthLua4::prequery(const DNSPacket& q) {
   return nullptr;
 }
 
-AuthLua4::~AuthLua4() = default;
+static void lua_report(const string& /* event */, const boost::optional<string>& /* line */)
+{
+  throw std::runtime_error("Script took too long");
+}
+
+AuthLua4::AuthLua4(const std::string& includePath) : BaseLua4(includePath)
+{
+  prepareContext();
+}
+
+int AuthLua4::s_luaRecordExecLimit{0};
+
+void AuthLua4::setExecLimit()
+{
+  if (s_luaRecordExecLimit > 0) {
+    d_lw->writeFunction("report", [](const string& event, const boost::optional<string>& line) -> void {
+        lua_report(event, line);
+      });
+
+    d_lw->executeCode(boost::str(boost::format("debug.sethook(report, '', %d)") % s_luaRecordExecLimit));
+  }
+}

--- a/pdns/lua-auth4.hh
+++ b/pdns/lua-auth4.hh
@@ -13,16 +13,19 @@
 class AuthLua4 : public BaseLua4
 {
 public:
-  AuthLua4(const std::string& includePath="") : BaseLua4(includePath) {
-    prepareContext();
-  };
-  bool updatePolicy(const DNSName &qname, const QType& qtype, const DNSName &zonename, const DNSPacket& packet);
-  bool axfrfilter(const ComboAddress&, const DNSName&, const DNSResourceRecord&, std::vector<DNSResourceRecord>&);
+  AuthLua4(const std::string& includePath="");
+  ~AuthLua4() override = default; // this is so unique_ptr works with an incomplete type
+
   LuaContext* getLua();
 
+  bool axfrfilter(const ComboAddress&, const DNSName&, const DNSResourceRecord&, std::vector<DNSResourceRecord>&);
   std::unique_ptr<DNSPacket> prequery(const DNSPacket& p);
+  bool updatePolicy(const DNSName &qname, const QType& qtype, const DNSName &zonename, const DNSPacket& packet);
 
-  ~AuthLua4() override; // this is so unique_ptr works with an incomplete type
+  void setExecLimit();
+
+  static int s_luaRecordExecLimit;
+
 protected:
   void postPrepareContext() override;
   void postLoad() override;

--- a/pdns/lua-record.cc
+++ b/pdns/lua-record.cc
@@ -48,8 +48,6 @@
    Pool checks ?
  */
 
-extern int  g_luaRecordExecLimit;
-
 // Slightly different from dnsdist-lua.hh, as we need ordering
 template <class T>
 using LuaAssociativeTable = std::map<std::string, T>;
@@ -1546,11 +1544,6 @@ static string lua_pickclosest(const iplist_t& ips)
   return pickclosest(s_lua_record_ctx->slog, s_lua_record_ctx->bestwho, conv).toString();
 }
 
-static void lua_report(const string& /* event */, const boost::optional<string>& /* line */)
-{
-  throw std::runtime_error("Script took too long");
-}
-
 static string lua_geoiplookup(const string &address, const GeoIPInterface::GeoIPQueryAttribute attr)
 {
   return getGeo(s_lua_record_ctx->slog, address, attr);
@@ -1747,10 +1740,6 @@ static std::unordered_map<std::string, int> lua_variables{
 
 static void setupLuaRecords(LuaContext& lua)
 {
-  lua.writeFunction("report", [](const string& event, const boost::optional<string>& line) -> void {
-      lua_report(event, line);
-    });
-
   lua.writeFunction("latlon", []() -> string {
       return lua_latlon();
     });
@@ -1913,9 +1902,7 @@ std::vector<shared_ptr<DNSRecordContent>> luaSynth(Logr::log_t slog, const std::
     }
     lua.writeVariable("bestwho", s_lua_record_ctx->bestwho);
 
-    if (g_luaRecordExecLimit > 0) {
-      lua.executeCode(boost::str(boost::format("debug.sethook(report, '', %d)") % g_luaRecordExecLimit));
-    }
+    LUA->setExecLimit();
 
     string actual;
     if(!code.empty() && code[0]!=';')

--- a/pdns/packethandler.cc
+++ b/pdns/packethandler.cc
@@ -86,6 +86,7 @@ PacketHandler::PacketHandler(Logr::log_t slog) :
   else
   {
     d_pdl = std::make_unique<AuthLua4>(::arg()["lua-global-include-dir"]);
+    d_pdl->setExecLimit();
     d_pdl->loadFile(fname);
   }
 }

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -1036,7 +1036,7 @@ int PacketHandler::processUpdate(DNSPacket& packet)
   std::unique_ptr<AuthLua4> update_policy_lua;
   if (!fname.empty()) {
     try {
-      update_policy_lua = std::make_unique<AuthLua4>();
+      update_policy_lua = std::make_unique<AuthLua4>(::arg()["lua-global-include-dir"]);
       update_policy_lua->loadFile(fname);
     }
     catch (const std::runtime_error& e) {

--- a/pdns/rfc2136handler.cc
+++ b/pdns/rfc2136handler.cc
@@ -1037,6 +1037,7 @@ int PacketHandler::processUpdate(DNSPacket& packet)
   if (!fname.empty()) {
     try {
       update_policy_lua = std::make_unique<AuthLua4>(::arg()["lua-global-include-dir"]);
+      update_policy_lua->setExecLimit();
       update_policy_lua->loadFile(fname);
     }
     catch (const std::runtime_error& e) {


### PR DESCRIPTION
### Short description
This PR tries to make sure that all Lua scripts will run in similar conditions:
- the dns update policy script did not have access to the `lua-global-include-dir`.
- the `lua-record-exec-limit` setting now applies to all Lua scripts. (that's questionable, do we want this? or do we want per-script-type exec-limit values?)

~~In addition, there is a fix to what seems to be a bug to me: the `LUA-AXFR-SCRIPT` zone metadata previously would only be taken into account if the `lua-axfr-script` global settings was non-empty. This contradicts the documentation which says that the metadata always overrides the global setting.~~ (I was on drugs and did not read the code correctly, there was no bug there, only two local variables with names differing by one letter only)

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
