### PR TITLE
dnsdist: Fix broken web server documentation samples

### DIFF
--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -10,7 +10,8 @@ To visually interact with dnsdist, a webserver can be enabled.
       .. code-block:: yaml
 
         webserver:
-          listen_address: "127.0.0.1:8083"
+          listen_addresses:
+            - "127.0.0.1:8083"
           password: "supersecretpassword"
           api_key: "supersecretAPIkey"
 
@@ -34,7 +35,8 @@ Only connections from 127.0.0.1 and ::1 are allowed by default. To allow connect
       .. code-block:: yaml
 
         webserver:
-          listen_address: "127.0.0.1:8083"
+          listen_addresses:
+            - "127.0.0.1:8083"
           password: "supersecretpassword"
           api_key: "supersecretAPIkey"
           acl:
@@ -77,7 +79,8 @@ For example, to remove the X-Frame-Options header and add a X-Custom one:
       .. code-block:: yaml
 
         webserver:
-          listen_address: "127.0.0.1:8083"
+          listen_addresses:
+            - "127.0.0.1:8083"
           password: "supersecretpassword"
           api_key: "supersecretAPIkey"
           custom_headers:


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Reported by Brian Candler (thanks!).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
