### PR TITLE
auth: allow record additions to change the disabled flag

### DIFF
--- a/pdns/pdnsutil.cc
+++ b/pdns/pdnsutil.cc
@@ -2880,6 +2880,7 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds)
   rr.qtype = DNSRecordContent::TypeToNumber(cmds.at(2));
   ::arg().assignNum(rr.ttl, "default-ttl");
   rr.auth = true;
+  rr.disabled = false;
   rr.domain_id = di.id;
   rr.qname = name;
 
@@ -2920,12 +2921,22 @@ static int addOrReplaceRecord(bool isAdd, const vector<string>& cmds)
     // would-be new records which contents are identical to the existing ones.
     di.backend->lookup(QType(QType::ANY), rr.qname, static_cast<int>(di.id));
     while (di.backend->get(oldrr)) {
-      oldrrs.push_back(oldrr);
+      bool keepOld{true};
       for (auto iter = newrrs.begin(); iter != newrrs.end(); ++iter) {
         if (iter->content == oldrr.content) {
-          newrrs.erase(iter);
+          // If the contents are identical but the [disabled] value differs,
+          // discard the old record and keep the new.
+          if (iter->disabled == oldrr.disabled) {
+            newrrs.erase(iter);
+          }
+          else {
+            keepOld = false;
+          }
           break;
         }
+      }
+      if (keepOld) {
+        oldrrs.push_back(oldrr);
       }
     }
     newrrs.insert(newrrs.end(), oldrrs.begin(), oldrrs.end());

--- a/pdns/ws-auth.cc
+++ b/pdns/ws-auth.cc
@@ -2819,9 +2819,20 @@ static applyResult applyPruneOrExtend(const DomainInfo& domainInfo, const ZoneNa
       if (iter->content == new_record.content) {
         // We found the record we've been instructed to add or delete.
         seenRecord = true;
-        // If it is to be added, we don't have anything more to do.
+        bool keepOld{true};
         // If it is to be deleted, just remove it from the RRset we're building.
         if (operationType == PRUNE) {
+          keepOld = false;
+        }
+        else {
+          // If it is to be added, we don't have anything more to do, unless the
+          // [disabled] value differs.
+          if (operationType == EXTEND && iter->disabled != new_record.disabled) {
+            keepOld = false;
+            seenRecord = false;
+          }
+        }
+        if (!keepOld) {
           rrset.erase(iter);
         }
         break;

--- a/regression-tests.api/test_Zones.py
+++ b/regression-tests.api/test_Zones.py
@@ -1865,6 +1865,18 @@ $NAME$  1D  IN  SOA ns1.example.org. hostmaster.example.org. (
         # verify that the zone contents did not change
         data2 = self.get_zone(name)
         self.assertEqual(get_rrset(data, "a." + name), get_rrset(data2, "a." + name))
+        # add the same record again, this time disabled
+        rrset["records"][0]["disabled"] = True
+        payload = {"rrsets": [rrset]}
+        r = self.session.patch(
+            self.url("/api/v1/servers/localhost/zones/" + name),
+            data=json.dumps(payload),
+            headers={"content-type": "application/json"},
+        )
+        self.assert_success(r)
+        # verify that (only) the new record is there and has changed state
+        data = self.get_zone(name)
+        self.assertEqual(get_rrset(data, "a." + name, "A")["records"], rrset["records"])
 
     def test_zone_rr_bogus_extend(self):
         name, payload, zone = self.create_zone()


### PR DESCRIPTION
### Short description
As reported in #18008, the API and `pdnsutil` should be able to handle changing the "disabled" state of an existing record. This PR adds the appropriate logic for this situation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [X] added or modified regression test(s)
- [ ] added or modified unit test(s)
