### PR TITLE
dnsdist: Tighten access to metrics when the dashboard is passwordless

### DIFF
--- a/pdns/dnsdistdist/dnsdist-web.cc
+++ b/pdns/dnsdistdist/dnsdist-web.cc
@@ -336,35 +336,38 @@ static bool isAnAPIRequest(const YaHTTP::Request& req)
   return req.url.path.find("/api/") == 0;
 }
 
-static bool isAnAPIRequestAllowedWithWebAuth(const YaHTTP::Request& req)
-{
-  return req.url.path == "/api/v1/servers/localhost";
-}
-
-static bool isAStatsRequest(const YaHTTP::Request& req)
+static bool isAMetricsRequest(const YaHTTP::Request& req)
 {
   return req.url.path == "/jsonstat" || req.url.path == "/metrics";
+}
+
+static bool isADashboardMetricsRequest(const YaHTTP::Request& req)
+{
+  return req.url.path == "/jsonstat" || req.url.path == "/api/v1/servers/localhost";
 }
 
 static bool handleAuthorization(const YaHTTP::Request& req)
 {
   const auto& config = dnsdist::configuration::getCurrentRuntimeConfiguration();
 
-  if (isAStatsRequest(req)) {
+  if (isADashboardMetricsRequest(req)) {
+    if (checkWebPassword(req, config.d_webPassword, config.d_dashboardRequiresAuthentication)) {
+      return true;
+    }
+  }
+
+  if (isAMetricsRequest(req)) {
     if (config.d_statsRequireAuthentication) {
       /* Access to the stats is allowed for both API and Web users */
-      return checkAPIKey(req, config.d_webAPIKey) || checkWebPassword(req, config.d_webPassword, config.d_dashboardRequiresAuthentication);
+      return checkAPIKey(req, config.d_webAPIKey)
+        || checkWebPassword(req, config.d_webPassword, true);
     }
     return true;
   }
 
   if (isAnAPIRequest(req)) {
     /* Access to the API requires a valid API key */
-    if (!config.d_apiRequiresAuthentication || checkAPIKey(req, config.d_webAPIKey)) {
-      return true;
-    }
-
-    return isAnAPIRequestAllowedWithWebAuth(req) && checkWebPassword(req, config.d_webPassword, config.d_dashboardRequiresAuthentication);
+    return !config.d_apiRequiresAuthentication || checkAPIKey(req, config.d_webAPIKey);
   }
 
   return checkWebPassword(req, config.d_webPassword, config.d_dashboardRequiresAuthentication);
@@ -416,7 +419,7 @@ static void handleCORS(const YaHTTP::Request& req, YaHTTP::Response& resp)
       resp.headers["Access-Control-Allow-Origin"] = origin->second;
       resp.headers["Vary"] = "Origin"; // prevents cached data to be used for a different Origin
 
-      if (isAStatsRequest(req) || isAnAPIRequestAllowedWithWebAuth(req)) {
+      if (isAMetricsRequest(req) || isADashboardMetricsRequest(req)) {
         resp.headers["Access-Control-Allow-Credentials"] = "true";
       }
     }

--- a/pdns/dnsdistdist/docs/guides/webserver.rst
+++ b/pdns/dnsdistdist/docs/guides/webserver.rst
@@ -122,7 +122,7 @@ the auth for the calls altogether by setting them to false; they are true by def
      - allowed
      - not allowed
    * - ``/jsonstat``
-     - ``statsRequireAuthentication``
+     - ``statsRequireAuthentication`` or ``dashboardRequiresAuthentication``
      - allowed
      - allowed
    * - ``/metrics``

--- a/pdns/dnsdistdist/docs/reference/config.rst
+++ b/pdns/dnsdistdist/docs/reference/config.rst
@@ -451,7 +451,7 @@ Webserver configuration
   * ``acl=newACL``: string - List of IP addresses, as a string, that are allowed to open a connection to the web server. Defaults to "127.0.0.1, ::1".
   * ``allowCrossOriginRequests``: bool - Whether the webserver allows cross-origin HTTP requests. This might allow a malicious website to read metrics provided by the API if a user's browser has valid credentials cached for the webserver while the user visits the malicious website. Default to false.
   * ``apiRequiresAuthentication``: bool - Whether access to the API (/api endpoints) require a valid API key. Defaults to true.
-  * ``dashboardRequiresAuthentication``: bool - Whether access to the internal dashboard requires a valid password. Defaults to true.
+  * ``dashboardRequiresAuthentication``: bool - Whether access to the internal dashboard requires a valid password. Defaults to true. Setting this to false gives access to the /api/v1/servers/localhost and /jsonstat endpoints without authentication to anyone allowed by the ACL, as these endpoints are used by the dashboard to collect metrics.
   * ``statsRequireAuthentication``: bool - Whether access to the statistics (/metrics and /jsonstat endpoints) require a valid password or API key. Defaults to true.
   * ``prometheusAddInstanceLabel``: bool - Whether to add an instance label to every metric. The value of this label is set by :func:`setServerID`. Defaults to false.
   * ``maxConcurrentConnections``: int - The maximum number of concurrent web connections, or 0 which means an unlimited number. Defaults to 100.

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -1011,7 +1011,13 @@ class TestAPIWithoutAuthentication(APITestsBase):
 
 class TestDashboardWithoutAuthentication(APITestsBase):
     __test__ = True
-    _noAuthPaths = ["/", "/index.html", "/jsonstat?command=stats", "/jsonstat?command=dynblocklist", "/api/v1/servers/localhost"]
+    _noAuthPaths = [
+        "/",
+        "/index.html",
+        "/jsonstat?command=stats",
+        "/jsonstat?command=dynblocklist",
+        "/api/v1/servers/localhost",
+    ]
     _apiKeyPaths = [
         "/api/v1/servers/localhost/config",
         "/api/v1/servers/localhost/pool?name=",
@@ -1021,7 +1027,12 @@ class TestDashboardWithoutAuthentication(APITestsBase):
     _basicAuthPaths = [
         "/metrics",
     ]
-    _config_params = ["_testServerPort", "_webServerPort", "_webServerBasicAuthPasswordHashed", "_webServerAPIKeyHashed"]
+    _config_params = [
+        "_testServerPort",
+        "_webServerPort",
+        "_webServerBasicAuthPasswordHashed",
+        "_webServerAPIKeyHashed",
+    ]
     _config_template = """
     setACL({"127.0.0.1/32", "::1/128"})
     newServer({address="127.0.0.1:%d"})
@@ -1065,6 +1076,7 @@ class TestDashboardWithoutAuthentication(APITestsBase):
             headers = {"x-api-key": self._webServerAPIKey}
             r = requests.get(url, headers=headers, timeout=self._webTimeout)
             self.assertEqual(r.status_code, 200)
+
 
 class TestCustomLuaEndpoint(APITestsBase):
     __test__ = True

--- a/regression-tests.dnsdist/test_API.py
+++ b/regression-tests.dnsdist/test_API.py
@@ -1011,13 +1011,22 @@ class TestAPIWithoutAuthentication(APITestsBase):
 
 class TestDashboardWithoutAuthentication(APITestsBase):
     __test__ = True
-    _basicPath = "/"
-    _config_params = ["_testServerPort", "_webServerPort"]
+    _noAuthPaths = ["/", "/index.html", "/jsonstat?command=stats", "/jsonstat?command=dynblocklist", "/api/v1/servers/localhost"]
+    _apiKeyPaths = [
+        "/api/v1/servers/localhost/config",
+        "/api/v1/servers/localhost/pool?name=",
+        "/api/v1/servers/localhost/rings",
+        "/api/v1/servers/localhost/statistics",
+    ]
+    _basicAuthPaths = [
+        "/metrics",
+    ]
+    _config_params = ["_testServerPort", "_webServerPort", "_webServerBasicAuthPasswordHashed", "_webServerAPIKeyHashed"]
     _config_template = """
     setACL({"127.0.0.1/32", "::1/128"})
     newServer({address="127.0.0.1:%d"})
     webserver("127.0.0.1:%d")
-    setWebserverConfig({ dashboardRequiresAuthentication=false })
+    setWebserverConfig({ dashboardRequiresAuthentication=false, password="%s", apiKey="%s" })
     """
     _verboseMode = True
 
@@ -1026,13 +1035,36 @@ class TestDashboardWithoutAuthentication(APITestsBase):
         API: Dashboard do not require authentication
         """
 
-        for path in [self._basicPath]:
+        for path in self._noAuthPaths:
             url = "http://127.0.0.1:" + str(self._webServerPort) + path
-
             r = requests.get(url, timeout=self._webTimeout)
             self.assertTrue(r)
             self.assertEqual(r.status_code, 200)
 
+        # these should still require authentication
+        for path in self._apiKeyPaths + self._basicAuthPaths:
+            url = "http://127.0.0.1:" + str(self._webServerPort) + path
+            r = requests.get(url, timeout=self._webTimeout)
+            self.assertEqual(r.status_code, 401)
+
+        # these should be allowed with the web password
+        for path in self._basicAuthPaths:
+            url = "http://127.0.0.1:" + str(self._webServerPort) + path
+            r = requests.get(url, auth=("whatever", self._webServerBasicAuthPassword), timeout=self._webTimeout)
+            self.assertEqual(r.status_code, 200)
+
+        # these should NOT be allowed with the web password
+        for path in self._apiKeyPaths:
+            url = "http://127.0.0.1:" + str(self._webServerPort) + path
+            r = requests.get(url, auth=("whatever", self._webServerBasicAuthPassword), timeout=self._webTimeout)
+            self.assertEqual(r.status_code, 401)
+
+        # these should be allowed with an API key
+        for path in self._apiKeyPaths + self._basicAuthPaths:
+            url = "http://127.0.0.1:" + str(self._webServerPort) + path
+            headers = {"x-api-key": self._webServerAPIKey}
+            r = requests.get(url, headers=headers, timeout=self._webTimeout)
+            self.assertEqual(r.status_code, 200)
 
 class TestCustomLuaEndpoint(APITestsBase):
     __test__ = True


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
The internal web dashboard requires browsers to be able to access some metrics (`/jonstat` and `/api/v1/servers/localhost`), which means that when the dashboard is configured to be passwordless (not the default) these endpoints becomes de-facto passwordless as well for all clients allowed by the webserver ACL. This might not have been documented clearly enough, as we keep receiving reports claiming this to be a vulnerability, which it clearly isn't. We also allowed passwordless to the `/metrics` prometheus endpoint in that configuration, which is not necessary and does expose slightly more read-only metrics than the other endpoints.
This commit removes passwordless access to the `/metrics` endpoint in this specific configuration, and clarifies a bit further which endpoints are made accessible without a password.

We want to thank the dozens of researchers that reached out to us to report this.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [ ] added or modified unit test(s)
