### PR TITLE
auth: yet another lmdb bugfix

### DIFF
--- a/modules/lmdbbackend/lmdbbackend.cc
+++ b/modules/lmdbbackend/lmdbbackend.cc
@@ -2126,6 +2126,7 @@ void LMDBBackend::lookupInternal(const QType& type, const DNSName& qdomain, doma
 
   DNSName relqname = qdomain.makeRelative(info.zone);
   if (relqname.empty()) {
+    d_lookupstate.reset();
     return;
   }
   // cout<<"get will look for "<<relqname<< " in zone "<<info.zone<<" with id "<<info.id<<" and type "<<type.toString()<<endl;

--- a/modules/lmdbbackend/lmdbbackend.hh
+++ b/modules/lmdbbackend/lmdbbackend.hh
@@ -427,9 +427,9 @@ private:
     // database contents at cursor
     MDBOutVal val;
     // whether to include disabled records in the results
-    bool includedisabled;
+    bool includedisabled{false};
     // whether we are doing comments (false=records, true=comments)
-    bool comments;
+    bool comments{false};
     // comment found by last call to getInternal
     Comment comment;
 


### PR DESCRIPTION
### Short description
The changes in #18027 have exposed a code path where `lookup` does not completely initialize the `d_lookupstate` member. If this is the first `lookup` ever done by the backend, then `get` will access uninitialized memory.

This is the one-liner fix, so that it can be backported easily to 5.1 (the backport to 5.0 and 4.9 need to reset `d_getcursor` instead of `d_lookupstate`).

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [X] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [X] compiled this code
- [X] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
