### PR TITLE
dnsdist: Set `IPV6_V6ONLY` on the web server's listening sockets

### DIFF
--- a/pdns/dnsdistdist/dnsdist.cc
+++ b/pdns/dnsdistdist/dnsdist.cc
@@ -1245,6 +1245,9 @@ static ListeningSockets initListeningSockets()
   for (const auto& local : currentConfig.d_webServerAddresses) {
     try {
       auto webServerSocket = Socket(local.sin4.sin_family, SOCK_STREAM, 0);
+      if (local.isIPv6()) {
+        SSetsockopt(webServerSocket.getHandle(), IPPROTO_IPV6, IPV6_V6ONLY, 1);
+      }
       webServerSocket.bind(local, true);
       webServerSocket.listen(5);
       result.d_webServerSockets.emplace_back(local, std::move(webServerSocket));

--- a/pdns/dnsdistdist/docs/upgrade_guide.rst
+++ b/pdns/dnsdistdist/docs/upgrade_guide.rst
@@ -6,6 +6,8 @@ Upgrade Guide
 
 Queries received from clients that have the truncated bit (TC) set are now dropped.
 
+The internal web server now binds listening sockets with ``IPV6_V6ONLY`` set, which means that ``[::]`` no longer accepts IPv4 connections. If you want to listen on both IPv4 and IPv6, you need to add a second line with ``0.0.0.0`` to your existing configuration.
+
 2.1.0-beta2 to 2.1.0
 --------------------
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Right now it's complicated to listen on all IPv4 and IPv6 addresses at the same time because `[::]` binds to IPv4 and IPv6 but maps IPv4 addresses in IPv6 so they are not allowed by the ACL, unless great care is taken to map them in the ACL as well.
Reported by Brian Candler (thanks!).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
