### PR TITLE
rec: Fix Lua to YAML conversion of custom RPZ policies

### DIFF
--- a/pdns/recursordist/rec_control.cc
+++ b/pdns/recursordist/rec_control.cc
@@ -342,6 +342,8 @@ int main(int argc, char** argv)
     "trace-regex",
   };
   try {
+    // needed to be able to parse (and convert to YAML) custom RPZ entries
+    reportAllTypes();
     initArguments(argc, argv, log);
     string sockname = "pdns_recursor";
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Without this fix, `rec_control show-yaml` was trying to parse of the content of the custom policy as `UnknownRecordContent` since the right types were not registered, resulting in a "Unknown record was stored incorrectly, need 3 fields, got 1: [...]" exception because the format did not match the expected one. 
We might want to backport this fix to stable branches.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
