### PR TITLE
dnsdist: re-add missing libsodium include

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -91,6 +91,10 @@
 #include "sstuff.hh"
 #include "threadname.hh"
 
+#ifdef HAVE_LIBSODIUM
+#include <sodium.h>
+#endif
+
 /* Known sins:
 
    Receiver is currently single threaded


### PR DESCRIPTION
### Short description
After commit 415a18aa0563 libsodium's sodium_init() went missing in certain build configurations:
```
../dnsdist-9999/pdns/dnsdistdist/dnsdist.cc: In function 'int main(int, char**)': ../dnsdist-9999/pdns/dnsdistdist/dnsdist.cc:1327:9: error: 'sodium_init' was not declared in this scope
 1327 |     if (sodium_init() == -1) {
      |         ^~~~~~~~~~~
```
This adds it back.
Fixes #18018 

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
